### PR TITLE
feat!: rename bind to try and introduce global logger configuration

### DIFF
--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -9,6 +9,8 @@ items:
         href: waystone-monads-option-collections.md
       - name: Result
         href: waystone-monads-result.md
+      - name: Upgrading
+        href: waystone-monads-migration.md
   - name: Waystone.Monads.FluentValidation
     items:
       - name: Fluent Validation

--- a/docs/docs/waystone-monads-migration.md
+++ b/docs/docs/waystone-monads-migration.md
@@ -1,0 +1,21 @@
+﻿# Upgrading
+
+## v1.x..v2.x
+
+### Renamed `Bind` to `Try`
+
+The `Option.Bind` and `Result.Bind` factory methods have been renamed to `Try`
+to better adhere to functional programing concepts.
+
+`Bind` is often associated with `FlatMap`, a way of composing functions together
+in a pipeline. This renaming removes the confusion.
+
+### Introduced `MonadsGlobalConfig`
+
+This configuration allows the setting of a global error logger that will be
+invoked whenever an exception is caught and handled by the library.
+
+### Removed local error handling
+
+Removed the local handle error callback on the `Option.Try` methods in favour of
+the `MonadsGlobalConfig`.

--- a/docs/docs/waystone-monads-option.md
+++ b/docs/docs/waystone-monads-option.md
@@ -27,6 +27,9 @@ Option<string> none = Option.None<string>();
 
 ### Try
 
+> [!NOTE]
+> This was previously named `Bind` in v1.x
+
 The `Try` method allows you to convert the return value of a function into an
 `Option` type. It will execute the factory you provide inside a `try catch`
 block.

--- a/docs/docs/waystone-monads-option.md
+++ b/docs/docs/waystone-monads-option.md
@@ -25,12 +25,11 @@ Option<string> some = Option.Some("I have a value");
 Option<string> none = Option.None<string>();
 ```
 
-### Bind
+### Try
 
-The `Bind` method allows you to convert the return value of a function into an
+The `Try` method allows you to convert the return value of a function into an
 `Option` type. It will execute the factory you provide inside a `try catch`
-block, and provides a callback function parameter where you can handle any
-exceptions thrown by the factory.
+block.
 
 #### Examples
 

--- a/docs/docs/waystone-monads-result.md
+++ b/docs/docs/waystone-monads-result.md
@@ -21,6 +21,9 @@ Result<int, string> err = Result.Err<int, string>("error");
 
 ### Try
 
+> [!NOTE]
+> This was previously named `Bind` in v1.x
+
 The `Try` method allows you to convert the return value of a function into an
 `Result` type. It will execute the factory you provide inside a `try catch`
 block, and provides a callback function parameter where you can map any

--- a/docs/docs/waystone-monads-result.md
+++ b/docs/docs/waystone-monads-result.md
@@ -19,9 +19,9 @@ Result<int, string> ok = Result.Ok<int, string>(1);
 Result<int, string> err = Result.Err<int, string>("error");
 ```
 
-### Bind
+### Try
 
-The `Bind` method allows you to convert the return value of a function into an
+The `Try` method allows you to convert the return value of a function into an
 `Result` type. It will execute the factory you provide inside a `try catch`
 block, and provides a callback function parameter where you can map any
 exception thrown into an error value of your choice.

--- a/docs/docs/waystone-monads.md
+++ b/docs/docs/waystone-monads.md
@@ -2,9 +2,9 @@
 
 ## Common Concepts
 
-### Bind
+### Try
 
-Provides a way to bind the result of a function into an `Option` or `Result`
+Provides a way to store the result of a function into an `Option` or `Result`
 type.
 
 ### Match

--- a/docs/docs/waystone-monads.md
+++ b/docs/docs/waystone-monads.md
@@ -7,6 +7,9 @@
 Provides a way to store the result of a function into an `Option` or `Result`
 type.
 
+> [!NOTE]
+> This was previously named `Bind` in v1.x
+
 ### Match
 
 Performing a `Match` will ensure you handle all possible states of an `Option`

