### PR TITLE
feat(analyzers): add WM1007 for types deriving from Option or Result

### DIFF
--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -36,3 +36,11 @@ WM3002 | Design | Disabled | A throw could be a Result
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 WM2014 | Usage | Info | FlatMap has been renamed to AndThen
+
+## Release 5.6.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+WM1007 | Reliability | Warning | A type derives from Option or Result

--- a/src/Waystone.Monads.Analyzers/InheritanceAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/InheritanceAnalyzer.cs
@@ -1,0 +1,80 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InheritanceAnalyzer : MonadAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rules.DerivesFromMonad);
+
+    protected override void Register(
+        CompilationStartAnalysisContext context,
+        MonadSymbols symbols) =>
+        context.RegisterSymbolAction(
+            symbol => Analyze(symbol, symbols),
+            SymbolKind.NamedType);
+
+    private static void Analyze(
+        SymbolAnalysisContext context,
+        MonadSymbols symbols)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+
+        if (type.BaseType is null
+         || !symbols.IsMonad(type.BaseType)
+         || IsLibraryCase(type, symbols))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Rules.DerivesFromMonad,
+                LocationOf(type, type.BaseType.Name),
+                Semantics.Display(type),
+                Semantics.Display(type.BaseType)));
+    }
+
+    private static bool IsLibraryCase(
+        INamedTypeSymbol type,
+        MonadSymbols symbols)
+    {
+        var definition = type.OriginalDefinition;
+
+        return SymbolEqualityComparer.Default.Equals(definition, symbols.Some)
+            || SymbolEqualityComparer.Default.Equals(definition, symbols.None)
+            || SymbolEqualityComparer.Default.Equals(definition, symbols.Ok)
+            || SymbolEqualityComparer.Default.Equals(definition, symbols.Err);
+    }
+
+    private static Location LocationOf(
+        INamedTypeSymbol type,
+        string baseName)
+    {
+        var declared = type.DeclaringSyntaxReferences
+           .Select(reference => reference.GetSyntax())
+           .OfType<TypeDeclarationSyntax>()
+           .Where(declaration => declaration.BaseList is not null)
+           .SelectMany(declaration => declaration.BaseList!.Types)
+           .FirstOrDefault(
+                baseType => NameOf(baseType.Type) == baseName);
+
+        return declared?.Type.GetLocation()
+            ?? type.Locations.FirstOrDefault()
+            ?? Location.None;
+    }
+
+    private static string? NameOf(TypeSyntax type) =>
+        type switch
+        {
+            GenericNameSyntax generic => generic.Identifier.ValueText,
+            SimpleNameSyntax simple => simple.Identifier.ValueText,
+            QualifiedNameSyntax qualified => NameOf(qualified.Right),
+            _ => null,
+        };
+}

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -44,6 +44,12 @@ public static class Rules
         "This call returns '{0}' and the value is unused, so a failure is silently ignored",
         "A discarded Result throws nothing and reports nothing. Match on it, or propagate it to a caller that will.");
 
