### PR TITLE
feat(validation-err): add mapping to error type

### DIFF
--- a/src/Waystone.Monads.FluentValidation/Configs/MonadOptionsExtensions.cs
+++ b/src/Waystone.Monads.FluentValidation/Configs/MonadOptionsExtensions.cs
@@ -1,0 +1,39 @@
+namespace Waystone.Monads.FluentValidation.Configs;
+
+using System.Diagnostics.CodeAnalysis;
+using Waystone.Monads.Configs;
+using Waystone.Monads.FluentValidation.Results;
+using Waystone.Monads.Results.Errors;
+
+/// <summary>
+/// Extensions for chaining <see cref="MonadValidationOptions"/> configuration onto the global <see cref="MonadOptions"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class MonadOptionsExtensions
+{
+    /// <summary>
+    /// Configures he error code that will be used when converting a <see cref="ValidationErr"/>
+    /// into an <see cref="Error"/>
+    /// </summary>
+    /// <remarks>The default error code is `validation.failed`.</remarks>
+    /// <param name="_">The <see cref="MonadOptions"/> to chain the method from.</param>
+    /// <param name="errorCode">The validation error code to use.</param>
+    /// <returns>The instance of <see cref="MonadValidationOptions"/> for chaining more configurations.</returns>
+    public static MonadValidationOptions UseValidationErrorCode(
+        this MonadOptions _,
+        string errorCode) => MonadValidationOptions.Global.UseValidationErrorCode(errorCode);
+
+
+    /// <summary>
+    /// Configures the fallback error message that will be used when converting a <see cref="ValidationErr"/>
+    /// into an <see cref="Error"/> if the validation error does not have a specific message set.
+    /// </summary>
+    /// <remarks>The default fallback error message is `One or more validation errors occurred.`</remarks>
+    /// <param name="_">The <see cref="MonadOptions"/> to chain the method from.</param>
+    /// <param name="fallbackErrorMessage">The fallback error message to use.</param>
+    /// <returns>The instance of <see cref="MonadValidationOptions"/> for chaining more configurations.</returns>
+    public static MonadValidationOptions UseFallbackValidationErrorMessage(
+        this MonadOptions _,
+        string fallbackErrorMessage) =>
+        MonadValidationOptions.Global.UseFallbackValidationErrorMessage(fallbackErrorMessage);
+}