--- a/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
+++ b/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
@@ -1,0 +1,41 @@
+﻿namespace Waystone.Monads.Configs;
+
+using System;
+using System.Diagnostics;
+using Options;
+
+/// <summary>
+/// Provides configuration options and utilities for handling monadic
+/// operations in the Waystone.Monads library, including global exception handling
+/// mechanisms.
+/// </summary>
+public static class MonadsGlobalConfig
+{
+    internal static Option<Action<Exception>> LogAction { get; set; } =
+#if DEBUG
+        Option.Some<Action<Exception>>(ex => Debug.WriteLine(
+                                           $"[Waystone.Monads] {ex}"));
+#else
+        Option.None<Action<Exception>>();
+#endif
+
+    internal static void LogException(
+        Exception ex) =>
+        LogAction.Inspect(action => action.Invoke(ex));
+
+
+    /// <summary>
+    /// Configures the global exception logger used in the Waystone.Monads
+    /// library. Any exceptions occurring during certain operations can be logged using
+    /// the provided action.
+    /// </summary>
+    /// <param name="log">
+    /// The action to execute when logging exceptions. Accepts an
+    /// <see cref="Exception" /> parameter.
+    /// </param>
+    public static void UseExceptionLogger(
+        Action<Exception> log)
+    {
+        LogAction = Option.Some(log);
+    }
+}

--- a/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
+++ b/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Options;
 
 /// <summary>
@@ -11,17 +12,18 @@ using Options;
 /// </summary>
 public static class MonadsGlobalConfig
 {
-    internal static Option<Action<Exception>> LogAction { get; set; } =
+    internal static Option<Action<Exception, string>> LogAction { get; set; } =
 #if DEBUG
-        Option.Some<Action<Exception>>(ex => Debug.WriteLine(
-                                           $"[Waystone.Monads] {ex}"));
+        Option.Some<Action<Exception, string>>((ex, source) => Debug.WriteLine(
+                                                   $"[Waystone.Monads::{source}] {ex}"));
 #else
-        Option.None<Action<Exception>>();
+        Option.None<Action<Exception, string>>();
 #endif
 
     internal static void LogException(
-        Exception ex) =>
-        LogAction.Inspect(action => action.Invoke(ex));
+        Exception ex,
+        [CallerMemberName] string source = "") =>
+        LogAction.Inspect(action => action.Invoke(ex, source));
 
 
     /// <summary>
@@ -36,6 +38,6 @@ public static class MonadsGlobalConfig
     public static void UseExceptionLogger(
         Action<Exception> log)
     {
-        LogAction = Option.Some(log);
+        LogAction = Option.Some<Action<Exception, string>>((ex, _) => log(ex));
     }
 }

