### PR TITLE
feat(analyzers): add WM1008 for nullable Option and Result declarations

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
+++ b/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
@@ -23,6 +23,10 @@ internal class Misuse
 
     internal void DiscardedResult() => Save();
 
+#nullable enable
+    internal Option<int>? NullableOption() => null;
+#nullable restore
+
     private void Accept(Option<int> option) { }
 
     internal async Task DiscardedResultBehindConfigureAwait() =>

--- a/sample/Waystone.Monads.Analyzers.Sample/README.md
+++ b/sample/Waystone.Monads.Analyzers.Sample/README.md
@@ -25,7 +25,7 @@ nullable, which is what `WM1005` needs to see that a value may be null.
 
 ## Trying the code fixes
 
-Open either file in an IDE and invoke the lightbulb. Twelve of the twenty-two rules
+Open either file in an IDE and invoke the lightbulb. Thirteen of the twenty-three rules
 offer a fix; the rest are reported without one, either because the correction is
 ambiguous (`Ok` or `Err`?) or because it changes a signature and cascades to
 callers the fix cannot see.

--- a/src/Waystone.Monads.Analyzers.CodeFixes/RemoveNullableAnnotationCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/RemoveNullableAnnotationCodeFix.cs
@@ -1,0 +1,40 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Composition;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class RemoveNullableAnnotationCodeFix : MonadCodeFix
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("WM1008");
+
+    protected override void Register(
+        CodeFixContext context,
+        Diagnostic diagnostic,
+        SyntaxNode node,
+        SemanticModel model,
+        MonadSymbols symbols)
+    {
+        if (node.FirstAncestorOrSelf<NullableTypeSyntax>() is not
+                { } annotated)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Remove the nullable annotation",
+                token => ReplaceAsync(
+                    context.Document,
+                    annotated,
+                    annotated.ElementType,
+                    token),
+                nameof(RemoveNullableAnnotationCodeFix)),
+            diagnostic);
+    }
+}

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -44,3 +44,11 @@ WM2014 | Usage | Info | FlatMap has been renamed to AndThen
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 WM1007 | Reliability | Warning | A type derives from Option or Result
+
+## Release 5.7.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+WM1008 | Reliability | Warning | An Option or Result is declared nullable

--- a/src/Waystone.Monads.Analyzers/DeclaredTypeAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/DeclaredTypeAnalyzer.cs
@@ -11,6 +11,7 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
+            Rules.NullableMonadDeclared,
             Rules.NestedOption,
             Rules.ResultWithIdenticalTypeArguments,
             Rules.DerivedMonadTypeDeclared);
@@ -54,6 +55,16 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
         }
 
         var location = node.GetLocation();
+
+        if (node.Parent is NullableTypeSyntax annotated)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Rules.NullableMonadDeclared,
+                    annotated.GetLocation(),
+                    Semantics.Display(type),
+                    symbols.IsOption(type) ? "None" : "Err"));
+        }
 
         if (symbols.IsDerivedCase(type))
         {

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -50,6 +50,12 @@ public static class Rules
         "'{0}' derives from '{1}', which has exactly two cases. Compose the monad instead of inheriting from it.",
         "Option and Result exist to have two states, and every member that switches on them handles two. A third case is invisible to Match, so it takes whichever branch the base case falls into. Both hierarchies close in v6, and a derived type will not compile against it.");
 
+    public static readonly DiagnosticDescriptor NullableMonadDeclared = Bug(
+        "WM1008",
+        "An Option or Result is declared nullable",
+        "'{0}?' has three states where two are meaningful. Drop the annotation — '{1}' already expresses the case you are reaching for.",
+        "Option and Result are records, so the compiler accepts a nullable annotation on one. The annotation adds a third state to a type whose whole purpose is to have exactly two, and the null it admits throws on the next member access rather than being handled as an absence. This reports alongside WM2011 on a nullable derived case such as 'Some<int>?' deliberately: both statements are independently true and each has its own fix.");
+
     public static readonly DiagnosticDescriptor UnwrapUsed = Idiom(
         "WM2001",
         "Unwrap throws on the failure case",

--- a/src/Waystone.Monads.Analyzers/Semantics.cs
+++ b/src/Waystone.Monads.Analyzers/Semantics.cs
@@ -193,7 +193,8 @@ public static class Semantics
         var current = node;
 
         while (current.Parent is QualifiedNameSyntax
-            or AliasQualifiedNameSyntax)
+            or AliasQualifiedNameSyntax
+            or NullableTypeSyntax)
         {
             current = current.Parent;
         }

