### PR TITLE
feat: add the missing Rust Option and Result methods

### DIFF
--- a/src/Waystone.Monads/Options/Extensions/AndExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/AndExtensions.cs
@@ -1,0 +1,58 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using System.Threading.Tasks;
+
+public static class AndExtensions
+{
+    extension<T>(Task<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and returns <see cref="None{T}" /> if
+        /// the option is a <see cref="None{T}" />, otherwise returns
+        /// <paramref name="other" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the value contained in the other option.</typeparam>
+        /// <param name="other">
+        /// The option to return when the awaited option is a
+        /// <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" /> containing
+        /// <paramref name="other" /> if the awaited option was a <see cref="Some{T}" />,
+        /// or <see cref="None{T}" /> otherwise.
+        /// </returns>
+        public async Task<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
+            where TOut : notnull
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.And(other);
+        }
+    }
+
+    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and returns
+        /// <see cref="None{T}" /> if the option is a <see cref="None{T}" />, otherwise
+        /// returns <paramref name="other" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the value contained in the other option.</typeparam>
+        /// <param name="other">
+        /// The option to return when the awaited option is a
+        /// <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" /> containing
+        /// <paramref name="other" /> if the awaited option was a <see cref="Some{T}" />,
+        /// or <see cref="None{T}" /> otherwise.
+        /// </returns>
+        public async Task<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
+            where TOut : notnull
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.And(other);
+        }
+    }
+}

--- a/src/Waystone.Monads/Options/Extensions/AsEnumerableExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/AsEnumerableExtensions.cs
@@ -1,0 +1,45 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public static class AsEnumerableExtensions
+{
+    extension<T>(Task<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and returns a sequence over the
+        /// possibly contained value.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// contained value once if the awaited option was a <see cref="Some{T}" />,
+        /// otherwise an empty sequence.
+        /// </returns>
+        public async Task<IEnumerable<T>> AsEnumerableAsync()
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.AsEnumerable();
+        }
+    }
+
+    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and returns a sequence over the
+        /// possibly contained value.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// contained value once if the awaited option was a <see cref="Some{T}" />,
+        /// otherwise an empty sequence.
+        /// </returns>
+        public async Task<IEnumerable<T>> AsEnumerableAsync()
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.AsEnumerable();
+        }
+    }
+}

