### PR TITLE
feat(analyzers): add WM2015 for OrDefault on a value type

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/Idioms.cs
+++ b/sample/Waystone.Monads.Analyzers.Sample/Idioms.cs
@@ -55,6 +55,9 @@ internal class Idioms
 
     internal string? NullableAlongsideOption(int id) => null;
 
+    internal int UnwrapsOrDefaultOnAStruct(Option<int> option) =>
+        option.UnwrapOrDefault();
+
     internal Option<int> UsesTheOldFlatMapName(Option<int> option) =>
         option.FlatMap(value => Option.Some(value * 2));
 }

--- a/sample/Waystone.Monads.Analyzers.Sample/README.md
+++ b/sample/Waystone.Monads.Analyzers.Sample/README.md
@@ -25,7 +25,7 @@ nullable, which is what `WM1005` needs to see that a value may be null.
 
 ## Trying the code fixes
 
-Open either file in an IDE and invoke the lightbulb. Thirteen of the twenty-four rules
+Open either file in an IDE and invoke the lightbulb. Thirteen of the twenty-five rules
 offer a fix; the rest are reported without one, either because the correction is
 ambiguous (`Ok` or `Err`?) or because it changes a signature and cascades to
 callers the fix cannot see.

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -60,3 +60,11 @@ WM1008 | Reliability | Warning | An Option or Result is declared nullable
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 WM1009 | Reliability | Warning | Option of bool or of an enum with a zero member
+
+## Release 5.10.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+WM2015 | Usage | Info | OrDefault on a value type cannot express the absent case

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -146,6 +146,12 @@ public static class Rules
         "'{0}' is obsolete and will be removed in v6. Use '{1}'.",
         "Rust names this operation and_then, and Result already spelled it AndThen. FlatMap remains only as a forwarding member until the next major version.");
 