--- a/src/Waystone.Monads/Options/Extensions/InspectExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/InspectExtensions.cs
@@ -34,7 +34,7 @@ public static class InspectExtensions
 
         public async Task<Option<T>> InspectAsync(Action<T> action)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             if (option.IsNone) return option;
 
@@ -61,7 +61,7 @@ public static class InspectExtensions
 
         public async Task<Option<T>> InspectAsync(Action<T> action)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             if (option.IsNone) return option;
 

--- a/src/Waystone.Monads/Options/Extensions/MapOrElseExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrElseExtensions.cs
@@ -56,7 +56,7 @@ public static class MapOrElseExtensions
             Func<TOut> defaultFunc,
             Func<T, TOut> map)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             if (option.IsNone)
             {
@@ -123,7 +123,7 @@ public static class MapOrElseExtensions
             Func<TOut> defaultFunc,
             Func<T, TOut> map)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             if (option.IsNone)
             {

--- a/src/Waystone.Monads/Options/Extensions/OrElseExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/OrElseExtensions.cs
@@ -20,7 +20,7 @@ public static class OrElseExtensions
     {
         public async Task<Option<T>> OrElseAsync(Func<Option<T>> elseFunc)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             return option.IsSome ? option : elseFunc.Invoke();
         }
@@ -39,7 +39,7 @@ public static class OrElseExtensions
     {
         public async Task<Option<T>> OrElseAsync(Func<Option<T>> elseFunc)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             return option.IsSome ? option : elseFunc.Invoke();
         }

--- a/src/Waystone.Monads/Options/Extensions/UnwrapOrElseExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnwrapOrElseExtensions.cs
@@ -17,7 +17,7 @@ public static class UnwrapOrElseExtensions
     {
         public async Task<T> UnwrapOrElseAsync(Func<T> elseFunc)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             return option.IsSome
                 ? option.Expect("Expected Some but found None.")
@@ -38,7 +38,7 @@ public static class UnwrapOrElseExtensions
     {
         public async Task<T> UnwrapOrElseAsync(Func<T> elseFunc)
         {
-            Option<T>? option = await optionTask.ConfigureAwait(false);
+            Option<T> option = await optionTask.ConfigureAwait(false);
 
             return option.IsSome
                 ? option.Expect("Expected Some but found None.")

--- a/src/Waystone.Monads/Results/Extensions/AndThenExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/AndThenExtensions.cs
@@ -111,7 +111,7 @@ public static class AndThenExtensions
         public async Task<Result<TOut, TErr>> AndThenAsync<TOut>(
             Func<TOk, Result<TOut, TErr>> factory) where TOut : notnull
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return result.AndThen(factory);
         }
@@ -175,7 +175,7 @@ public static class AndThenExtensions
         public async Task<Result<TOut, TErr>> AndThenAsync<TOut>(
             Func<TOk, Result<TOut, TErr>> factory) where TOut : notnull
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return result.AndThen(factory);
         }

--- a/src/Waystone.Monads/Results/Extensions/FlattenExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/FlattenExtensions.cs
@@ -43,7 +43,7 @@ public static class FlattenExtensions
         /// </returns>
         public async Task<Result<TOk, TErr>> FlattenAsync()
         {
-            Result<Result<TOk, TErr>, TErr>? result =
+            Result<Result<TOk, TErr>, TErr> result =
                 await resultTask.ConfigureAwait(false);
 
             if (result.IsOk) return result.Expect("Expected Ok but found Err.");
@@ -71,7 +71,7 @@ public static class FlattenExtensions
         /// </returns>
         public async Task<Result<TOk, TErr>> FlattenAsync()
         {
-            Result<Result<TOk, TErr>, TErr>? result =
+            Result<Result<TOk, TErr>, TErr> result =
                 await resultTask.ConfigureAwait(false);
 
             if (result.IsOk) return result.Expect("Expected Ok but found Err.");

--- a/src/Waystone.Monads/Results/Extensions/InspectErrExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/InspectErrExtensions.cs
@@ -54,7 +54,7 @@ public static class InspectErrExtensions
         public async Task<Result<TOk, TErr>> InspectErrAsync(
             Func<TErr, Task> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             if (result.IsOk) return result;
 
@@ -79,7 +79,7 @@ public static class InspectErrExtensions
         public async Task<Result<TOk, TErr>> InspectErrAsync(
             Action<TErr> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             if (result.IsOk) return result;
 
@@ -112,7 +112,7 @@ public static class InspectErrExtensions
         public async Task<Result<TOk, TErr>> InspectErrAsync(
             Func<TErr, Task> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             if (result.IsOk) return result;
 
@@ -138,7 +138,7 @@ public static class InspectErrExtensions
         public async Task<Result<TOk, TErr>> InspectErrAsync(
             Action<TErr> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             if (result.IsOk) return result;
 

--- a/src/Waystone.Monads/Results/Extensions/InspectExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/InspectExtensions.cs
@@ -56,7 +56,7 @@ public static class InspectExtensions
         public async Task<Result<TOk, TErr>> InspectAsync(
             Func<TOk, Task> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return await result.InspectAsync(action).ConfigureAwait(false);
         }
@@ -80,7 +80,7 @@ public static class InspectExtensions
         /// </returns>
         public async Task<Result<TOk, TErr>> InspectAsync(Action<TOk> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return result.Inspect(action);
         }
@@ -106,7 +106,7 @@ public static class InspectExtensions
         public async Task<Result<TOk, TErr>> InspectAsync(
             Func<TOk, Task> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return await result.InspectAsync(action).ConfigureAwait(false);
         }
@@ -130,7 +130,7 @@ public static class InspectExtensions
         /// </returns>
         public async Task<Result<TOk, TErr>> InspectAsync(Action<TOk> action)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return result.Inspect(action);
         }

--- a/src/Waystone.Monads/Results/Extensions/IsOkAndExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/IsOkAndExtensions.cs
@@ -80,7 +80,7 @@ public static class IsOkAndExtensions
         /// </returns>
         public async Task<bool> IsOkAndAsync(Func<TOk, bool> predicate)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             if (result.IsErr) return false;
 
@@ -136,7 +136,7 @@ public static class IsOkAndExtensions
         /// </returns>
         public async Task<bool> IsOkAndAsync(Func<TOk, bool> predicate)
         {
-            Result<TOk, TErr>? result = await resultTask.ConfigureAwait(false);
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             if (result.IsErr) return false;
 

--- a/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
@@ -183,4 +183,14 @@ public class CodeFixTests
             Verify.Diagnostic(Rules.DerivedMonadTypeDeclared)
                .WithLocation(0)
                .WithArguments("Some<int>", "Option<int>"));
+
+    [Fact]
+    public Task StripsTheNullableAnnotationFromAnOption() =>
+        Verify.CodeFixAsync<DeclaredTypeAnalyzer,
+            RemoveNullableAnnotationCodeFix>(
+            "internal bool Check({|#0:Option<int>?|} option) => option is null;",
+            "internal bool Check(Option<int> option) => option is null;",
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Option<int>", "None"));
 }

--- a/test/Waystone.Monads.Analyzers.Tests/DeclaredTypeAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/DeclaredTypeAnalyzerTests.cs
@@ -6,6 +6,101 @@ using Xunit;
 public class DeclaredTypeAnalyzerTests
 {
     [Fact]
+    public Task FlagsANullableOptionReturnType() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal {|#0:Option<int>?|} Absent() => null;
+            """,
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Option<int>", "None"));
+
+    [Fact]
+    public Task FlagsANullableResultParameter() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal bool Check({|#0:Result<int, string>?|} result) =>
+                result is null;
+            """,
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Result<int, string>", "Err"));
+
+    [Fact]
+    public Task FlagsANullableOptionProperty() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal {|#0:Option<string>?|} Value { get; set; }
+            """,
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Option<string>", "None"));
+
+    [Fact]
+    public Task FlagsANullableOptionLocal() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal bool Check()
+            {
+                {|#0:Option<int>?|} absent = null;
+
+                return absent is null;
+            }
+            """,
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Option<int>", "None"));
+
+    [Fact]
+    public Task FlagsANullableOptionInATypeArgument() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal Task<{|#0:Option<int>?|}> AbsentAsync() =>
+                Task.FromResult<Option<int>?>(null);
+            """,
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Option<int>", "None"));
+
+    [Fact]
+    public Task FlagsANullableDerivedCaseTwice() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal bool Check({|#0:{|#1:Some<int>|}?|} some) => some is null;
+            """,
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Some<int>", "None"),
+            Verify.Diagnostic(Rules.DerivedMonadTypeDeclared)
+               .WithLocation(1)
+               .WithArguments("Some<int>", "Option<int>"));
+
+    [Fact]
+    public Task FlagsANullableOptionInAnUnannotatedContext() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            #nullable disable
+            internal {|#0:Option<int>?|} Absent() => null;
+            """,
+            Verify.Diagnostic(Rules.NullableMonadDeclared)
+               .WithLocation(0)
+               .WithArguments("Option<int>", "None"));
+
+    [Fact]
+    public Task IgnoresAnUnannotatedOption() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
+            """
+            internal Option<int> Absent() => Option.None<int>();
+            """);
+
+    [Fact]
+    public Task IgnoresANullableValueThatIsNotAMonad() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
+            """
+            internal int? Absent() => null;
+            """);
+
+    [Fact]
     public Task FlagsANestedOptionReturnType() =>
         Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
             """

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -50,7 +50,7 @@ public class RulesTests
     [Fact]
     public void EveryTierIsPopulated()
     {
-        MisuseRules().Count.ShouldBe(7);
+        MisuseRules().Count.ShouldBe(8);
         IdiomRules().Count.ShouldBe(14);
         MigrationRules().Count.ShouldBe(2);
     }

--- a/test/Waystone.Monads.Tests/Options/Extensions/MapOrElseExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/MapOrElseExtensionsTests.cs
@@ -1,0 +1,31 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(MapOrElseExtensions))]
+public sealed class MapOrElseExtensionsTests
+{
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenMapOrElseAsync_ThenReturnTheMappedValue()
+    {
+        int result = await new ValueTask<Option<int>>(Option.Some(1))
+           .MapOrElseAsync(() => 0, x => x + 1);
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenMapOrElseAsync_ThenReturnTheFallback()
+    {
+        int result = await new ValueTask<Option<int>>(Option.None<int>())
+           .MapOrElseAsync(() => 0, x => x + 1);
+
+        result.ShouldBe(0);
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/OrElseExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/OrElseExtensionsTests.cs
@@ -1,0 +1,49 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(OrElseExtensions))]
+public sealed class OrElseExtensionsTests
+{
+    [Fact]
+    public async Task GivenSomeTask_WhenOrElseAsync_ThenReturnThisOption()
+    {
+        Option<int> result = await Task.FromResult(Option.Some(1))
+           .OrElseAsync(() => Option.Some(2));
+
+        result.ShouldBeSomeValue(1);
+    }
+
+    [Fact]
+    public async Task GivenNoneTask_WhenOrElseAsync_ThenReturnTheOtherOption()
+    {
+        Option<int> result = await Task.FromResult(Option.None<int>())
+           .OrElseAsync(() => Option.Some(2));
+
+        result.ShouldBeSomeValue(2);
+    }
+
+    [Fact]
+    public async Task GivenSomeValueTask_WhenOrElseAsync_ThenReturnThisOption()
+    {
+        Option<int> result = await new ValueTask<Option<int>>(Option.Some(1))
+           .OrElseAsync(() => Option.Some(2));
+
+        result.ShouldBeSomeValue(1);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenOrElseAsync_ThenReturnTheOtherOption()
+    {
+        Option<int> result =
+            await new ValueTask<Option<int>>(Option.None<int>())
+               .OrElseAsync(() => Option.Some(2));
+
+        result.ShouldBeSomeValue(2);
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/UnwrapOrElseExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/UnwrapOrElseExtensionsTests.cs
@@ -1,0 +1,50 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(UnwrapOrElseExtensions))]
+public sealed class UnwrapOrElseExtensionsTests
+{
+    [Fact]
+    public async Task GivenSomeTask_WhenUnwrapOrElseAsync_ThenReturnTheValue()
+    {
+        int result = await Task.FromResult(Option.Some(1))
+           .UnwrapOrElseAsync(() => 2);
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneTask_WhenUnwrapOrElseAsync_ThenReturnTheFallback()
+    {
+        int result = await Task.FromResult(Option.None<int>())
+           .UnwrapOrElseAsync(() => 2);
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenUnwrapOrElseAsync_ThenReturnTheValue()
+    {
+        int result = await new ValueTask<Option<int>>(Option.Some(1))
+           .UnwrapOrElseAsync(() => 2);
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenUnwrapOrElseAsync_ThenReturnTheFallback()
+    {
+        int result = await new ValueTask<Option<int>>(Option.None<int>())
+           .UnwrapOrElseAsync(() => 2);
+
+        result.ShouldBe(2);
+    }
+}

--- a/test/Waystone.Monads.Tests/Results/Extensions/InspectErrExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/InspectErrExtensionsTests.cs
@@ -1,0 +1,48 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using NSubstitute;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(InspectErrExtensions))]
+public sealed class InspectErrExtensionsTests
+{
+    [Fact]
+    public async Task GivenErrTask_WhenInspectErrAsync_ThenInvokeTheAction()
+    {
+        var action = Substitute.For<Action<string>>();
+
+        await Task.FromResult(Result.Err<int, string>("error"))
+           .InspectErrAsync(action);
+
+        action.Received(1).Invoke("error");
+    }
+
+    [Fact]
+    public async Task
+        GivenOkTask_WhenInspectErrAsync_ThenDoNotInvokeTheAction()
+    {
+        var action = Substitute.For<Action<string>>();
+
+        await Task.FromResult(Result.Ok<int, string>(1))
+           .InspectErrAsync(action);
+
+        action.DidNotReceiveWithAnyArgs().Invoke(default);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrValueTask_WhenInspectErrAsync_ThenInvokeTheAction()
+    {
+        var action = Substitute.For<Action<string>>();
+
+        await new ValueTask<Result<int, string>>(
+                Result.Err<int, string>("error"))
+           .InspectErrAsync(action);
+
+        action.Received(1).Invoke("error");
+    }
+}

--- a/test/Waystone.Monads.Tests/Results/Extensions/InspectExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/InspectExtensionsTests.cs
@@ -1,0 +1,57 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using NSubstitute;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(InspectExtensions))]
+public sealed class InspectExtensionsTests
+{
+    [Fact]
+    public async Task GivenOkTask_WhenInspectAsync_ThenInvokeTheAction()
+    {
+        var action = Substitute.For<Action<int>>();
+
+        await Task.FromResult(Result.Ok<int, string>(1))
+           .InspectAsync(action);
+
+        action.Received(1).Invoke(1);
+    }
+
+    [Fact]
+    public async Task GivenErrTask_WhenInspectAsync_ThenDoNotInvokeTheAction()
+    {
+        var action = Substitute.For<Action<int>>();
+
+        await Task.FromResult(Result.Err<int, string>("error"))
+           .InspectAsync(action);
+
+        action.DidNotReceiveWithAnyArgs().Invoke(default);
+    }
+
+    [Fact]
+    public async Task GivenOkValueTask_WhenInspectAsync_ThenInvokeTheAction()
+    {
+        var action = Substitute.For<Action<int>>();
+
+        await new ValueTask<Result<int, string>>(Result.Ok<int, string>(1))
+           .InspectAsync(action);
+
+        action.Received(1).Invoke(1);
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenInspectAsyncWithATaskAction_ThenAwaitIt()
+    {
+        var action = Substitute.For<Func<int, Task>>();
+
+        await new ValueTask<Result<int, string>>(Result.Ok<int, string>(1))
+           .InspectAsync(action);
+
+        await action.Received(1).Invoke(1);
+    }
+}

--- a/test/Waystone.Monads.Tests/Results/Extensions/IsOkAndExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/IsOkAndExtensionsTests.cs
@@ -1,0 +1,52 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Monads.Extensions;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(IsOkAndExtensions))]
+public sealed class IsOkAndExtensionsTests
+{
+    [Fact]
+    public async Task GivenOkTask_WhenIsOkAndAsync_ThenEvaluateThePredicate()
+    {
+        bool result = await Task.FromResult(Result.Ok<int, string>(1))
+           .IsOkAndAsync(x => x > 0);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GivenErrTask_WhenIsOkAndAsync_ThenReturnFalse()
+    {
+        bool result = await Task.FromResult(Result.Err<int, string>("error"))
+           .IsOkAndAsync(x => x > 0);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenIsOkAndAsync_ThenEvaluateThePredicate()
+    {
+        bool result =
+            await new ValueTask<Result<int, string>>(
+                    Result.Ok<int, string>(1))
+               .IsOkAndAsync(x => x > 0);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GivenErrValueTask_WhenIsOkAndAsync_ThenReturnFalse()
+    {
+        bool result =
+            await new ValueTask<Result<int, string>>(
+                    Result.Err<int, string>("error"))
+               .IsOkAndAsync(x => x > 0);
+
+        result.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Option and Result are records, so `Option<T>?` compiles. It buys nothing —
the absent case is None and the failed case is Err — and the null it admits
throws on the next member access instead of being handled as an absence.

WM1008 extends DeclaredTypeAnalyzer rather than adding a class, since the
syntax registration, the name filter and the declaration-position guard were
already there. It keys on the NullableTypeSyntax parent rather than on
Semantics.IsNullable, so it fires in annotated and unannotated contexts alike
— a nullable-disabled consumer is the one the compiler helps least, and the
one this rule is for.

Semantics.IsDeclarationTypePosition now ascends through NullableTypeSyntax.
Without that, no rule in this analyzer saw a nullable declaration at all; with
it, `Some<int>?` reports WM1008 and WM2011 both, which is right — the two
statements are independently true and the report is placed before the early
returns so neither suppresses the other.

The rule found 22 sites in this library: `Option<T>? option = await …` locals
sitting next to identical methods that declare `Option<T>`. Stripped. They are
locals, so the public surface is untouched.

Code fix included; removing an annotation cannot change meaning.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>