--- a/src/Waystone.Monads.FluentValidation/Configs/MonadOptionsExtensions.cs
+++ b/src/Waystone.Monads.FluentValidation/Configs/MonadOptionsExtensions.cs
@@ -12,7 +12,7 @@ using Waystone.Monads.Results.Errors;
 public static class MonadOptionsExtensions
 {
     /// <summary>
-    /// Configures he error code that will be used when converting a <see cref="ValidationErr"/>
+    /// Configures the error code that will be used when converting a <see cref="ValidationErr"/>
     /// into an <see cref="Error"/>
     /// </summary>
     /// <remarks>The default error code is `validation.failed`.</remarks>

--- a/src/Waystone.Monads.FluentValidation/Configs/MonadValidationOptions.cs
+++ b/src/Waystone.Monads.FluentValidation/Configs/MonadValidationOptions.cs
@@ -1,0 +1,66 @@
+namespace Waystone.Monads.FluentValidation.Configs;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Waystone.Monads.FluentValidation.Results;
+using Waystone.Monads.Results.Errors;
+
+/// <summary>
+/// Global configuration options for the Waystone.Monads.FluentValidation library.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class MonadValidationOptions
+{
+    private static readonly Lazy<MonadValidationOptions> _singleton =
+        new(() => new MonadValidationOptions());
+
+    internal static MonadValidationOptions Global => _singleton.Value;
+
+    private MonadValidationOptions()
+    {
+        ValidationErrorCode = "validation.failed";
+        FallbackValidationErrorMessage = "One or more validation errors occurred.";
+    }
+
+
+    internal string ValidationErrorCode { get; set; }
+
+
+    internal string FallbackValidationErrorMessage { get; set; }
+
+    /// <summary>
+    /// Configures he error code that will be used when converting a <see cref="ValidationErr"/>
+    /// into an <see cref="Error"/>
+    /// </summary>
+    /// <remarks>The default error code is `validation.failed`.</remarks>
+    /// <param name="errorCode">The validation error code to use.</param>
+    /// <returns>The instance of <see cref="MonadValidationOptions"/> for chaining more configurations.</returns>
+    public MonadValidationOptions UseValidationErrorCode(string errorCode)
+    {
+        if (string.IsNullOrWhiteSpace(errorCode))
+        {
+            throw new ArgumentException("Error code cannot be null or whitespace.", nameof(errorCode));
+        }
+
+        ValidationErrorCode = errorCode;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the fallback error message that will be used when converting a <see cref="ValidationErr"/>
+    /// into an <see cref="Error"/> if the validation error does not have a specific message set.
+    /// </summary>
+    /// <remarks>The default fallback error message is `One or more validation errors occurred.`</remarks>
+    /// <param name="fallbackErrorMessage">The fallback error message to use.</param>
+    /// <returns>The instance of <see cref="MonadValidationOptions"/> for chaining more configurations.</returns>
+    public MonadValidationOptions UseFallbackValidationErrorMessage(string fallbackErrorMessage)
+    {
+        if (string.IsNullOrWhiteSpace(fallbackErrorMessage))
+        {
+            throw new ArgumentException("Fallback error message cannot be null or whitespace.", nameof(fallbackErrorMessage));
+        }
+
+        FallbackValidationErrorMessage = fallbackErrorMessage;
+        return this;
+    }
+}

--- a/src/Waystone.Monads.FluentValidation/Configs/MonadValidationOptions.cs
+++ b/src/Waystone.Monads.FluentValidation/Configs/MonadValidationOptions.cs
@@ -29,7 +29,7 @@ public sealed class MonadValidationOptions
     internal string FallbackValidationErrorMessage { get; set; }
 
     /// <summary>
-    /// Configures he error code that will be used when converting a <see cref="ValidationErr"/>
+    /// Configures the error code that will be used when converting a <see cref="ValidationErr"/>
     /// into an <see cref="Error"/>
     /// </summary>
     /// <remarks>The default error code is `validation.failed`.</remarks>

--- a/src/Waystone.Monads.FluentValidation/Results/ValidationErr.cs
+++ b/src/Waystone.Monads.FluentValidation/Results/ValidationErr.cs
@@ -55,7 +55,7 @@ public sealed class ValidationErr
     /// Converts the <see cref="ValidationErr" /> to an <see cref="Error" />.
     /// </summary>
     /// <remarks>
-    /// Uses the options configured in <see cref="MonadValidationOptions"/> to determine\
+    /// Uses the options configured in <see cref="MonadValidationOptions"/> to determine
     /// the error code and the fallback error message (for when there are no errors in the validation result).
     /// </remarks>
     /// <returns>The created <see cref="Error"/></returns>

--- a/src/Waystone.Monads.FluentValidation/Results/ValidationErr.cs
+++ b/src/Waystone.Monads.FluentValidation/Results/ValidationErr.cs
@@ -1,8 +1,13 @@
 ﻿namespace Waystone.Monads.FluentValidation.Results;
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using global::FluentValidation.Results;
 using Options;
+using Waystone.Monads.FluentValidation.Configs;
+using Waystone.Monads.Results.Errors;
 
 /// <summary>The errors that were encountered while running a validator</summary>
 public sealed class ValidationErr
@@ -45,6 +50,28 @@ public sealed class ValidationErr
     /// <inheritdoc cref="ValidationResult.ToDictionary" />
     public IDictionary<string, string[]> ToDictionary() =>
         _validationResult.ToDictionary();
+
+    /// <summary>
+    /// Converts the <see cref="ValidationErr" /> to an <see cref="Error" />.
+    /// </summary>
+    /// <remarks>
+    /// Uses the options configured in <see cref="MonadValidationOptions"/> to determine\
+    /// the error code and the fallback error message (for when there are no errors in the validation result).
+    /// </remarks>
+    /// <returns>The created <see cref="Error"/></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public Error ToError()
+    {
+        Debug.Assert(_validationResult.IsValid is false, "Validation Result should never be valid here.");
+
+        ErrorCode errorCode = new(MonadValidationOptions.Global.ValidationErrorCode);
+
+        string errorMessage = Errors.Count > 0
+            ? string.Join("; ", Errors.Select(e => e.ErrorMessage.TrimEnd('.')))
+            : MonadValidationOptions.Global.FallbackValidationErrorMessage;
+
+        return new Error(errorCode, $"{errorMessage};");
+    }
 
     /// <inheritdoc cref="ValidationResult.ToString()" />
     public override string ToString() => _validationResult.ToString();

--- a/src/Waystone.Monads/Configs/MonadOptions.cs
+++ b/src/Waystone.Monads/Configs/MonadOptions.cs
@@ -10,7 +10,7 @@ using Waystone.Monads.Results.Errors;
 /// Global configuration options for the Waystone.Monads library.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class MonadOptions
+public sealed class MonadOptions
 {
     private static readonly Lazy<MonadOptions> _singleton =
         new(() => new MonadOptions());
@@ -88,7 +88,7 @@ public class MonadOptions
     public MonadOptions UseFallbackErrorCode(string errorCode)
     {
         if (string.IsNullOrWhiteSpace(errorCode))
-            throw new InvalidOperationException("The fallback error code cannot be null or whitespace.");
+            throw new ArgumentException("The fallback error code cannot be null or whitespace.", nameof(errorCode));
 
         FallbackErrorCode = errorCode.Trim();
         return this;
@@ -104,7 +104,7 @@ public class MonadOptions
     public MonadOptions UseFallbackErrorMessage(string errorMessage)
     {
         if (string.IsNullOrWhiteSpace(errorMessage))
-            throw new InvalidOperationException("The fallback error message cannot be null or whitespace.");
+            throw new ArgumentException("The fallback error message cannot be null or whitespace.", nameof(errorMessage));
 
         FallbackErrorMessage = errorMessage.Trim();
         return this;

--- a/src/Waystone.Monads/Properties/AssemblyInfo.cs
+++ b/src/Waystone.Monads/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Waystone.Monads.Tests")]
+[assembly: InternalsVisibleTo("Waystone.Monads.FluentValidation")]

--- a/test/Waystone.Monads.Tests/FluentValidation/Results/ValidationErrTests.cs
+++ b/test/Waystone.Monads.Tests/FluentValidation/Results/ValidationErrTests.cs
@@ -1,0 +1,49 @@
+namespace Waystone.Monads.FluentValidation.Results;
+
+using System.Collections.Generic;
+using global::FluentValidation.Results;
+using Shouldly;
+using Waystone.Monads.Extensions;
+using Xunit;
+
+public class ValidationErrTests
+{
+    [Fact]
+    public void GivenInvalidValidationResult_WhenCreatingValidationErr_ThenReturnSome()
+    {
+        var validationResult = new ValidationResult([
+            new ValidationFailure("Property", "Error message")
+        ]);
+
+        var result = ValidationErr.Create(validationResult);
+
+        result.ShouldBeSome();
+        var validationErr = result.Unwrap();
+        validationErr.AsValidationResult().ShouldBe(validationResult);
+    }
+
+    [Fact]
+    public void GivenValidValidationResult_WhenCreatingValidationErr_ThenReturnNone()
+    {
+        var validationResult = new ValidationResult();
+
+        var result = ValidationErr.Create(validationResult);
+
+        result.ShouldBeNone();
+    }
+
+    [Fact]
+    public void WhenConvertingToError_ThenReturnExpectedErrorProperties()
+    {
+        var validationResult = new ValidationResult([
+            new ValidationFailure("Property1", "Error message 1."),
+            new ValidationFailure("Property2", "Error message 2.")
+        ]);
+
+        var validationErr = ValidationErr.Create(validationResult);
+        var error = validationErr.Unwrap().ToError();
+
+        error.Code.Value.ShouldBe("validation.failed"); ;
+        error.Message.ShouldBe("Error message 1; Error message 2;");
+    }
+}

--- a/test/Waystone.Monads.Tests/FluentValidation/Results/ValidationErrTests.cs
+++ b/test/Waystone.Monads.Tests/FluentValidation/Results/ValidationErrTests.cs
@@ -43,7 +43,7 @@ public class ValidationErrTests
         var validationErr = ValidationErr.Create(validationResult);
         var error = validationErr.Unwrap().ToError();
 
-        error.Code.Value.ShouldBe("validation.failed"); ;
+        error.Code.Value.ShouldBe("validation.failed");
         error.Message.ShouldBe("Error message 1; Error message 2;");
     }
 }


### PR DESCRIPTION
Adds a method to the ValidationErr class that converts it into the built in Error class of Waystone.Monads