### PR TITLE
ci: stop a submitted stack cancelling its own checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pull-request
+  group: pull-request-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:
@@ -13,6 +13,12 @@ on:
     paths:
       - 'src/**'
       - 'test/**'
+      - 'sample/**'
+      - '.editorconfig'
+      - 'Directory.Packages.props'
+      - 'Waystone.Net.sln'
+      - 'global.json'
+      - 'GitVersion.yml'
       - '.github/workflows/pull-request.yml'
 
 jobs:


### PR DESCRIPTION
## What

Keys the `Pull Request` workflow's concurrency group on the pull request number, and adds the shared build inputs to its paths filter.

## Why

The workflow used one global `pull-request` concurrency group with `cancel-in-progress: true`. Every pull request in the repository shared a single slot, so submitting a stack had each run cancel the one before it — only the top pull request kept its checks, and the rest showed no status at all.

The trigger needed no change. GitHub evaluates a stacked pull request as though it targeted the base of the stack, so `branches: main` already matches every layer ([docs](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests)). `branches: main` stays.

Separately, the paths filter covered only `src/**` and `test/**`. A change to `.editorconfig` decides which `Microsoft.CodeAnalysis.Analyzers` metarules fail the analyzer build, and ran no checks at all; `Directory.Packages.props`, `global.json` and `GitVersion.yml` were in the same position.

## Verification

This pull request exercises the change, since it matches its own paths filter.

No public API surface changes, so no paired documentation pull request.