--- a/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
+++ b/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
@@ -14,8 +14,11 @@ public static class MonadsGlobalConfig
 {
     private static Option<Action<Exception, string>> LogAction { get; set; } =
 #if DEBUG
-        Option.Some<Action<Exception, string>>((ex, source) => Debug.WriteLine(
-                                                   $"[Waystone.Monads::{source}] {ex}"));
+        Option.Some<Action<Exception, string>>((ex, source) =>
+        {
+            Debug.WriteLine(
+                $"[Waystone.Monads::{source}] Handled exception of type '{ex.GetType().Name}': {ex}");
+        });
 #else
         Option.None<Action<Exception, string>>();
 #endif

--- a/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
+++ b/src/Waystone.Monads/Configs/MonadsGlobalConfig.cs
@@ -12,7 +12,7 @@ using Options;
 /// </summary>
 public static class MonadsGlobalConfig
 {
-    internal static Option<Action<Exception, string>> LogAction { get; set; } =
+    private static Option<Action<Exception, string>> LogAction { get; set; } =
 #if DEBUG
         Option.Some<Action<Exception, string>>((ex, source) => Debug.WriteLine(
                                                    $"[Waystone.Monads::{source}] {ex}"));

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -15,18 +15,13 @@ public static class Option
     /// A method which when executed will produce the value of
     /// the <see cref="Option{T}" />
     /// </param>
-    /// <param name="onError">
-    /// Optional. Provides access to any exceptions the factory
-    /// throws. Not providing a callback will mean the exception gets swallowed.
-    /// </param>
     /// <typeparam name="T">The factory return value's type</typeparam>
     /// <returns>
     /// A <see cref="Some{T}" /> if the factory executes successfully,
     /// otherwise a <see cref="None{T}" />
     /// </returns>
     public static Option<T> Try<T>(
-        Func<T> factory,
-        Action<Exception>? onError = null)
+        Func<T> factory)
         where T : notnull
     {
         try
@@ -36,7 +31,6 @@ public static class Option
         }
         catch (Exception ex)
         {
-            onError?.Invoke(ex);
             MonadsGlobalConfig.LogException(ex);
             return None<T>();
         }
@@ -50,18 +44,13 @@ public static class Option
     /// An asynchronous method which when awaited will
     /// produce the value for the <see cref="Option{T}" />
     /// </param>
-    /// <param name="onError">
-    /// Optional. Provides access to any exceptions the factory
-    /// throws. Not providing a callback will mean the exception gets swallowed.
-    /// </param>
     /// <typeparam name="T">The async factory return type</typeparam>
     /// <returns>
     /// A <see cref="Some{T}" /> if the factory succeeds, otherwise a
     /// <see cref="None{T}" />
     /// </returns>
     public static async Task<Option<T>> Try<T>(
-        Func<Task<T>> asyncFactory,
-        Action<Exception>? onError = null) where T : notnull
+        Func<Task<T>> asyncFactory) where T : notnull
     {
         try
         {
@@ -70,7 +59,6 @@ public static class Option
         }
         catch (Exception ex)
         {
-            onError?.Invoke(ex);
             MonadsGlobalConfig.LogException(ex);
             return None<T>();
         }

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -2,12 +2,13 @@
 
 using System;
 using System.Threading.Tasks;
+using Configs;
 
 /// <summary>Static functions for <see cref="Option{T}" /></summary>
 public static class Option
 {
     /// <summary>
-    /// Binds the result of a <paramref name="factory" /> into an
+    /// Tries to store the result of a <paramref name="factory" /> into an
     /// <see cref="Option{T}" />
     /// </summary>
     /// <param name="factory">
@@ -23,7 +24,7 @@ public static class Option
     /// A <see cref="Some{T}" /> if the factory executes successfully,
     /// otherwise a <see cref="None{T}" />
     /// </returns>
-    public static Option<T> Bind<T>(
+    public static Option<T> Try<T>(
         Func<T> factory,
         Action<Exception>? onError = null)
         where T : notnull
@@ -36,13 +37,14 @@ public static class Option
         catch (Exception ex)
         {
             onError?.Invoke(ex);
+            MonadsGlobalConfig.LogException(ex);
             return None<T>();
         }
     }
 
     /// <summary>
-    /// Binds the result of an <paramref name="asyncFactory" /> into an
-    /// <see cref="Option{T}" />
+    /// Tries to store the result of an <paramref name="asyncFactory" /> into
+    /// an <see cref="Option{T}" />
     /// </summary>
     /// <param name="asyncFactory">
     /// An asynchronous method which when awaited will
@@ -57,7 +59,7 @@ public static class Option
     /// A <see cref="Some{T}" /> if the factory succeeds, otherwise a
     /// <see cref="None{T}" />
     /// </returns>
-    public static async Task<Option<T>> Bind<T>(
+    public static async Task<Option<T>> Try<T>(
         Func<Task<T>> asyncFactory,
         Action<Exception>? onError = null) where T : notnull
     {
@@ -69,6 +71,7 @@ public static class Option
         catch (Exception ex)
         {
             onError?.Invoke(ex);
+            MonadsGlobalConfig.LogException(ex);
             return None<T>();
         }
     }

--- a/src/Waystone.Monads/README.md
+++ b/src/Waystone.Monads/README.md
@@ -35,3 +35,16 @@ representing an error and containing an error value.
 > [!NOTE]
 > Each concrete result type requires the other's generic type parameters in
 > order to correlate correctly with each other.
+
+## Configuration
+
+You can configure an action to be invoked when an exception is caught and
+handled by the library. Invoke the `UseExceptionLogger` function once during the
+lifetime of your app:
+
+```csharp
+MonadsGlobalConfig.UseExceptionLogger(ex => 
+{
+    Log.Error(ex, "Exception when creating monad"); // use Serilog/NLog/Etc
+});
+```

--- a/src/Waystone.Monads/Results/Result.cs
+++ b/src/Waystone.Monads/Results/Result.cs
@@ -2,12 +2,13 @@
 
 using System;
 using System.Threading.Tasks;
+using Configs;
 
 /// <summary>Static methods for <see cref="Result{TOk,TErr}" /></summary>
 public static class Result
 {
     /// <summary>
-    /// Binds the result of a <paramref name="factory" /> into a
+    /// Tries to store the result of a <paramref name="factory" /> into a
     /// <see cref="Result{TOk,TErr}" />, invoking <paramref name="onError" /> if the
     /// factory throws an exception.
     /// </summary>
@@ -25,7 +26,7 @@ public static class Result
     /// An <see cref="Ok{TOk,TErr}" /> if the factory executes successfully,
     /// otherwise a <see cref="Err{TOk,TErr}" />
     /// </returns>
-    public static Result<TOk, TErr> Bind<TOk, TErr>(
+    public static Result<TOk, TErr> Try<TOk, TErr>(
         Func<TOk> factory,
         Func<Exception, TErr> onError) where TOk : notnull where TErr : notnull
     {
@@ -35,13 +36,14 @@ public static class Result
         }
         catch (Exception ex)
         {
+            MonadsGlobalConfig.LogException(ex);
             return Err<TOk, TErr>(onError(ex));
         }
     }
 
     /// <summary>
-    /// Binds the result of an <paramref name="asyncFactory" /> into a
-    /// <see cref="Result{TOk, TErr}" />, invoking <paramref name="onError" /> if the
+    /// Tries to store the result of an <paramref name="asyncFactory" /> into
+    /// a <see cref="Result{TOk, TErr}" />, invoking <paramref name="onError" /> if the
     /// factory throws an exception.
     /// </summary>
     /// <param name="asyncFactory">
@@ -58,7 +60,7 @@ public static class Result
     /// An <see cref="Ok{TOk,TErr}" /> if the factory executes successfully,
     /// otherwise a <see cref="Err{TOk,TErr}" />
     /// </returns>
-    public static async Task<Result<TOk, TErr>> Bind<TOk, TErr>(
+    public static async Task<Result<TOk, TErr>> Try<TOk, TErr>(
         Func<Task<TOk>> asyncFactory,
         Func<Exception, TErr> onError) where TOk : notnull where TErr : notnull
     {
@@ -68,6 +70,7 @@ public static class Result
         }
         catch (Exception ex)
         {
+            MonadsGlobalConfig.LogException(ex);
             return Err<TOk, TErr>(onError(ex));
         }
     }

--- a/test/Waystone.Monads.Tests/Options/OptionTests.cs
+++ b/test/Waystone.Monads.Tests/Options/OptionTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Configs;
 using JetBrains.Annotations;
 using NSubstitute;
 using Shouldly;
@@ -10,6 +11,14 @@ using Xunit;
 [TestSubject(typeof(Option))]
 public sealed class OptionTests
 {
+    private readonly Action<Exception> _callback;
+
+    public OptionTests()
+    {
+        _callback = Substitute.For<Action<Exception>>();
+        MonadsGlobalConfig.UseExceptionLogger(_callback);
+    }
+
     [Fact]
     public async Task GivenAsyncFactory_WhenBinding_ReturnSome()
     {
@@ -25,47 +34,40 @@ public sealed class OptionTests
     public async Task
         GivenAsyncFactoryThrows_WhenBinding_ThenReturnNone()
     {
-        var callback = Substitute.For<Action<Exception>>();
-        Task<Option<int>> optionTask = Option.Try<int>(
-            async () =>
-            {
-                await Task.Delay(10);
-                throw new Exception();
-            },
-            callback);
+        Task<Option<int>> optionTask = Option.Try<int>(async () =>
+        {
+            await Task.Delay(10);
+            throw new Exception();
+        });
 
         Option<int> option = await optionTask;
 
         option.ShouldBe(Option.None<int>());
-        callback.Received().Invoke(Arg.Any<Exception>());
+        _callback.Received().Invoke(Arg.Any<Exception>());
     }
 
 
     [Fact]
     public void WhenBindingFactoryThatSucceeds_ThenReturnSome()
     {
-        var callback = Substitute.For<Action<Exception>>();
-        Option<int> option = Option.Try(() => 1, callback);
+        Option<int> option = Option.Try(() => 1);
         option.ShouldBe(Option.Some(1));
-        callback.DidNotReceive().Invoke(Arg.Any<Exception>());
+        _callback.DidNotReceive().Invoke(Arg.Any<Exception>());
     }
 
     [Fact]
     public void
         GivenFactoryThatThrows_AndOnErrorCallback_WhenBindingFactory_ThenInvokeCallback()
     {
-        var callback = Substitute.For<Action<Exception>>();
-        Option<int> option = Option.Try(
-            () =>
-            {
-                throw new Exception();
+        Option<int> option = Option.Try(() =>
+        {
+            throw new Exception();
 #pragma warning disable CS0162 // Unreachable code detected
-                return 1;
+            return 1;
 #pragma warning restore CS0162 // Unreachable code detected
-            },
-            callback);
+        });
         option.ShouldBe(Option.None<int>());
-        callback.Received(1).Invoke(Arg.Any<Exception>());
+        _callback.Received(1).Invoke(Arg.Any<Exception>());
     }
 
 

--- a/test/Waystone.Monads.Tests/Options/OptionTests.cs
+++ b/test/Waystone.Monads.Tests/Options/OptionTests.cs
@@ -1,94 +1,93 @@
-﻿namespace Waystone.Monads.Options
+﻿namespace Waystone.Monads.Options;
+
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+[TestSubject(typeof(Option))]
+public sealed class OptionTests
 {
-    using System;
-    using System.Threading.Tasks;
-    using JetBrains.Annotations;
-    using NSubstitute;
-    using Shouldly;
-    using Xunit;
-
-    [TestSubject(typeof(Option))]
-    public sealed class OptionTests
+    [Fact]
+    public async Task GivenAsyncFactory_WhenBinding_ReturnSome()
     {
-        [Fact]
-        public async Task GivenAsyncFactory_WhenBinding_ReturnSome()
-        {
-            Task<Option<int>> optionTask =
-                Option.Bind(() => Task.FromResult(42));
+        Task<Option<int>> optionTask =
+            Option.Try(() => Task.FromResult(42));
 
-            Option<int> option = await optionTask;
+        Option<int> option = await optionTask;
 
-            option.ShouldBe(Option.Some(42));
-        }
+        option.ShouldBe(Option.Some(42));
+    }
 
-        [Fact]
-        public async Task
-            GivenAsyncFactoryThrows_WhenBinding_ThenReturnNone()
-        {
-            var callback = Substitute.For<Action<Exception>>();
-            Task<Option<int>> optionTask = Option.Bind<int>(
-                async () =>
-                {
-                    await Task.Delay(10);
-                    throw new Exception();
-                },
-                callback);
+    [Fact]
+    public async Task
+        GivenAsyncFactoryThrows_WhenBinding_ThenReturnNone()
+    {
+        var callback = Substitute.For<Action<Exception>>();
+        Task<Option<int>> optionTask = Option.Try<int>(
+            async () =>
+            {
+                await Task.Delay(10);
+                throw new Exception();
+            },
+            callback);
 
-            Option<int> option = await optionTask;
+        Option<int> option = await optionTask;
 
-            option.ShouldBe(Option.None<int>());
-            callback.Received().Invoke(Arg.Any<Exception>());
-        }
+        option.ShouldBe(Option.None<int>());
+        callback.Received().Invoke(Arg.Any<Exception>());
+    }
 
 
-        [Fact]
-        public void WhenBindingFactoryThatSucceeds_ThenReturnSome()
-        {
-            var callback = Substitute.For<Action<Exception>>();
-            Option<int> option = Option.Bind(() => 1, callback);
-            option.ShouldBe(Option.Some(1));
-            callback.DidNotReceive().Invoke(Arg.Any<Exception>());
-        }
+    [Fact]
+    public void WhenBindingFactoryThatSucceeds_ThenReturnSome()
+    {
+        var callback = Substitute.For<Action<Exception>>();
+        Option<int> option = Option.Try(() => 1, callback);
+        option.ShouldBe(Option.Some(1));
+        callback.DidNotReceive().Invoke(Arg.Any<Exception>());
+    }
 
-        [Fact]
-        public void
-            GivenFactoryThatThrows_AndOnErrorCallback_WhenBindingFactory_ThenInvokeCallback()
-        {
-            var callback = Substitute.For<Action<Exception>>();
-            Option<int> option = Option.Bind(
-                () =>
-                {
-                    throw new Exception();
+    [Fact]
+    public void
+        GivenFactoryThatThrows_AndOnErrorCallback_WhenBindingFactory_ThenInvokeCallback()
+    {
+        var callback = Substitute.For<Action<Exception>>();
+        Option<int> option = Option.Try(
+            () =>
+            {
+                throw new Exception();
 #pragma warning disable CS0162 // Unreachable code detected
-                    return 1;
+                return 1;
 #pragma warning restore CS0162 // Unreachable code detected
-                },
-                callback);
-            option.ShouldBe(Option.None<int>());
-            callback.Received(1).Invoke(Arg.Any<Exception>());
-        }
+            },
+            callback);
+        option.ShouldBe(Option.None<int>());
+        callback.Received(1).Invoke(Arg.Any<Exception>());
+    }
 
 
-        [Fact]
-        public void WhenImplicitlyCreatingOption_ThenReturnExpected()
-        {
-            Option<int> option1 = 0;
-            Option<int> option2 = 1;
-            Option<string> option3 = string.Empty;
+    [Fact]
+    public void WhenImplicitlyCreatingOption_ThenReturnExpected()
+    {
+        Option<int> option1 = 0;
+        Option<int> option2 = 1;
+        Option<string> option3 = string.Empty;
 #pragma warning disable CS8604 // Possible null reference argument.
-            // ReSharper disable once PreferConcreteValueOverDefault
-            Option<string> option4 = default(string);
-            // ReSharper disable once PreferConcreteValueOverDefault
-            Option<Guid> option5 = default(Guid);
+        // ReSharper disable once PreferConcreteValueOverDefault
+        Option<string> option4 = default(string);
+        // ReSharper disable once PreferConcreteValueOverDefault
+        Option<Guid> option5 = default(Guid);
 #pragma warning restore CS8604 // Possible null reference argument.
-            Option<Guid> option6 = Guid.NewGuid();
+        Option<Guid> option6 = Guid.NewGuid();
 
-            option1.IsSome.ShouldBeFalse();
-            option2.IsSome.ShouldBeTrue();
-            option3.IsSome.ShouldBeTrue();
-            option4.IsSome.ShouldBeFalse();
-            option5.IsSome.ShouldBeFalse();
-            option6.IsSome.ShouldBeTrue();
-        }
+        option1.IsSome.ShouldBeFalse();
+        option2.IsSome.ShouldBeTrue();
+        option3.IsSome.ShouldBeTrue();
+        option4.IsSome.ShouldBeFalse();
+        option5.IsSome.ShouldBeFalse();
+        option6.IsSome.ShouldBeTrue();
     }
 }

--- a/test/Waystone.Monads.Tests/Results/ResultTests.cs
+++ b/test/Waystone.Monads.Tests/Results/ResultTests.cs
@@ -1,82 +1,81 @@
-﻿namespace Waystone.Monads.Results
+﻿namespace Waystone.Monads.Results;
+
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+[TestSubject(typeof(Result))]
+public sealed class ResultTests
 {
-    using System;
-    using System.Threading.Tasks;
-    using JetBrains.Annotations;
-    using NSubstitute;
-    using Shouldly;
-    using Xunit;
-
-    [TestSubject(typeof(Result))]
-    public sealed class ResultTests
+    [Fact]
+    public void GivenFactoryThatSucceeds_WhenBindingFactory_ThenReturnOk()
     {
-        [Fact]
-        public void GivenFactoryThatSucceeds_WhenBindingFactory_ThenReturnOk()
-        {
-            var callback = Substitute.For<Func<Exception, string>>();
-            Result<int, string>
-                result = Result.Bind(() => 1, callback);
-            result.ShouldBe(Result.Ok<int, string>(1));
-            callback.DidNotReceive().Invoke(Arg.Any<Exception>());
-        }
+        var callback = Substitute.For<Func<Exception, string>>();
+        Result<int, string>
+            result = Result.Try(() => 1, callback);
+        result.ShouldBe(Result.Ok<int, string>(1));
+        callback.DidNotReceive().Invoke(Arg.Any<Exception>());
+    }
 
-        [Fact]
-        public void GivenFactoryThatFails_WhenBindingFactory_ThenReturnError()
-        {
-            var callback = Substitute.For<Func<Exception, string>>();
-            callback.Invoke(Arg.Any<Exception>()).Returns("error");
-            Result<int, string> result = Result.Bind(
-                () =>
-                {
-                    throw new Exception();
+    [Fact]
+    public void GivenFactoryThatFails_WhenBindingFactory_ThenReturnError()
+    {
+        var callback = Substitute.For<Func<Exception, string>>();
+        callback.Invoke(Arg.Any<Exception>()).Returns("error");
+        Result<int, string> result = Result.Try(
+            () =>
+            {
+                throw new Exception();
 #pragma warning disable CS0162 // Unreachable code detected
-                    return 1;
+                return 1;
 #pragma warning restore CS0162 // Unreachable code detected
-                },
-                callback);
-            result.ShouldBe(Result.Err<int, string>("error"));
-            callback.Received(1).Invoke(Arg.Any<Exception>());
-        }
+            },
+            callback);
+        result.ShouldBe(Result.Err<int, string>("error"));
+        callback.Received(1).Invoke(Arg.Any<Exception>());
+    }
 
-        [Fact]
-        public async Task
-            GivenAsyncFactoryThatSucceeds_WhenBindingFactory_ThenReturnOk()
-        {
-            var callback = Substitute.For<Func<Exception, string>>();
-            Result<int, string> result = await Result.Bind(
-                () => Task.FromResult(1),
-                callback);
-            result.ShouldBe(Result.Ok<int, string>(1));
-            callback.DidNotReceive().Invoke(Arg.Any<Exception>());
-        }
+    [Fact]
+    public async Task
+        GivenAsyncFactoryThatSucceeds_WhenBindingFactory_ThenReturnOk()
+    {
+        var callback = Substitute.For<Func<Exception, string>>();
+        Result<int, string> result = await Result.Try(
+            () => Task.FromResult(1),
+            callback);
+        result.ShouldBe(Result.Ok<int, string>(1));
+        callback.DidNotReceive().Invoke(Arg.Any<Exception>());
+    }
 
-        [Fact]
-        public async Task
-            GivenAsyncFactoryThatFails_WhenBindingFactory_ThenReturnError()
-        {
-            var callback = Substitute.For<Func<Exception, string>>();
-            callback.Invoke(Arg.Any<Exception>()).Returns("error");
-            Result<int, string> result = await Result.Bind(
-                () =>
-                {
-                    throw new Exception();
+    [Fact]
+    public async Task
+        GivenAsyncFactoryThatFails_WhenBindingFactory_ThenReturnError()
+    {
+        var callback = Substitute.For<Func<Exception, string>>();
+        callback.Invoke(Arg.Any<Exception>()).Returns("error");
+        Result<int, string> result = await Result.Try(
+            () =>
+            {
+                throw new Exception();
 #pragma warning disable CS0162 // Unreachable code detected
-                    return Task.FromResult(1);
+                return Task.FromResult(1);
 #pragma warning restore CS0162 // Unreachable code detected
-                },
-                callback);
-            result.ShouldBe(Result.Err<int, string>("error"));
-            callback.Received(1).Invoke(Arg.Any<Exception>());
-        }
+            },
+            callback);
+        result.ShouldBe(Result.Err<int, string>("error"));
+        callback.Received(1).Invoke(Arg.Any<Exception>());
+    }
 
-        [Fact]
-        public void WhenImplicitlyCreatingResult_ThenReturnExpected()
-        {
-            Result<int, string> ok = 1;
-            Result<int, string> err = "error";
+    [Fact]
+    public void WhenImplicitlyCreatingResult_ThenReturnExpected()
+    {
+        Result<int, string> ok = 1;
+        Result<int, string> err = "error";
 
-            ok.ShouldBe(Result.Ok<int, string>(1));
-            err.ShouldBe(Result.Err<int, string>("error"));
-        }
+        ok.ShouldBe(Result.Ok<int, string>(1));
+        err.ShouldBe(Result.Err<int, string>("error"));
     }
 }


### PR DESCRIPTION
### Renamed `Bind` to `Try`

The `Option.Bind` and `Result.Bind` factory methods have been renamed to `Try`
to better adhere to functional programing concepts.

`Bind` is often associated with `FlatMap`, a way of composing functions together
in a pipeline. This renaming removes the confusion.

### Introduced `MonadsGlobalConfig`

This configuration allows the setting of a global error logger that will be
invoked whenever an exception is caught and handled by the library.

### Removed local error handling

Removed the local handle error callback on the `Option.Try` methods in favour of
the `MonadsGlobalConfig`.