### PR TITLE
feat(analyzers): add WM1009 for Option of bool or a zero-member enum

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
+++ b/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
@@ -23,6 +23,11 @@ internal class Misuse
 
     internal void DiscardedResult() => Save();
 
+    internal Option<bool> OptionOfBool() => Option.None<bool>();
+
+    internal Option<Colour> OptionOfAnEnumWithAZeroMember() =>
+        Option.None<Colour>();
+
 #nullable enable
     internal Option<int>? NullableOption() => null;
 #nullable restore
@@ -36,4 +41,10 @@ internal class Misuse
 
     private Task<Result<int, Error>> SaveAsync() =>
         Task.FromResult(Result.Ok<int, Error>(1));
+}
+
+internal enum Colour
+{
+    Red = 0,
+    Green = 1,
 }

--- a/sample/Waystone.Monads.Analyzers.Sample/README.md
+++ b/sample/Waystone.Monads.Analyzers.Sample/README.md
@@ -25,7 +25,7 @@ nullable, which is what `WM1005` needs to see that a value may be null.
 
 ## Trying the code fixes
 
-Open either file in an IDE and invoke the lightbulb. Thirteen of the twenty-three rules
+Open either file in an IDE and invoke the lightbulb. Thirteen of the twenty-four rules
 offer a fix; the rest are reported without one, either because the correction is
 ambiguous (`Ok` or `Err`?) or because it changes a signature and cascades to
 callers the fix cannot see.

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -52,3 +52,11 @@ WM1007 | Reliability | Warning | A type derives from Option or Result
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 WM1008 | Reliability | Warning | An Option or Result is declared nullable
+
+## Release 5.8.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+WM1009 | Reliability | Warning | Option of bool or of an enum with a zero member

--- a/src/Waystone.Monads.Analyzers/DeclaredTypeAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/DeclaredTypeAnalyzer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
+using System.Linq;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
@@ -12,6 +13,7 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             Rules.NullableMonadDeclared,
+            Rules.OptionOfZeroValuedType,
             Rules.NestedOption,
             Rules.ResultWithIdenticalTypeArguments,
             Rules.DerivedMonadTypeDeclared);
@@ -66,6 +68,19 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
                     symbols.IsOption(type) ? "None" : "Err"));
         }
 
+        if (symbols.IsOption(type)
+         && symbols.TypeArgumentsOf(type) is { Length: 1 } held
+         && AdviceFor(held[0]) is { } advice)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Rules.OptionOfZeroValuedType,
+                    location,
+                    Semantics.Display(type),
+                    Semantics.Display(held[0]),
+                    advice));
+        }
+
         if (symbols.IsDerivedCase(type))
         {
             var declared = symbols.BaseCaseOf(type);
@@ -112,4 +127,23 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
         }
     }
 
+    private static string? AdviceFor(ITypeSymbol held)
+    {
+        if (held.SpecialType == SpecialType.System_Boolean)
+        {
+            return
+                "Use a three-state enum whose zero member carries the state you meant None to express";
+        }
+
+        return held.TypeKind == TypeKind.Enum && HasZeroMember(held)
+            ? "Renumber it so no meaningful member is 0, leaving zero to the state None expresses"
+            : null;
+    }
+
+    private static bool HasZeroMember(ITypeSymbol held) =>
+        held.GetMembers()
+           .OfType<IFieldSymbol>()
+           .Any(
+                field => field.HasConstantValue
+                      && Semantics.IsZeroConstant(field.ConstantValue));
 }

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -56,6 +56,12 @@ public static class Rules
         "'{0}?' has three states where two are meaningful. Drop the annotation — '{1}' already expresses the case you are reaching for.",
         "Option and Result are records, so the compiler accepts a nullable annotation on one. The annotation adds a third state to a type whose whole purpose is to have exactly two, and the null it admits throws on the next member access rather than being handled as an absence. This reports alongside WM2011 on a nullable derived case such as 'Some<int>?' deliberately: both statements are independently true and each has its own fix.");
 
+    public static readonly DiagnosticDescriptor OptionOfZeroValuedType = Bug(
+        "WM1009",
+        "Option of bool or of an enum with a zero member",
+        "'{0}' cannot hold the default of '{1}', because 'Option.Some' throws on it. {2}.",
+        "Option.Some rejects a value equal to default(T), so an Option over a type whose zero is a meaningful value cannot represent part of its own domain. WM1001 and WM1004 catch a call site that provably passes a default; this rule catches the declaration, before anything reaches the throwing path. The scope is bool and enums with a zero member deliberately — widening it to every value type would fire on Option<int> throughout code that works today, and a Warning ships enabled to every consumer on upgrade.");
+
     public static readonly DiagnosticDescriptor UnwrapUsed = Idiom(
         "WM2001",
         "Unwrap throws on the failure case",

--- a/src/Waystone.Monads.Analyzers/Semantics.cs
+++ b/src/Waystone.Monads.Analyzers/Semantics.cs
@@ -69,6 +69,9 @@ public static class Semantics
         return IsWellKnownDefault(value);
     }
 