--- a/src/Waystone.Monads/Options/Extensions/MapOrDefaultExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrDefaultExtensions.cs
@@ -1,0 +1,147 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using System;
+using System.Threading.Tasks;
+
+public static class MapOrDefaultExtensions
+{
+    extension<T>(Option<T> option) where T : notnull
+    {
+        /// <summary>
+        /// Awaits <paramref name="map" /> against the contained value if the option is
+        /// a <see cref="Some{T}" />, otherwise returns the <see langword="default" /> of
+        /// <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the value inside the
+        /// option if it is a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the
+        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
+            Func<T, Task<TOut>> map)
+            where TOut : notnull
+        {
+            if (option.IsNone) return default;
+
+            T some = option.Expect("Expected Some but found None.");
+
+            return await map.Invoke(some).ConfigureAwait(false);
+        }
+    }
+
+    extension<T>(Task<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and applies <paramref name="map" /> to
+        /// the contained value if the option is a <see cref="Some{T}" />, otherwise
+        /// returns the <see langword="default" /> of <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to transform the value inside the option if it is
+        /// a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
+            where TOut : notnull
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.MapOrDefault(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and awaits <paramref name="map" />
+        /// against the contained value if the option is a <see cref="Some{T}" />,
+        /// otherwise returns the <see langword="default" /> of
+        /// <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the value inside the
+        /// option if it is a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+            Func<T, Task<TOut>> map)
+            where TOut : notnull
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            if (option.IsNone) return default;
+
+            T some = option.Expect("Expected Some but found None.");
+
+            return await map.Invoke(some).ConfigureAwait(false);
+        }
+    }
+
+    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and applies
+        /// <paramref name="map" /> to the contained value if the option is a
+        /// <see cref="Some{T}" />, otherwise returns the <see langword="default" /> of
+        /// <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to transform the value inside the option if it is
+        /// a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
+            where TOut : notnull
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.MapOrDefault(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and awaits
+        /// <paramref name="map" /> against the contained value if the option is a
+        /// <see cref="Some{T}" />, otherwise returns the <see langword="default" /> of
+        /// <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the value inside the
+        /// option if it is a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+            Func<T, Task<TOut>> map)
+            where TOut : notnull
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            if (option.IsNone) return default;
+
+            T some = option.Expect("Expected Some but found None.");
+
+            return await map.Invoke(some).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Waystone.Monads/Options/Extensions/ReduceExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/ReduceExtensions.cs
@@ -1,0 +1,134 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using System;
+using System.Threading.Tasks;
+
+public static class ReduceExtensions
+{
+    extension<T>(Option<T> option) where T : notnull
+    {
+        /// <summary>
+        /// Merges the option with another option, awaiting
+        /// <paramref name="reduce" /> when both are a <see cref="Some{T}" />.
+        /// </summary>
+        /// <param name="other">The option to merge with.</param>
+        /// <param name="reduce">
+        /// A function that asynchronously combines two present
+        /// values.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both
+        /// are a <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when
+        /// only one of them is, and <see cref="None{T}" /> when neither is.
+        /// </returns>
+        public async ValueTask<Option<T>> ReduceAsync(
+            Option<T> other,
+            Func<T, T, Task<T>> reduce)
+        {
+            if (option.IsNone) return other;
+
+            if (other.IsNone) return option;
+
+            T some = option.Expect("Expected Some but found None.");
+            T otherSome = other.Expect("Expected Some but found None.");
+
+            return await reduce.Invoke(some, otherSome).ConfigureAwait(false);
+        }
+    }
+
+    extension<T>(Task<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and merges the option with another
+        /// option.
+        /// </summary>
+        /// <param name="other">The option to merge with.</param>
+        /// <param name="reduce">The function that combines two present values.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
+        /// one of them is, and <see cref="None{T}" /> when neither is.
+        /// </returns>
+        public async Task<Option<T>> ReduceAsync(
+            Option<T> other,
+            Func<T, T, T> reduce)
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.Reduce(other, reduce);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and merges the option with another
+        /// option, awaiting <paramref name="reduce" /> when both are a
+        /// <see cref="Some{T}" />.
+        /// </summary>
+        /// <param name="other">The option to merge with.</param>
+        /// <param name="reduce">
+        /// A function that asynchronously combines two present
+        /// values.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
+        /// one of them is, and <see cref="None{T}" /> when neither is.
+        /// </returns>
+        public async Task<Option<T>> ReduceAsync(
+            Option<T> other,
+            Func<T, T, Task<T>> reduce)
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return await option.ReduceAsync(other, reduce)
+               .ConfigureAwait(false);
+        }
+    }
+
+    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and merges the option with
+        /// another option.
+        /// </summary>
+        /// <param name="other">The option to merge with.</param>
+        /// <param name="reduce">The function that combines two present values.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
+        /// one of them is, and <see cref="None{T}" /> when neither is.
+        /// </returns>
+        public async Task<Option<T>> ReduceAsync(
+            Option<T> other,
+            Func<T, T, T> reduce)
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.Reduce(other, reduce);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and merges the option with
+        /// another option, awaiting <paramref name="reduce" /> when both are a
+        /// <see cref="Some{T}" />.
+        /// </summary>
+        /// <param name="other">The option to merge with.</param>
+        /// <param name="reduce">
+        /// A function that asynchronously combines two present
+        /// values.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
+        /// one of them is, and <see cref="None{T}" /> when neither is.
+        /// </returns>
+        public async Task<Option<T>> ReduceAsync(
+            Option<T> other,
+            Func<T, T, Task<T>> reduce)
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return await option.ReduceAsync(other, reduce)
+               .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Waystone.Monads/Options/Extensions/UnzipExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnzipExtensions.cs
@@ -1,0 +1,48 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using System.Threading.Tasks;
+
+public static class UnzipExtensions
+{
+    extension<T1, T2>(Task<Option<(T1, T2)>> optionTask)
+        where T1 : notnull where T2 : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and unzips the option containing a
+        /// tuple into a tuple of two options.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing a pair of <see cref="Some{T}" />
+        /// options carrying the two halves of the tuple if the awaited option was a
+        /// <see cref="Some{T}" />, otherwise a pair of <see cref="None{T}" />.
+        /// </returns>
+        public async Task<(Option<T1>, Option<T2>)> UnzipAsync()
+        {
+            Option<(T1, T2)> option =
+                await optionTask.ConfigureAwait(false);
+
+            return option.Unzip();
+        }
+    }
+
+    extension<T1, T2>(ValueTask<Option<(T1, T2)>> optionTask)
+        where T1 : notnull where T2 : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and unzips the option containing
+        /// a tuple into a tuple of two options.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing a pair of <see cref="Some{T}" />
+        /// options carrying the two halves of the tuple if the awaited option was a
+        /// <see cref="Some{T}" />, otherwise a pair of <see cref="None{T}" />.
+        /// </returns>
+        public async Task<(Option<T1>, Option<T2>)> UnzipAsync()
+        {
+            Option<(T1, T2)> option =
+                await optionTask.ConfigureAwait(false);
+
+            return option.Unzip();
+        }
+    }
+}

--- a/src/Waystone.Monads/Options/OptionOfT.cs
+++ b/src/Waystone.Monads/Options/OptionOfT.cs
@@ -1,6 +1,7 @@
 ﻿namespace Waystone.Monads.Options;
 
 using System;
+using System.Collections.Generic;
 using Exceptions;
 using Extensions;
 using Results;
@@ -131,6 +132,23 @@ public abstract record Option<T> where T : notnull
 
     /// <summary>
     /// Returns <see cref="None{T}" /> if the option is a <see cref="None{T}" />,
