### PR TITLE
feat: add UnwrapOrNull and MapOrNull for struct values

### DIFF
--- a/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
@@ -1,0 +1,158 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using System;
+using System.Threading.Tasks;
+
+public static class MapOrNullExtensions
+{
+    extension<T>(Option<T> option) where T : notnull
+    {
+        /// <summary>
+        /// Applies <paramref name="map" /> to the contained value if the option is a
+        /// <see cref="Some{T}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <remarks>
+        /// Prefer this to <see cref="Option{T}.MapOrDefault{T2}" /> when
+        /// <typeparamref name="TOut" /> is a value type. <c>MapOrDefault</c> returns the
+        /// default of <typeparamref name="TOut" /> for a <see cref="None{T}" />, which is
+        /// indistinguishable from a legitimate zero.
+        /// </remarks>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to transform the value inside the option if it is
+        /// a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// The transformed value if the option was a <see cref="Some{T}" />,
+        /// otherwise <see langword="null" />.
+        /// </returns>
+        public TOut? MapOrNull<TOut>(Func<T, TOut> map) where TOut : struct =>
+            option.Match<TOut?>(value => map.Invoke(value), () => null);
+
+        /// <summary>
+        /// Awaits <paramref name="map" /> against the contained value if the option is
+        /// a <see cref="Some{T}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the value inside the
+        /// option if it is a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the
+        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
+        /// </returns>
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(
+            Func<T, Task<TOut>> map)
+            where TOut : struct
+        {
+            if (option.IsNone) return null;
+
+            T some = option.Expect("Expected Some but found None.");
+
+            return await map.Invoke(some).ConfigureAwait(false);
+        }
+    }
+
+    extension<T>(Task<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and applies <paramref name="map" /> to
+        /// the contained value if the option is a <see cref="Some{T}" />, otherwise
+        /// returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to transform the value inside the option if it is
+        /// a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
+            where TOut : struct
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.MapOrNull(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and awaits <paramref name="map" />
+        /// against the contained value if the option is a <see cref="Some{T}" />,
+        /// otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the value inside the
+        /// option if it is a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
+            where TOut : struct
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            if (option.IsNone) return null;
+
+            T some = option.Expect("Expected Some but found None.");
+
+            return await map.Invoke(some).ConfigureAwait(false);
+        }
+    }
+
+    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and applies
+        /// <paramref name="map" /> to the contained value if the option is a
+        /// <see cref="Some{T}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to transform the value inside the option if it is
+        /// a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
+            where TOut : struct
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.MapOrNull(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and awaits
+        /// <paramref name="map" /> against the contained value if the option is a
+        /// <see cref="Some{T}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the output value.</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the value inside the
+        /// option if it is a <see cref="Some{T}" />.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
+            where TOut : struct
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            if (option.IsNone) return null;
+
+            T some = option.Expect("Expected Some but found None.");
+
+            return await map.Invoke(some).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Waystone.Monads/Options/Extensions/UnwrapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnwrapOrNullExtensions.cs
@@ -1,0 +1,64 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using System.Threading.Tasks;
+
+public static class UnwrapOrNullExtensions
+{
+    extension<T>(Option<T> option) where T : struct
+    {
+        /// <summary>
+        /// Returns the contained value if the option is a <see cref="Some{T}" />,
+        /// otherwise <see langword="null" />.
+        /// </summary>
+        /// <remarks>
+        /// Prefer this to <see cref="Option{T}.UnwrapOrDefault" /> when
+        /// <typeparamref name="T" /> is a value type. <c>UnwrapOrDefault</c> returns the
+        /// default of <typeparamref name="T" /> for a <see cref="None{T}" />, which is
+        /// indistinguishable from a legitimate zero.
+        /// </remarks>
+        /// <returns>
+        /// The contained value if the option was a <see cref="Some{T}" />,
+        /// otherwise <see langword="null" />.
+        /// </returns>
+        public T? UnwrapOrNull() => option.Match<T?>(value => value, () => null);
+    }
+
+    extension<T>(Task<Option<T>> optionTask) where T : struct
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and returns the contained value if
+        /// the option is a <see cref="Some{T}" />, otherwise <see langword="null" />.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the contained value if the
+        /// awaited option was a <see cref="Some{T}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<T?> UnwrapOrNullAsync()
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.UnwrapOrNull();
+        }
+    }
+
+    extension<T>(ValueTask<Option<T>> optionTask) where T : struct
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and returns the contained value
+        /// if the option is a <see cref="Some{T}" />, otherwise
+        /// <see langword="null" />.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the contained value if the
+        /// awaited option was a <see cref="Some{T}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<T?> UnwrapOrNullAsync()
+        {
+            Option<T> option = await optionTask.ConfigureAwait(false);
+
+            return option.UnwrapOrNull();
+        }
+    }
+}