+    public static readonly DiagnosticDescriptor OrDefaultOnAValueType = Idiom(
+        "WM2015",
+        "OrDefault on a value type cannot express the absent case",
+        "'{0}' hands back the default of '{1}' when there is no value, which is indistinguishable from a real one. '{2}' returns null instead.",
+        "T? on a type parameter constrained only to notnull is an annotation, not a Nullable<T>, so for a value type UnwrapOrDefault and MapOrDefault return 0, false or default(Guid) for the absent case. That is legitimate where the caller genuinely wants the default, which is why this rule informs rather than warns. It does not contradict WM2007: that rule removes a repeated type from UnwrapOr, and this one asks whether the default was meant as a value.");
+
     public static readonly DiagnosticDescriptor NullableReturnCouldBeOption = Migration(
         "WM3001",
         "A nullable return could be an Option",

--- a/src/Waystone.Monads.Analyzers/SimplificationAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/SimplificationAnalyzer.cs
@@ -12,6 +12,7 @@ public sealed class SimplificationAnalyzer : MonadAnalyzer
         ImmutableArray.Create(
             Rules.MapThenFlatten,
             Rules.UnwrapOrWithDefault,
+            Rules.OrDefaultOnAValueType,
             Rules.MonadComparedToNull);
 
     protected override void Register(
@@ -39,7 +40,8 @@ public sealed class SimplificationAnalyzer : MonadAnalyzer
         string name = invocation.TargetMethod.Name;
 
         if (name is not ("Flatten" or "FlattenAsync" or "UnwrapOr"
-            or "UnwrapOrAsync")
+            or "UnwrapOrAsync" or "UnwrapOrDefault" or "UnwrapOrDefaultAsync"
+            or "MapOrDefault" or "MapOrDefaultAsync")
          || !symbols.IsMonadInvocation(invocation))
         {
             return;
@@ -55,7 +57,34 @@ public sealed class SimplificationAnalyzer : MonadAnalyzer
         if (name is "UnwrapOr" or "UnwrapOrAsync")
         {
             AnalyzeUnwrapOr(context, invocation, symbols);
+
+            return;
         }
+
+        AnalyzeOrDefault(context, invocation, symbols);
+    }
+
+    private static void AnalyzeOrDefault(
+        OperationAnalysisContext context,
+        IInvocationOperation invocation,
+        MonadSymbols symbols)
+    {
+        var produced = symbols.UnwrapAwaitable(invocation.Type);
+
+        if (produced is null || !produced.IsValueType)
+        {
+            return;
+        }
+
+        string name = invocation.TargetMethod.Name;
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Rules.OrDefaultOnAValueType,
+                Semantics.NameLocationOf(invocation),
+                name,
+                Semantics.Display(produced),
+                name.Replace("Default", "Null")));
     }
 
     private static void AnalyzeFlatten(

--- a/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
@@ -103,10 +103,17 @@ public class CodeFixTests
     public Task ReplacesUnwrapOrOfADefaultWithUnwrapOrDefault() =>
         Verify.CodeFixAsync<SimplificationAnalyzer, UseUnwrapOrDefaultCodeFix>(
             "internal int Value(Option<int> option) => option.{|#0:UnwrapOr|}(0);",
-            "internal int Value(Option<int> option) => option.UnwrapOrDefault();",
-            Verify.Diagnostic(Rules.UnwrapOrWithDefault)
-               .WithLocation(0)
-               .WithArguments("int"));
+            "internal int Value(Option<int> option) => option.{|#1:UnwrapOrDefault|}();",
+            [
+                Verify.Diagnostic(Rules.UnwrapOrWithDefault)
+                   .WithLocation(0)
+                   .WithArguments("int"),
+            ],
+            [
+                Verify.Diagnostic(Rules.OrDefaultOnAValueType)
+                   .WithLocation(1)
+                   .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull"),
+            ]);
 
     [Fact]
     public Task ReplacesMapThenFlattenWithAndThen() =>

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -51,7 +51,7 @@ public class RulesTests
     public void EveryTierIsPopulated()
     {
         MisuseRules().Count.ShouldBe(9);
-        IdiomRules().Count.ShouldBe(14);
+        IdiomRules().Count.ShouldBe(15);
         MigrationRules().Count.ShouldBe(2);
     }
 

--- a/test/Waystone.Monads.Analyzers.Tests/SimplificationAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/SimplificationAnalyzerTests.cs
@@ -42,6 +42,85 @@ public class SimplificationAnalyzerTests
                .WithArguments("int"));
 
     [Fact]