+    /// otherwise returns <paramref name="other" />.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="other" /> is eagerly evaluated. If you are passing the
+    /// result of a function call, prefer <see cref="AndThen{T2}" />, which is
+    /// lazily evaluated.
+    /// </remarks>
+    /// <param name="other">The option to return when this one is a <see cref="Some{T}" />.</param>
+    /// <typeparam name="T2">The type of the value contained in the other option.</typeparam>
+#if !DEBUG
+    [DebuggerStepThrough]
+#endif
+    public Option<T2> And<T2>(Option<T2> other) where T2 : notnull =>
+        Match(_ => other, Option.None<T2>);
+
+    /// <summary>
+    /// Returns <see cref="None{T}" /> if the option is a <see cref="None{T}" />,
     /// otherwise calls <paramref name="map" /> with the wrapped value and returns
     /// the result.
     /// </summary>
@@ -183,6 +201,19 @@ public abstract record Option<T> where T : notnull
     /// <param name="map">The map function.</param>
     /// <typeparam name="T2">The return type of the map function.</typeparam>
     public abstract T2 MapOr<T2>(T2 @default, Func<T, T2> map);
+
+    /// <summary>
+    /// Returns the <see langword="default" /> of <typeparamref name="T2" /> (if
+    /// <see cref="None{T}" />), or applies a function to the contained value (if
+    /// <see cref="Some{T}" />).
+    /// </summary>
+    /// <param name="map">The map function.</param>
+    /// <typeparam name="T2">The return type of the map function.</typeparam>
+#if !DEBUG
+    [DebuggerStepThrough]
+#endif
+    public T2? MapOrDefault<T2>(Func<T, T2> map) where T2 : notnull =>
+        Match<T2?>(map, () => default);
 
     /// <summary>
     /// Computes a default from a function (if <see cref="None{T}" />), or
@@ -279,6 +310,39 @@ public abstract record Option<T> where T : notnull
         Func<T, TOther, TOut> zip)
         where TOther : notnull
         where TOut : notnull;
+
+    /// <summary>Merges the current option with another option.</summary>
+    /// <remarks>
+    /// Unlike <see cref="ZipWith{TOther,TOut}" />, an option that is a
+    /// <see cref="Some{T}" /> survives a <see cref="None{T}" /> on the other side.
+    /// </remarks>
+    /// <param name="other">The option to merge with.</param>
+    /// <param name="reduce">The function that combines two present values.</param>
+    /// <returns>
+    /// <c>Some(reduce(a, b))</c> when both options are <see cref="Some{T}" />,
+    /// whichever option is <see cref="Some{T}" /> when only one of them is, and
+    /// <see cref="None{T}" /> when neither is.
+    /// </returns>
+#if !DEBUG
+    [DebuggerStepThrough]
+#endif
+    public Option<T> Reduce(Option<T> other, Func<T, T, T> reduce) =>
+        Match(
+            value => other.Match<Option<T>>(
+                otherValue => reduce(value, otherValue),
+                () => value),
+            () => other);
+
+    /// <summary>Returns a sequence over the possibly contained value.</summary>
+    /// <returns>
+    /// A sequence yielding the contained value once if the option is a
+    /// <see cref="Some{T}" />, otherwise an empty sequence.
+    /// </returns>
+#if !DEBUG
+    [DebuggerStepThrough]
+#endif
+    public IEnumerable<T> AsEnumerable() =>
+        Match<IEnumerable<T>>(value => new[] { value }, Array.Empty<T>);
 
     /// <summary>
     /// Transforms the current <see cref="Option{T}" /> into a

--- a/src/Waystone.Monads/Results/Extensions/AsEnumerableExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/AsEnumerableExtensions.cs
@@ -1,0 +1,49 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public static class AsEnumerableExtensions
+{
+    extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and returns a sequence over the
+        /// possibly contained <see cref="Ok{TOk,TErr}" /> value.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// contained value once if the awaited result was an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise an empty sequence.
+        /// </returns>
+        public async Task<IEnumerable<TOk>> AsEnumerableAsync()
+        {
+            Result<TOk, TErr> result =
+                await resultTask.ConfigureAwait(false);
+
+            return result.AsEnumerable();
+        }
+    }
+
+    extension<TOk, TErr>(ValueTask<Result<TOk, TErr>> resultTask)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and returns a sequence over the
+        /// possibly contained <see cref="Ok{TOk,TErr}" /> value.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// contained value once if the awaited result was an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise an empty sequence.
+        /// </returns>
+        public async Task<IEnumerable<TOk>> AsEnumerableAsync()
+        {
+            Result<TOk, TErr> result =
+                await resultTask.ConfigureAwait(false);
+
+            return result.AsEnumerable();
+        }
+    }
+}