--- a/src/Waystone.Monads/Results/Extensions/MapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapOrNullExtensions.cs
@@ -1,0 +1,166 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using System;
+using System.Threading.Tasks;
+
+public static class MapOrNullExtensions
+{
+    extension<TOk, TErr>(Result<TOk, TErr> result)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Applies <paramref name="map" /> to the contained value if the result is an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <remarks>
+        /// Prefer this to <see cref="Result{TOk,TErr}.MapOrDefault{TOut}" /> when
+        /// <typeparamref name="TOut" /> is a value type. <c>MapOrDefault</c> returns the
+        /// default of <typeparamref name="TOut" /> for an <see cref="Err{TOk,TErr}" />,
+        /// which is indistinguishable from a legitimate zero.
+        /// </remarks>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to transform the <see cref="Ok{TOk,TErr}" />
+        /// value.
+        /// </param>
+        /// <returns>
+        /// The transformed value if the result was an <see cref="Ok{TOk,TErr}" />,
+        /// otherwise <see langword="null" />.
+        /// </returns>
+        public TOut? MapOrNull<TOut>(Func<TOk, TOut> map) where TOut : struct =>
+            result.Match<TOut?>(value => map.Invoke(value), _ => null);
+
+        /// <summary>
+        /// Awaits <paramref name="map" /> against the contained value if the result is
+        /// an <see cref="Ok{TOk,TErr}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the
+        /// <see cref="Ok{TOk,TErr}" /> value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the
+        /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(
+            Func<TOk, Task<TOut>> map)
+            where TOut : struct
+        {
+            if (result.IsErr) return null;
+
+            TOk ok = result.Expect("Expected Ok but found Err.");
+
+            return await map.Invoke(ok).ConfigureAwait(false);
+        }
+    }
+
+    extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and applies <paramref name="map" /> to
+        /// the contained value if the result is an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to transform the <see cref="Ok{TOk,TErr}" />
+        /// value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, TOut> map)
+            where TOut : struct
+        {
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
+
+            return result.MapOrNull(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and awaits <paramref name="map" />
+        /// against the contained value if the result is an <see cref="Ok{TOk,TErr}" />,
+        /// otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the
+        /// <see cref="Ok{TOk,TErr}" /> value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, Task<TOut>> map)
+            where TOut : struct
+        {
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
+
+            if (result.IsErr) return null;
+
+            TOk ok = result.Expect("Expected Ok but found Err.");
+
+            return await map.Invoke(ok).ConfigureAwait(false);
+        }
+    }
+
+    extension<TOk, TErr>(ValueTask<Result<TOk, TErr>> resultTask)
+        where TOk : notnull where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and applies
+        /// <paramref name="map" /> to the contained value if the result is an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to transform the <see cref="Ok{TOk,TErr}" />
+        /// value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, TOut> map)
+            where TOut : struct
+        {
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
+
+            return result.MapOrNull(map);
+        }
+
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and awaits
+        /// <paramref name="map" /> against the contained value if the result is an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise returns <see langword="null" />.
+        /// </summary>
+        /// <typeparam name="TOut">The mapped result value type</typeparam>
+        /// <param name="map">
+        /// A function to asynchronously transform the
+        /// <see cref="Ok{TOk,TErr}" /> value.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, Task<TOut>> map)
+            where TOut : struct
+        {
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
+
+            if (result.IsErr) return null;
+
+            TOk ok = result.Expect("Expected Ok but found Err.");
+
+            return await map.Invoke(ok).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Waystone.Monads/Results/Extensions/UnwrapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/UnwrapOrNullExtensions.cs
@@ -1,0 +1,70 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using System.Threading.Tasks;
+
+public static class UnwrapOrNullExtensions
+{
+    extension<TOk, TErr>(Result<TOk, TErr> result)
+        where TOk : struct where TErr : notnull
+    {
+        /// <summary>
+        /// Returns the contained value if the result is an
+        /// <see cref="Ok{TOk,TErr}" />, otherwise <see langword="null" />.
+        /// </summary>
+        /// <remarks>
+        /// Prefer this to <see cref="Result{TOk,TErr}.UnwrapOrDefault" /> when
+        /// <typeparamref name="TOk" /> is a value type. <c>UnwrapOrDefault</c> returns
+        /// the default of <typeparamref name="TOk" /> for an
+        /// <see cref="Err{TOk,TErr}" />, which is indistinguishable from a legitimate
+        /// zero.
+        /// </remarks>
+        /// <returns>
+        /// The contained value if the result was an <see cref="Ok{TOk,TErr}" />,
+        /// otherwise <see langword="null" />.
+        /// </returns>
+        public TOk? UnwrapOrNull() =>
+            result.Match<TOk?>(value => value, _ => null);
+    }
+
+    extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
+        where TOk : struct where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="Task{TResult}" /> and returns the contained value if
+        /// the result is an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the contained value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<TOk?> UnwrapOrNullAsync()
+        {
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
+
+            return result.UnwrapOrNull();
+        }
+    }
+
+    extension<TOk, TErr>(ValueTask<Result<TOk, TErr>> resultTask)
+        where TOk : struct where TErr : notnull
+    {
+        /// <summary>
+        /// Awaits the <see cref="ValueTask{TResult}" /> and returns the contained value
+        /// if the result is an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{TResult}" /> containing the contained value if the awaited
+        /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
+        /// <see langword="null" />.
+        /// </returns>
+        public async Task<TOk?> UnwrapOrNullAsync()
+        {
+            Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
+
+            return result.UnwrapOrNull();
+        }
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/MapOrNullExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/MapOrNullExtensionsTests.cs
@@ -1,0 +1,120 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(MapOrNullExtensions))]
+public sealed class MapOrNullExtensionsTests
+{
+    [Fact]
+    public void GivenSome_WhenMapOrNull_ThenReturnTheMappedValue() =>
+        Option.Some(1).MapOrNull(x => x + 1).ShouldBe(2);
+
+    [Fact]
+    public void GivenNone_WhenMapOrNull_ThenReturnNull() =>
+        Option.None<int>().MapOrNull(x => x + 1).ShouldBeNull();
+
+    [Fact]
+    public void GivenSome_WhenMapOrNullToTheDefault_ThenReturnTheDefault() =>
+        Option.Some(1).MapOrNull(_ => 0).ShouldBe(0);
+
+    [Fact]
+    public async Task GivenSome_WhenMapOrNullAsync_ThenReturnTheMappedValue()
+    {
+        int? value = await Option.Some(1)
+           .MapOrNullAsync(x => Task.FromResult(x + 1));
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenNone_WhenMapOrNullAsync_ThenReturnNull()
+    {
+        int? value = await Option.None<int>()
+           .MapOrNullAsync(x => Task.FromResult(x + 1));
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int? value = await Task.FromResult(Option.Some(1))
+           .MapOrNullAsync(x => x + 1);
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnNull()
+    {
+        int? value = await Task.FromResult(Option.None<int>())
+           .MapOrNullAsync(x => x + 1);
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int? value = await Task.FromResult(Option.Some(1))
+           .MapOrNullAsync(x => Task.FromResult(x + 1));
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnNull()
+    {
+        int? value = await Task.FromResult(Option.None<int>())
+           .MapOrNullAsync(x => Task.FromResult(x + 1));
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int? value = await new ValueTask<Option<int>>(Option.Some(1))
+           .MapOrNullAsync(x => x + 1);
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnNull()
+    {
+        int? value = await new ValueTask<Option<int>>(Option.None<int>())
+           .MapOrNullAsync(x => x + 1);
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int? value = await new ValueTask<Option<int>>(Option.Some(1))
+           .MapOrNullAsync(x => Task.FromResult(x + 1));
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenNoneValueTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnNull()
+    {
+        int? value = await new ValueTask<Option<int>>(Option.None<int>())
+           .MapOrNullAsync(x => Task.FromResult(x + 1));
+
+        value.ShouldBeNull();
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/UnwrapOrNullExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/UnwrapOrNullExtensionsTests.cs
@@ -1,0 +1,65 @@
+namespace Waystone.Monads.Options.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(UnwrapOrNullExtensions))]
+public sealed class UnwrapOrNullExtensionsTests
+{
+    [Fact]
+    public void GivenSome_WhenUnwrapOrNull_ThenReturnTheValue() =>
+        Option.Some(1).UnwrapOrNull().ShouldBe(1);
+
+    [Fact]
+    public void GivenNone_WhenUnwrapOrNull_ThenReturnNull() =>
+        Option.None<int>().UnwrapOrNull().ShouldBeNull();
+
+    [Fact]
+    public void
+        GivenNone_WhenUnwrapOrNull_ThenTheAbsenceIsDistinctFromUnwrapOrDefault()
+    {
+        Option<int> none = Option.None<int>();
+
+        none.UnwrapOrDefault().ShouldBe(0);
+        none.UnwrapOrNull().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GivenSomeTask_WhenUnwrapOrNullAsync_ThenReturnTheValue()
+    {
+        int? value = await Task.FromResult(Option.Some(1))
+           .UnwrapOrNullAsync();
+
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GivenNoneTask_WhenUnwrapOrNullAsync_ThenReturnNull()
+    {
+        int? value = await Task.FromResult(Option.None<int>())
+           .UnwrapOrNullAsync();
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTask_WhenUnwrapOrNullAsync_ThenReturnTheValue()
+    {
+        int? value = await new ValueTask<Option<int>>(Option.Some(1))
+           .UnwrapOrNullAsync();
+
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GivenNoneValueTask_WhenUnwrapOrNullAsync_ThenReturnNull()
+    {
+        int? value = await new ValueTask<Option<int>>(Option.None<int>())
+           .UnwrapOrNullAsync();
+
+        value.ShouldBeNull();
+    }
+}

--- a/test/Waystone.Monads.Tests/Results/Extensions/MapOrNullExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/MapOrNullExtensionsTests.cs
@@ -1,0 +1,129 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(MapOrNullExtensions))]
+public sealed class MapOrNullExtensionsTests
+{
+    [Fact]
+    public void GivenOk_WhenMapOrNull_ThenReturnTheMappedValue() =>
+        Result.Ok<int, string>(1).MapOrNull(value => value + 1).ShouldBe(2);
+
+    [Fact]
+    public void GivenErr_WhenMapOrNull_ThenReturnNull() =>
+        Result.Err<int, string>("failed")
+           .MapOrNull(value => value + 1)
+           .ShouldBeNull();
+
+    [Fact]
+    public void GivenOk_WhenMapOrNullToTheDefault_ThenReturnTheDefault() =>
+        Result.Ok<int, string>(1).MapOrNull(_ => 0).ShouldBe(0);
+
+    [Fact]
+    public async Task GivenOk_WhenMapOrNullAsync_ThenReturnTheMappedValue()
+    {
+        int? value = await Result.Ok<int, string>(1)
+           .MapOrNullAsync(ok => Task.FromResult(ok + 1));
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenErr_WhenMapOrNullAsync_ThenReturnNull()
+    {
+        int? value = await Result.Err<int, string>("failed")
+           .MapOrNullAsync(ok => Task.FromResult(ok + 1));
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenOkTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int? value = await Task.FromResult(Result.Ok<int, string>(1))
+           .MapOrNullAsync(ok => ok + 1);
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GivenErrTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnNull()
+    {
+        int? value = await Task.FromResult(Result.Err<int, string>("failed"))
+           .MapOrNullAsync(ok => ok + 1);
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenOkTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int? value = await Task.FromResult(Result.Ok<int, string>(1))
+           .MapOrNullAsync(ok => Task.FromResult(ok + 1));
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnNull()
+    {
+        int? value = await Task.FromResult(Result.Err<int, string>("failed"))
+           .MapOrNullAsync(ok => Task.FromResult(ok + 1));
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnTheMappedValue()
+    {
+        int? value =
+            await new ValueTask<Result<int, string>>(
+                    Result.Ok<int, string>(1))
+               .MapOrNullAsync(ok => ok + 1);
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrValueTask_WhenMapOrNullAsyncWithASyncMap_ThenReturnNull()
+    {
+        int? value =
+            await new ValueTask<Result<int, string>>(
+                    Result.Err<int, string>("failed"))
+               .MapOrNullAsync(ok => ok + 1);
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnTheMappedValue()
+    {
+        int? value =
+            await new ValueTask<Result<int, string>>(
+                    Result.Ok<int, string>(1))
+               .MapOrNullAsync(ok => Task.FromResult(ok + 1));
+
+        value.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task
+        GivenErrValueTask_WhenMapOrNullAsyncWithAnAsyncMap_ThenReturnNull()
+    {
+        int? value =
+            await new ValueTask<Result<int, string>>(
+                    Result.Err<int, string>("failed"))
+               .MapOrNullAsync(ok => Task.FromResult(ok + 1));
+
+        value.ShouldBeNull();
+    }
+}

--- a/test/Waystone.Monads.Tests/Results/Extensions/UnwrapOrNullExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/UnwrapOrNullExtensionsTests.cs
@@ -1,0 +1,69 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+[TestSubject(typeof(UnwrapOrNullExtensions))]
+public sealed class UnwrapOrNullExtensionsTests
+{
+    [Fact]
+    public void GivenOk_WhenUnwrapOrNull_ThenReturnTheValue() =>
+        Result.Ok<int, string>(1).UnwrapOrNull().ShouldBe(1);
+
+    [Fact]
+    public void GivenErr_WhenUnwrapOrNull_ThenReturnNull() =>
+        Result.Err<int, string>("failed").UnwrapOrNull().ShouldBeNull();
+
+    [Fact]
+    public void
+        GivenErr_WhenUnwrapOrNull_ThenTheFailureIsDistinctFromUnwrapOrDefault()
+    {
+        Result<int, string> err = Result.Err<int, string>("failed");
+
+        err.UnwrapOrDefault().ShouldBe(0);
+        err.UnwrapOrNull().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GivenOkTask_WhenUnwrapOrNullAsync_ThenReturnTheValue()
+    {
+        int? value = await Task.FromResult(Result.Ok<int, string>(1))
+           .UnwrapOrNullAsync();
+
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GivenErrTask_WhenUnwrapOrNullAsync_ThenReturnNull()
+    {
+        int? value = await Task.FromResult(Result.Err<int, string>("failed"))
+           .UnwrapOrNullAsync();
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GivenOkValueTask_WhenUnwrapOrNullAsync_ThenReturnTheValue()
+    {
+        int? value =
+            await new ValueTask<Result<int, string>>(
+                    Result.Ok<int, string>(1))
+               .UnwrapOrNullAsync();
+
+        value.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GivenErrValueTask_WhenUnwrapOrNullAsync_ThenReturnNull()
+    {
+        int? value =
+            await new ValueTask<Result<int, string>>(
+                    Result.Err<int, string>("failed"))
+               .UnwrapOrNullAsync();
+
+        value.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
UnwrapOrDefault on an Option<int> returns 0, not null. The signature is
`T? UnwrapOrDefault()` under `T : notnull`, and in an unconstrained generic
context `T?` for a struct is the struct's default — so the absent case comes
back indistinguishable from a legitimate zero, and Match was the only way out
of the type that preserved the difference.

Struct-constrained extensions rather than a second UnwrapOrDefault, because
constraints are not part of a signature: an overload differing only by
`T : struct` is a duplicate member, not an overload. Hence the distinct name.

Extensions rather than instance members. The constraint requires it — Option<T>
is declared `T : notnull` — and it avoids the trap from 4040a24: neither base
type has a non-public constructor, so a consumer can derive their own case and
a new abstract member would break them in a minor release.

ValueTask receivers return Task, matching the convention the rest of the
library uses today rather than pre-empting the v6 change that fixes it.

A test pins the thing this exists for: on None, UnwrapOrDefault() is 0 and
UnwrapOrNull() is null.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>