+    public Task FlagsUnwrapOrDefaultOnAnOptionOfAStruct() =>
+        Verify.AnalyzerAsync<SimplificationAnalyzer>(
+            """
+            internal int Value(Option<int> option) =>
+                option.{|#0:UnwrapOrDefault|}();
+            """,
+            Verify.Diagnostic(Rules.OrDefaultOnAValueType)
+               .WithLocation(0)
+               .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull"));
+
+    [Fact]
+    public Task FlagsUnwrapOrDefaultOnAResultWhoseOkIsAStruct() =>
+        Verify.AnalyzerAsync<SimplificationAnalyzer>(
+            """
+            internal int Value(Result<int, string> result) =>
+                result.{|#0:UnwrapOrDefault|}();
+            """,
+            Verify.Diagnostic(Rules.OrDefaultOnAValueType)
+               .WithLocation(0)
+               .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull"));
+
+    [Fact]
+    public Task FlagsMapOrDefaultProducingAStruct() =>
+        Verify.AnalyzerAsync<SimplificationAnalyzer>(
+            """
+            internal int Length(Option<string> option) =>
+                option.{|#0:MapOrDefault|}(value => value.Length);
+            """,
+            Verify.Diagnostic(Rules.OrDefaultOnAValueType)
+               .WithLocation(0)
+               .WithArguments("MapOrDefault", "int", "MapOrNull"));
+
+    [Fact]
+    public Task FlagsUnwrapOrDefaultAsyncBehindConfigureAwait() =>
+        Verify.AnalyzerAsync<SimplificationAnalyzer>(
+            """
+            internal async Task<int> ValueAsync(Task<Option<int>> option) =>
+                await option.{|#0:UnwrapOrDefaultAsync|}()
+                   .ConfigureAwait(false);
+            """,
+            Verify.Diagnostic(Rules.OrDefaultOnAValueType)
+               .WithLocation(0)
+               .WithArguments(
+                    "UnwrapOrDefaultAsync",
+                    "int",
+                    "UnwrapOrNullAsync"));
+
+    [Fact]
+    public Task IgnoresUnwrapOrDefaultOnAnOptionOfAReferenceType() =>
+        Verify.NoDiagnosticAsync<SimplificationAnalyzer>(
+            """
+            internal string? Value(Option<string> option) =>
+                option.UnwrapOrDefault();
+            """);
+
+    [Fact]
+    public Task IgnoresMapOrDefaultProducingAReferenceType() =>
+        Verify.NoDiagnosticAsync<SimplificationAnalyzer>(
+            """
+            internal string? Text(Option<int> option) =>
+                option.MapOrDefault(value => value.ToString());
+            """);
+
+    [Fact]
+    public Task IgnoresUnwrapOrDefaultOnSomethingThatIsNotAMonad() =>
+        Verify.NoDiagnosticAsync<SimplificationAnalyzer>(
+            """
+            internal sealed class Box
+            {
+                internal int UnwrapOrDefault() => 0;
+            }
+
+            internal class Subject
+            {
+                internal int Value(Box box) => box.UnwrapOrDefault();
+            }
+            """);
+
+    [Fact]
     public Task IgnoresUnwrapOrGivenARealFallback() =>
         Verify.NoDiagnosticAsync<SimplificationAnalyzer>(
             "internal int Value(Option<int> option) => option.UnwrapOr(1);");

--- a/test/Waystone.Monads.Analyzers.Tests/Verify.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/Verify.cs
@@ -49,6 +49,26 @@ internal static class Verify
         return test.RunAsync();
     }
 
+    public static Task CodeFixAsync<TAnalyzer, TCodeFix>(
+        string source,
+        string fixedSource,
+        DiagnosticResult[] expected,
+        DiagnosticResult[] remaining)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        var test = new CodeFixTest<TAnalyzer, TCodeFix>
+        {
+            TestCode = Wrap(source),
+            FixedCode = Wrap(fixedSource),
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        test.FixedState.ExpectedDiagnostics.AddRange(remaining);
+
+        return test.RunAsync();
+    }
+
     public static Task RawCodeFixAsync<TAnalyzer, TCodeFix>(
         string source,
         string fixedSource,


### PR DESCRIPTION
Without a rule pointing at them, UnwrapOrNull and MapOrNull are
undiscoverable and the trap they exist for stays live: Option<int>
.UnwrapOrDefault() returns 0, and nothing tells the caller that is not the
null they expected.

Info, not Warning. UnwrapOrDefault on a struct is legitimate when the caller
genuinely wants the default, so this is a suggestion.

Keyed on the invocation's own return type through UnwrapAwaitable, which is
right here because the awaitable comes straight off the method signature —
the ConfigureAwait blind spot only affects unwrapping a receiver, and there
is a test through `await … .ConfigureAwait(false)` pinning that. The receiver
is identified by MonadSymbols.IsMonadInvocation, not IsExtensionMethod.

No code fix. The rename changes the return type from T to T?, so the fix
would compile at the call site and break at the assignment, and there is no
position where that is reliably safe to decide.

WM2007 and WM2015 overlap: applying WM2007's fix to `UnwrapOr(0)` yields
`UnwrapOrDefault()`, which WM2015 then reports. Its code-fix test now asserts
that diagnostic in the fixed state rather than hiding it, so the interaction
is visible and tested. Both are Info and WM2015 ships no fix, so there is no
automated ping-pong — but the two rules do point in opposite directions for a
value type, and that is worth settling in review.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>