+    public static bool IsZeroConstant(object? constant) =>
+        constant is not null && IsZero(constant);
+
     public static bool IsMaybeNull(IOperation operation)
     {
         var value = Unconverted(operation);

--- a/test/Waystone.Monads.Analyzers.Tests/DeclaredTypeAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/DeclaredTypeAnalyzerTests.cs
@@ -101,6 +101,94 @@ public class DeclaredTypeAnalyzerTests
             """);
 
     [Fact]
+    public Task FlagsAnOptionOfBool() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal {|#0:Option<bool>|} Flag() => Option.None<bool>();
+            """,
+            Verify.Diagnostic(Rules.OptionOfZeroValuedType)
+               .WithLocation(0)
+               .WithArguments(
+                    "Option<bool>",
+                    "bool",
+                    "Use a three-state enum whose zero member carries the state you meant None to express"));
+
+    [Fact]
+    public Task FlagsAnOptionOfAnEnumWithAZeroMember() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal enum Colour { Red = 0, Green = 1 }
+
+            internal class Subject
+            {
+                internal {|#0:Option<Colour>|} Chosen() => Option.None<Colour>();
+            }
+            """,
+            Verify.Diagnostic(Rules.OptionOfZeroValuedType)
+               .WithLocation(0)
+               .WithArguments(
+                    "Option<Colour>",
+                    "Colour",
+                    "Renumber it so no meaningful member is 0, leaving zero to the state None expresses"));
+
+    [Fact]
+    public Task FlagsAnOptionOfAnEnumWhoseZeroMemberIsImplicit() =>
+        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+            """
+            internal enum Colour { Red, Green }
+
+            internal class Subject
+            {
+                internal {|#0:Option<Colour>|} Chosen() => Option.None<Colour>();
+            }
+            """,
+            Verify.Diagnostic(Rules.OptionOfZeroValuedType)
+               .WithLocation(0)
+               .WithArguments(
+                    "Option<Colour>",
+                    "Colour",
+                    "Renumber it so no meaningful member is 0, leaving zero to the state None expresses"));
+
+    [Fact]
+    public Task IgnoresAnOptionOfAnEnumWithoutAZeroMember() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
+            """
+            internal enum Colour { Red = 1, Green = 2 }
+
+            internal class Subject
+            {
+                internal Option<Colour> Chosen() => Option.None<Colour>();
+            }
+            """);
+
+    [Fact]
+    public Task IgnoresAnOptionOfAnEnumWithAnUnsignedUnderlyingType() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
+            """
+            internal enum Colour : byte { Red = 1, Green = 2 }
+
+            internal class Subject
+            {
+                internal Option<Colour> Chosen() => Option.None<Colour>();
+            }
+            """);
+
+    [Fact]
+    public Task IgnoresAnOptionOfAnIntEvenThoughZeroIsMeaningful() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
+            """
+            internal Option<int> Count() => Option.None<int>();
+            """);
+
+    [Fact]
+    public Task IgnoresAResultWhoseOkIsBool() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
+            """
+            internal Result<bool, string> Flag() =>
+                Result.Ok<bool, string>(true);
+            """);
+
+    [Fact]
     public Task FlagsANestedOptionReturnType() =>
         Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
             """

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -50,7 +50,7 @@ public class RulesTests
     [Fact]
     public void EveryTierIsPopulated()
     {
-        MisuseRules().Count.ShouldBe(8);
+        MisuseRules().Count.ShouldBe(9);
         IdiomRules().Count.ShouldBe(14);
         MigrationRules().Count.ShouldBe(2);
     }


### PR DESCRIPTION
Option.Some rejects a value equal to default(T), so Option.Some(false)
throws and half the domain of bool cannot be held. WM1001 and WM1004
catch a call site that provably passes a default; nothing looked at the
declaration, so Option<bool> sat in a signature unreported until someone
reached the throwing path at runtime.

Scope is bool and enums with a zero member, and stops there. The hazard is
general — Option<int> breaks on 0, Option<Guid> on Guid.Empty — but a
declaration rule at Warning severity ships enabled to every consumer on
upgrade, and widening it would fire across code that works today. One
descriptor, no Info tier for the wider case.

An enum with no zero member is not flagged: every value it can hold is a
legal Some. HasZeroMember compares the boxed ConstantValue through
Semantics.IsZeroConstant rather than casting to int, because an enum's
underlying type may be signed or unsigned.

No code fix. Both corrections — introducing a three-state enum, or
renumbering an existing one — are design changes with call sites the fix
cannot see, so the advice goes in the message instead.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>