### PR TITLE
ci: use NuGet trusted publishing for package pushes

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -99,6 +99,7 @@ jobs:
     name: Push packages
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     needs:
       - calculate-version
@@ -122,8 +123,14 @@ jobs:
         run: |
           dotnet pack -c Release --no-restore -o out -p:PackageVersion=${{ needs.calculate-version.outputs.semVer }}
 
+      - name: NuGet login
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: deploy
-        run: dotnet nuget push ./out/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./out/*.nupkg --skip-duplicate --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
   
   create-release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
       - build-and-test
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -126,8 +127,14 @@ jobs:
         run: |
           dotnet pack -c Release --no-restore -o out -p:PackageVersion=${{ needs.calculate-version.outputs.semVer }}
 
+      - name: NuGet login
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: deploy
-        run: dotnet nuget push ./out/*.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./out/*.nupkg --skip-duplicate --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
   
   create-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Problem

Package pushes are failing with `403 Forbidden` — the static `NUGET_API_KEY`
secret is no longer accepted.

## Change

Migrate both publish workflows to NuGet trusted publishing (OIDC), which mints
a short-lived API key per run instead of relying on a long-lived secret.

In `release.yml` (`push-packages`) and `pre-release.yml` (`deployment`):

- add `id-token: write` to the job `permissions` block
- add a `NuGet/login@v1` step after `Pack`
- push using `${{ steps.login.outputs.NUGET_API_KEY }}`

## Prerequisites

- Trusted publishing policies `waystone-dotnet-release` and
  `waystone-dotnet-pre-release` exist on nuget.org, scoped to this repo and
  keyed on the `release.yml` / `pre-release.yml` workflow filenames.
- Repo secret `NUGET_USER` holds the nuget.org profile name.

## Follow-up

The `NUGET_API_KEY` secret is left in place for now. It can be deleted once
both workflows have published successfully.