--- a/src/Waystone.Monads/Results/Extensions/MapOrDefaultExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapOrDefaultExtensions.cs
@@ -1,0 +1,148 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using System;
+using System.Threading.Tasks;
+
+public static class MapOrDefaultExtensions
+{
+    extension<TOk, TErr>(Result<TOk, TErr> result)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits <paramref name="map" /> against the contained value if the result is
+        /// an <see cref="Ok{TOk,TErr}" />, otherwise returns the
+        /// <see langword="default" /> of <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the
+        /// <see cref="Ok{TOk,TErr}" /> value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the
+        /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
+            Func<TOk, Task<TOut>> map)
+            where TOut : notnull
+        {
+            if (result.IsErr) return default;
+
+            TOk ok = result.Expect("Expected Ok but found Err.");
+
+            return await map.Invoke(ok).ConfigureAwait(false);
+        }
+    }
+
+    extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and applies <paramref name="map" /> to
+        /// the contained value if the result is an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// returns the <see langword="default" /> of <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to transform the <see cref="Ok{TOk,TErr}" />
+        /// value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<TOk, TOut> map)
+            where TOut : notnull
+        {
+            Result<TOk, TErr> result =
+                await resultTask.ConfigureAwait(false);
+
+            return result.MapOrDefault(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and awaits <paramref name="map" />
+        /// against the contained value if the result is an <see cref="Ok{TOk,TErr}" />,
+        /// otherwise returns the <see langword="default" /> of
+        /// <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the
+        /// <see cref="Ok{TOk,TErr}" /> value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+            Func<TOk, Task<TOut>> map)
+            where TOut : notnull
+        {
+            Result<TOk, TErr> result =
+                await resultTask.ConfigureAwait(false);
+
+            return await result.MapOrDefaultAsync(map)
+               .ConfigureAwait(false);
+        }
+    }
+
+    extension<TOk, TErr>(ValueTask<Result<TOk, TErr>> resultTask)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and applies
+        /// <paramref name="map" /> to the contained value if the result is an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise returns the
+        /// <see langword="default" /> of <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to transform the <see cref="Ok{TOk,TErr}" />
+        /// value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<TOk, TOut> map)
+            where TOut : notnull
+        {
+            Result<TOk, TErr> result =
+                await resultTask.ConfigureAwait(false);
+
+            return result.MapOrDefault(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and awaits
+        /// <paramref name="map" /> against the contained value if the result is an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise returns the
+        /// <see langword="default" /> of <typeparamref name="TOut" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the
+        /// <see cref="Ok{TOk,TErr}" /> value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
+        /// <typeparamref name="TOut" /> otherwise.
+        /// </returns>
+        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+            Func<TOk, Task<TOut>> map)
+            where TOut : notnull
+        {
+            Result<TOk, TErr> result =
+                await resultTask.ConfigureAwait(false);
+
+            return await result.MapOrDefaultAsync(map)
+               .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Waystone.Monads/Results/ResultOfTOkTErr.cs
+++ b/src/Waystone.Monads/Results/ResultOfTOkTErr.cs
@@ -1,6 +1,7 @@
 ﻿namespace Waystone.Monads.Results;
 
 using System;
+using System.Collections.Generic;
 using Exceptions;
 using Options;
 #if !DEBUG
@@ -280,6 +281,20 @@ public abstract record Result<TOk, TErr>
     public abstract TOut MapOr<TOut>(TOut @default, Func<TOk, TOut> map);
 
     /// <summary>
+    /// Returns the <see langword="default" /> of <typeparamref name="TOut" /> (if
+    /// <see cref="Err{TOk,TErr}" />), or applies a function to the contained value
+    /// (if <see cref="Ok{TOk,TErr}" />).
+    /// </summary>
+    /// <param name="map">The map function for an <see cref="Ok{TOk,TErr}" /></param>
+    /// <typeparam name="TOut">The mapped result value type</typeparam>
+#if !DEBUG
+    [DebuggerStepThrough]
+#endif
+    public TOut? MapOrDefault<TOut>(Func<TOk, TOut> map)
+        where TOut : notnull =>
+        Match<TOut?>(map, _ => default);
+
+    /// <summary>
     /// Maps a <c>Result&lt;TOk, TErr&gt;</c> to <typeparamref name="TOut" />
     /// by applying fallback function <paramref name="createDefault" /> to a contained
     /// <see cref="Err{TOk,TErr}" /> value, or the <paramref name="map" /> function to
@@ -332,6 +347,23 @@ public abstract record Result<TOk, TErr>
     /// consuming the result instance, and discarding the success value, if any.
     /// </remarks>
     public abstract Option<TErr> GetErr();
+
+    /// <summary>
+    /// Returns a sequence over the possibly contained
+    /// <see cref="Ok{TOk,TErr}" /> value.
+    /// </summary>
+    /// <returns>
+    /// A sequence yielding the contained value once if the result is an
+    /// <see cref="Ok{TOk,TErr}" />, otherwise an empty sequence. The error of an
+    /// <see cref="Err{TOk,TErr}" /> is discarded.
+    /// </returns>
+#if !DEBUG
+    [DebuggerStepThrough]
+#endif
+    public IEnumerable<TOk> AsEnumerable() =>
+        Match<IEnumerable<TOk>>(
+            value => new[] { value },
+            _ => Array.Empty<TOk>());
 
     /// <summary>
     /// Implicitly creates an <see cref="Ok{TOk,TErr}" /> result from a value

--- a/test/Waystone.Monads.Tests/Options/Extensions/AndExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/AndExtensionsTests.cs
@@ -1,0 +1,49 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(AndExtensions))]
+public sealed class AndExtensionsTests
+{
+    [Fact]
+    public async Task GivenSomeTask_WhenAndAsync_ThenReturnTheOtherOption()
+    {
+        Option<string> result = await Task.FromResult(Option.Some(1))
+           .AndAsync(Option.Some("value"));
+
+        result.ShouldBeSomeValue("value");
+    }
+
+    [Fact]
+    public async Task GivenNoneTask_WhenAndAsync_ThenReturnNone()
+    {
+        Option<string> result = await Task.FromResult(Option.None<int>())
+           .AndAsync(Option.Some("value"));
+
+        result.ShouldBeNone();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenAndAsync_ThenReturnTheOtherOption()
+    {
+        Option<string> result =
+            await new ValueTask<Option<int>>(Option.Some(1))
+               .AndAsync(Option.Some("value"));
+
+        result.ShouldBeSomeValue("value");
+    }
+
+    [Fact]
+    public async Task GivenNoneValueTask_WhenAndAsync_ThenReturnNone()
+    {
+        Option<string> result =
+            await new ValueTask<Option<int>>(Option.None<int>())
+               .AndAsync(Option.Some("value"));
+
+        result.ShouldBeNone();
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/AsEnumerableExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/AsEnumerableExtensionsTests.cs
@@ -1,0 +1,51 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(AsEnumerableExtensions))]
+public sealed class AsEnumerableExtensionsTests
+{
+    [Fact]
+    public async Task GivenSomeTask_WhenAsEnumerableAsync_ThenYieldTheValue()
+    {
+        IEnumerable<int> result = await Task.FromResult(Option.Some(1))
+           .AsEnumerableAsync();
+
+        result.ShouldBe(new[] { 1 });
+    }
+
+    [Fact]
+    public async Task GivenNoneTask_WhenAsEnumerableAsync_ThenYieldNothing()
+    {
+        IEnumerable<int> result = await Task.FromResult(Option.None<int>())
+           .AsEnumerableAsync();
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenAsEnumerableAsync_ThenYieldTheValue()
+    {
+        IEnumerable<int> result =
+            await new ValueTask<Option<int>>(Option.Some(1))
+               .AsEnumerableAsync();
+
+        result.ShouldBe(new[] { 1 });
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenAsEnumerableAsync_ThenYieldNothing()
+    {
+        IEnumerable<int> result =
+            await new ValueTask<Option<int>>(Option.None<int>())
+               .AsEnumerableAsync();
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/MapOrDefaultExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/MapOrDefaultExtensionsTests.cs
@@ -1,0 +1,124 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(MapOrDefaultExtensions))]
+public sealed class MapOrDefaultExtensionsTests
+{
+    [Fact]
+    public async Task GivenSome_WhenMapOrDefaultAsync_ThenReturnTheMappedValue()
+    {
+        Option<int> some = Option.Some(1);
+
+        int result =
+            await some.MapOrDefaultAsync(x => Task.FromResult(x + 1));
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenNone_WhenMapOrDefaultAsync_ThenReturnTheDefault()
+    {
+        Option<int> none = Option.None<int>();
+
+        int result =
+            await none.MapOrDefaultAsync(x => Task.FromResult(x + 1));
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int result = await Task.FromResult(Option.Some(1))
+           .MapOrDefaultAsync(x => x + 1);
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheDefault()
+    {
+        int result = await Task.FromResult(Option.None<int>())
+           .MapOrDefaultAsync(x => x + 1);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int result = await Task.FromResult(Option.Some(1))
+           .MapOrDefaultAsync(x => Task.FromResult(x + 1));
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheDefault()
+    {
+        int result = await Task.FromResult(Option.None<int>())
+           .MapOrDefaultAsync(x => Task.FromResult(x + 1));
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int result = await new ValueTask<Option<int>>(Option.Some(1))
+           .MapOrDefaultAsync(x => x + 1);
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheDefault()
+    {
+        int result = await new ValueTask<Option<int>>(Option.None<int>())
+           .MapOrDefaultAsync(x => x + 1);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int result = await new ValueTask<Option<int>>(Option.Some(1))
+           .MapOrDefaultAsync(x => Task.FromResult(x + 1));
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheDefault()
+    {
+        int result = await new ValueTask<Option<int>>(Option.None<int>())
+           .MapOrDefaultAsync(x => Task.FromResult(x + 1));
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenNone_WhenMapOrDefaultAsyncToAReferenceType_ThenReturnNull()
+    {
+        Option<int> none = Option.None<int>();
+
+        string? result = await none.MapOrDefaultAsync(
+            x => Task.FromResult(x.ToString()));
+
+        result.ShouldBeNull();
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/ReduceExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/ReduceExtensionsTests.cs
@@ -1,0 +1,118 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(ReduceExtensions))]
+public sealed class ReduceExtensionsTests
+{
+    [Fact]
+    public async Task GivenTwoSome_WhenReduceAsync_ThenCombineBothValues()
+    {
+        Option<int> some = Option.Some(1);
+
+        Option<int> result = await some.ReduceAsync(
+            Option.Some(2),
+            (x, y) => Task.FromResult(x + y));
+
+        result.ShouldBeSomeValue(3);
+    }
+
+    [Fact]
+    public async Task GivenOtherIsNone_WhenReduceAsync_ThenReturnThisOption()
+    {
+        Option<int> some = Option.Some(1);
+
+        Option<int> result = await some.ReduceAsync(
+            Option.None<int>(),
+            (x, y) => Task.FromResult(x + y));
+
+        result.ShouldBeSomeValue(1);
+    }
+
+    [Fact]
+    public async Task GivenThisIsNone_WhenReduceAsync_ThenReturnTheOtherOption()
+    {
+        Option<int> none = Option.None<int>();
+
+        Option<int> result = await none.ReduceAsync(
+            Option.Some(2),
+            (x, y) => Task.FromResult(x + y));
+
+        result.ShouldBeSomeValue(2);
+    }
+
+    [Fact]
+    public async Task GivenBothAreNone_WhenReduceAsync_ThenReturnNone()
+    {
+        Option<int> none = Option.None<int>();
+
+        Option<int> result = await none.ReduceAsync(
+            Option.None<int>(),
+            (x, y) => Task.FromResult(x + y));
+
+        result.ShouldBeNone();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeTask_WhenReduceAsyncWithASyncReduce_ThenCombineBothValues()
+    {
+        Option<int> result = await Task.FromResult(Option.Some(1))
+           .ReduceAsync(Option.Some(2), (x, y) => x + y);
+
+        result.ShouldBeSomeValue(3);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeTask_WhenReduceAsyncWithAnAsyncReduce_ThenCombineBothValues()
+    {
+        Option<int> result = await Task.FromResult(Option.Some(1))
+           .ReduceAsync(Option.Some(2), (x, y) => Task.FromResult(x + y));
+
+        result.ShouldBeSomeValue(3);
+    }
+
+    [Fact]
+    public async Task GivenNoneTask_WhenReduceAsync_ThenReturnTheOtherOption()
+    {
+        Option<int> result = await Task.FromResult(Option.None<int>())
+           .ReduceAsync(Option.Some(2), (x, y) => x + y);
+
+        result.ShouldBeSomeValue(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenReduceAsyncWithASyncReduce_ThenCombineBothValues()
+    {
+        Option<int> result = await new ValueTask<Option<int>>(Option.Some(1))
+           .ReduceAsync(Option.Some(2), (x, y) => x + y);
+
+        result.ShouldBeSomeValue(3);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenReduceAsyncWithAnAsyncReduce_ThenCombineBothValues()
+    {
+        Option<int> result = await new ValueTask<Option<int>>(Option.Some(1))
+           .ReduceAsync(Option.Some(2), (x, y) => Task.FromResult(x + y));
+
+        result.ShouldBeSomeValue(3);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenReduceAsync_ThenReturnTheOtherOption()
+    {
+        Option<int> result =
+            await new ValueTask<Option<int>>(Option.None<int>())
+               .ReduceAsync(Option.Some(2), (x, y) => x + y);
+
+        result.ShouldBeSomeValue(2);
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/UnzipExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/UnzipExtensionsTests.cs
@@ -1,0 +1,52 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(UnzipExtensions))]
+public sealed class UnzipExtensionsTests
+{
+    [Fact]
+    public async Task GivenSomeTask_WhenUnzipAsync_ThenReturnTwoSome()
+    {
+        (Option<int> first, Option<int> second) =
+            await Task.FromResult(Option.Some((1, 2))).UnzipAsync();
+
+        first.ShouldBeSomeValue(1);
+        second.ShouldBeSomeValue(2);
+    }
+
+    [Fact]
+    public async Task GivenNoneTask_WhenUnzipAsync_ThenReturnTwoNone()
+    {
+        (Option<int> first, Option<int> second) =
+            await Task.FromResult(Option.None<(int, int)>()).UnzipAsync();
+
+        first.ShouldBeNone();
+        second.ShouldBeNone();
+    }
+
+    [Fact]
+    public async Task GivenSomeValueTask_WhenUnzipAsync_ThenReturnTwoSome()
+    {
+        (Option<int> first, Option<int> second) =
+            await new ValueTask<Option<(int, int)>>(Option.Some((1, 2)))
+               .UnzipAsync();
+
+        first.ShouldBeSomeValue(1);
+        second.ShouldBeSomeValue(2);
+    }
+
+    [Fact]
+    public async Task GivenNoneValueTask_WhenUnzipAsync_ThenReturnTwoNone()
+    {
+        (Option<int> first, Option<int> second) =
+            await new ValueTask<Option<(int, int)>>(
+                Option.None<(int, int)>()).UnzipAsync();
+
+        first.ShouldBeNone();
+        second.ShouldBeNone();
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/NoneTests.cs
+++ b/test/Waystone.Monads.Tests/Options/NoneTests.cs
@@ -391,4 +391,45 @@ public class NoneTest
 
         result.ShouldBeNone();
     }
+
+    [Fact]
+    public void GivenNone_WhenAnd_ThenReturnNone()
+    {
+        Option<int> none = Option.None<int>();
+
+        none.And(Option.Some("value")).ShouldBeNone();
+    }
+
+    [Fact]
+    public void GivenNone_WhenMapOrDefault_ThenReturnTheDefault()
+    {
+        Option<int> none = Option.None<int>();
+
+        none.MapOrDefault(x => x + 1).ShouldBe(0);
+        none.MapOrDefault(x => x.ToString()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNone_WhenReduceGivenSome_ThenReturnTheOtherOption()
+    {
+        Option<int> none = Option.None<int>();
+
+        none.Reduce(Option.Some(2), (x, y) => x + y).ShouldBeSomeValue(2);
+    }
+
+    [Fact]
+    public void GivenNone_WhenReduceGivenNone_ThenReturnNone()
+    {
+        Option<int> none = Option.None<int>();
+
+        none.Reduce(Option.None<int>(), (x, y) => x + y).ShouldBeNone();
+    }
+
+    [Fact]
+    public void GivenNone_WhenAsEnumerable_ThenYieldNothing()
+    {
+        Option<int> none = Option.None<int>();
+
+        none.AsEnumerable().ShouldBeEmpty();
+    }
 }

--- a/test/Waystone.Monads.Tests/Options/SomeTests.cs
+++ b/test/Waystone.Monads.Tests/Options/SomeTests.cs
@@ -523,4 +523,53 @@ public sealed class SomeTests
 
         result.ShouldBeNone();
     }
+
+    [Fact]
+    public void WhenAndGivenSome_ThenReturnTheOtherOption()
+    {
+        Option<int> some = Option.Some(1);
+
+        some.And(Option.Some("value")).ShouldBeSomeValue("value");
+    }
+
+    [Fact]
+    public void WhenAndGivenNone_ThenReturnNone()
+    {
+        Option<int> some = Option.Some(1);
+
+        some.And(Option.None<string>()).ShouldBeNone();
+    }
+
+    [Fact]
+    public void WhenMapOrDefault_ThenReturnTheMappedValue()
+    {
+        Option<int> some = Option.Some(1);
+
+        some.MapOrDefault(x => x + 1).ShouldBe(2);
+    }
+
+    [Fact]
+    public void WhenReduceGivenSome_ThenCombineBothValues()
+    {
+        Option<int> some = Option.Some(1);
+
+        some.Reduce(Option.Some(2), (x, y) => x + y).ShouldBeSomeValue(3);
+    }
+
+    [Fact]
+    public void WhenReduceGivenNone_ThenReturnThisOption()
+    {
+        Option<int> some = Option.Some(1);
+
+        some.Reduce(Option.None<int>(), (x, y) => x + y)
+           .ShouldBeSomeValue(1);
+    }
+
+    [Fact]
+    public void WhenAsEnumerable_ThenYieldTheValueOnce()
+    {
+        Option<int> some = Option.Some(1);
+
+        some.AsEnumerable().ShouldBe(new[] { 1 });
+    }
 }

--- a/test/Waystone.Monads.Tests/Results/ErrTests.cs
+++ b/test/Waystone.Monads.Tests/Results/ErrTests.cs
@@ -348,4 +348,21 @@ public class ErrTests
 
         result.ShouldBe(Result.Err<int, int>(10));
     }
+
+    [Fact]
+    public void WhenMapOrDefault_ThenReturnTheDefault()
+    {
+        Result<int, string> err = Result.Err<int, string>("error");
+
+        err.MapOrDefault(value => value + 1).ShouldBe(0);
+        err.MapOrDefault(value => value.ToString()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void WhenAsEnumerable_ThenYieldNothing()
+    {
+        Result<int, string> err = Result.Err<int, string>("error");
+
+        err.AsEnumerable().ShouldBeEmpty();
+    }
 }

--- a/test/Waystone.Monads.Tests/Results/Extensions/AsEnumerableExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/AsEnumerableExtensionsTests.cs
@@ -1,0 +1,52 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(AsEnumerableExtensions))]
+public sealed class AsEnumerableExtensionsTests
+{
+    [Fact]
+    public async Task GivenOkTask_WhenAsEnumerableAsync_ThenYieldTheOkValue()
+    {
+        IEnumerable<int> result =
+            await Task.FromResult(Result.Ok<int, string>(1))
+               .AsEnumerableAsync();
+
+        result.ShouldBe(new[] { 1 });
+    }
+
+    [Fact]
+    public async Task GivenErrTask_WhenAsEnumerableAsync_ThenYieldNothing()
+    {
+        IEnumerable<int> result =
+            await Task.FromResult(Result.Err<int, string>("error"))
+               .AsEnumerableAsync();
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenAsEnumerableAsync_ThenYieldTheOkValue()
+    {
+        IEnumerable<int> result =
+            await new ValueTask<Result<int, string>>(
+                Result.Ok<int, string>(1)).AsEnumerableAsync();
+
+        result.ShouldBe(new[] { 1 });
+    }
+
+    [Fact]
+    public async Task GivenErrValueTask_WhenAsEnumerableAsync_ThenYieldNothing()
+    {
+        IEnumerable<int> result =
+            await new ValueTask<Result<int, string>>(
+                Result.Err<int, string>("error")).AsEnumerableAsync();
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/test/Waystone.Monads.Tests/Results/Extensions/MapOrDefaultExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/MapOrDefaultExtensionsTests.cs
@@ -1,0 +1,132 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(MapOrDefaultExtensions))]
+public sealed class MapOrDefaultExtensionsTests
+{
+    [Fact]
+    public async Task GivenOk_WhenMapOrDefaultAsync_ThenReturnTheMappedValue()
+    {
+        Result<int, string> ok = Result.Ok<int, string>(1);
+
+        int result =
+            await ok.MapOrDefaultAsync(value => Task.FromResult(value + 1));
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenErr_WhenMapOrDefaultAsync_ThenReturnTheDefault()
+    {
+        Result<int, string> err = Result.Err<int, string>("error");
+
+        int result =
+            await err.MapOrDefaultAsync(value => Task.FromResult(value + 1));
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenOkTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int result = await Task.FromResult(Result.Ok<int, string>(1))
+           .MapOrDefaultAsync(value => value + 1);
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheDefault()
+    {
+        int result = await Task.FromResult(Result.Err<int, string>("error"))
+           .MapOrDefaultAsync(value => value + 1);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenOkTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int result = await Task.FromResult(Result.Ok<int, string>(1))
+           .MapOrDefaultAsync(value => Task.FromResult(value + 1));
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheDefault()
+    {
+        int result = await Task.FromResult(Result.Err<int, string>("error"))
+           .MapOrDefaultAsync(value => Task.FromResult(value + 1));
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int result =
+            await new ValueTask<Result<int, string>>(
+                    Result.Ok<int, string>(1))
+               .MapOrDefaultAsync(value => value + 1);
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrValueTask_WhenMapOrDefaultAsyncWithASyncMap_ThenReturnTheDefault()
+    {
+        int result =
+            await new ValueTask<Result<int, string>>(
+                    Result.Err<int, string>("error"))
+               .MapOrDefaultAsync(value => value + 1);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int result =
+            await new ValueTask<Result<int, string>>(
+                    Result.Ok<int, string>(1))
+               .MapOrDefaultAsync(value => Task.FromResult(value + 1));
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrValueTask_WhenMapOrDefaultAsyncWithAnAsyncMap_ThenReturnTheDefault()
+    {
+        int result =
+            await new ValueTask<Result<int, string>>(
+                    Result.Err<int, string>("error"))
+               .MapOrDefaultAsync(value => Task.FromResult(value + 1));
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task
+        GivenErr_WhenMapOrDefaultAsyncToAReferenceType_ThenReturnNull()
+    {
+        Result<int, string> err = Result.Err<int, string>("error");
+
+        string? result = await err.MapOrDefaultAsync(
+            value => Task.FromResult(value.ToString()));
+
+        result.ShouldBeNull();
+    }
+}

--- a/test/Waystone.Monads.Tests/Results/OkTests.cs
+++ b/test/Waystone.Monads.Tests/Results/OkTests.cs
@@ -327,4 +327,20 @@ public class OkTests
 
         result.ShouldBe(Result.Ok<int, int>(1));
     }
+
+    [Fact]
+    public void WhenMapOrDefault_ThenReturnTheMappedValue()
+    {
+        Result<int, string> ok = Result.Ok<int, string>(1);
+
+        ok.MapOrDefault(value => value + 1).ShouldBe(2);
+    }
+
+    [Fact]
+    public void WhenAsEnumerable_ThenYieldTheOkValueOnce()
+    {
+        Result<int, string> ok = Result.Ok<int, string>(1);
+
+        ok.AsEnumerable().ShouldBe(new[] { 1 });
+    }
 }


### PR DESCRIPTION
Rust's Option<T> and Result<T, E> were enumerated member by member and
cross-referenced against ours. These are the ones viable in C# that were
missing.

Option<T> gains And, MapOrDefault, Reduce and AsEnumerable. Result<TOk,
TErr> gains MapOrDefault and AsEnumerable. Each has async variants on the
awaitable receiver shapes, and the delegate-taking ones also take an async
delegate on the plain receiver.

Unzip turned out to already exist on OptionOfTExtensions, so only its async
variants are new.

Reduce follows Rust: an option that is a Some survives a None on the other
side, which is what separates it from ZipWith. map_or_default and reduce are
nightly-gated in Rust; ZipWith already set that precedent.

The new members are non-abstract and expressed through Match rather than
overridden in Some, None, Ok and Err. Neither Option<T> nor Result<TOk,
TErr> has a non-public constructor, so a consumer can derive their own case,
and adding abstract members to either would break them in a minor release.
AndThen is implemented the same way.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>