+    public static readonly DiagnosticDescriptor DerivesFromMonad = Bug(
+        "WM1007",
+        "A type derives from Option or Result",
+        "'{0}' derives from '{1}', which has exactly two cases. Compose the monad instead of inheriting from it.",
+        "Option and Result exist to have two states, and every member that switches on them handles two. A third case is invisible to Match, so it takes whichever branch the base case falls into. Both hierarchies close in v6, and a derived type will not compile against it.");
+
     public static readonly DiagnosticDescriptor UnwrapUsed = Idiom(
         "WM2001",
         "Unwrap throws on the failure case",

--- a/test/Waystone.Monads.Analyzers.Tests/InheritanceAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/InheritanceAnalyzerTests.cs
@@ -1,0 +1,72 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Threading.Tasks;
+using Xunit;
+
+public class InheritanceAnalyzerTests
+{
+    [Fact]
+    public Task FlagsATypeDerivingFromOption() =>
+        Verify.AnalyzerAsync<InheritanceAnalyzer>(
+            """
+            internal sealed record Cache<T> : {|#0:Option<T>|}
+                where T : notnull
+            {
+                public override bool IsSome => false;
+                public override bool IsNone => true;
+                public override bool IsSomeAnd(Func<T, bool> predicate) => false;
+                public override bool IsNoneOr(Func<T, bool> predicate) => true;
+                public override TOut Match<TOut>(Func<T, TOut> onSome, Func<TOut> onNone) => onNone();
+                public override void Match(Action<T> onSome, Action onNone) => onNone();
+                public override T Expect(string message) => throw new InvalidOperationException();
+                public override T Unwrap() => throw new InvalidOperationException();
+                public override T UnwrapOr(T value) => value;
+                public override T? UnwrapOrDefault() => default;
+                public override T UnwrapOrElse(Func<T> @else) => @else();
+                public override Option<T2> Map<T2>(Func<T, T2> map) => Option.None<T2>();
+                public override T2 MapOr<T2>(T2 @default, Func<T, T2> map) => @default;
+                public override T2 MapOrElse<T2>(Func<T2> createDefault, Func<T, T2> map) => createDefault();
+                public override Option<T> Inspect(Action<T> action) => this;
+                public override Option<T> Filter(Func<T, bool> predicate) => this;
+                public override Option<T> Or(Option<T> other) => other;
+                public override Option<T> OrElse(Func<Option<T>> createElse) => createElse();
+                public override Option<T> Xor(Option<T> other) => other;
+                public override Option<(T, T2)> Zip<T2>(Option<T2> other) => Option.None<(T, T2)>();
+                public override Option<TOut> ZipWith<TOther, TOut>(Option<TOther> other, Func<T, TOther, TOut> zip) => Option.None<TOut>();
+                public override Result<T, TErr> OkOr<TErr>(TErr error) => Result.Err<T, TErr>(error);
+                public override Result<T, TErr> OkOrElse<TErr>(Func<TErr> errorFactory) => Result.Err<T, TErr>(errorFactory());
+            }
+            """,
+            Verify.Diagnostic(Rules.DerivesFromMonad)
+               .WithLocation(0)
+               .WithArguments("Cache<T>", "Option<T>"));
+
+    [Fact]
+    public Task IgnoresATypeThatMerelyHoldsAnOption() =>
+        Verify.NoDiagnosticAsync<InheritanceAnalyzer>(
+            """
+            internal sealed record Cache<T>(Option<T> Value)
+                where T : notnull;
+            """);
+
+    [Fact]
+    public Task IgnoresATypeDerivingFromSomethingElse() =>
+        Verify.NoDiagnosticAsync<InheritanceAnalyzer>(
+            """
+            internal abstract record Base;
+
+            internal sealed record Cache : Base;
+            """);
+
+    [Fact]
+    public Task IgnoresATypeThatOnlyReturnsOptions() =>
+        Verify.NoDiagnosticAsync<InheritanceAnalyzer>(
+            """
+            internal sealed class Subject
+            {
+                internal Option<int> Present() => Option.Some(1);
+
+                internal Option<int> Absent() => Option.None<int>();
+            }
+            """);
+}

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -50,7 +50,7 @@ public class RulesTests
     [Fact]
     public void EveryTierIsPopulated()
     {
-        MisuseRules().Count.ShouldBe(6);
+        MisuseRules().Count.ShouldBe(7);
         IdiomRules().Count.ShouldBe(14);
         MigrationRules().Count.ShouldBe(2);
     }


### PR DESCRIPTION
Neither Option<T> nor Result<TOk, TErr> has a non-public constructor, so a
consumer can declare a third case today. Nothing benefits from one: Match
takes two callbacks, so a derived case falls into whichever branch its base
returns, and the analyzer's own IsDerivedCase does not know about it.

WM1007 ships at warning severity, which is a deliberate spend of the rule
that reserves warnings for WM1xxx. The code it marks compiles and works
today, so it breaks a build nobody asked to change. It earns that because
v6 closes both hierarchies with an internal constructor and makes the new
members abstract, and a deriving consumer who only sees an info-level
suggestion in an IDE finds out by way of a compile error on upgrade.

No code fix. The correction is to hold a monad rather than be one, which
rewrites the type and cascades to every one of its callers.

The IsLibraryCase guard is what keeps Some, None, Ok and Err from tripping
the rule. It has no unit test because RegisterSymbolAction only sees
source-declared types, and those four reach a consumer's compilation as
metadata. The library's own build is the test: src builds with
TreatWarningsAsErrors, so removing the guard fails it four times.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>