### PR TITLE
feat: add Flatten, FlattenErr and Partition for sequences

### DIFF
--- a/src/Waystone.Monads/Options/Extensions/OptionsCollectionExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/OptionsCollectionExtensions.cs
@@ -54,6 +54,27 @@ public static class OptionsCollectionExtensions
         options.Select(o => o.Map(mapper));
 
     /// <summary>
+    /// Returns the values contained by the <see cref="Some{T}" /> elements of a
+    /// sequence, skipping the <see cref="None{T}" /> ones.
+    /// </summary>
+    /// <remarks>
+    /// This is the sequence counterpart of Rust's <c>iter().flatten()</c>, which
+    /// works because <c>Option</c> is itself iterable. It is lazy and streams.
+    /// </remarks>
+    /// <param name="options">
+    /// An <see cref="IEnumerable{T}" /> of
+    /// <see cref="Option{T}" />
+    /// </param>
+    /// <typeparam name="T">The option value's type</typeparam>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}" /> yielding the value of every
+    /// <see cref="Some{T}" /> in the source, in order
+    /// </returns>
+    public static IEnumerable<T> Flatten<T>(
+        this IEnumerable<Option<T>> options) where T : notnull =>
+        options.SelectMany(option => option.AsEnumerable());
+
+    /// <summary>
     /// Returns the first <see cref="Option{T}" /> of the sequence that
     /// satisfies a condition or a <see cref="None{T}" /> if a match is not found
     /// </summary>

--- a/src/Waystone.Monads/Results/Extensions/ResultsCollectionExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/ResultsCollectionExtensions.cs
@@ -1,0 +1,93 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>Extensions for <see cref="Result{TOk,TErr}" /> collections.</summary>
+public static class ResultsCollectionExtensions
+{
+    /// <summary>
+    /// Returns the values contained by the <see cref="Ok{TOk,TErr}" /> elements of a
+    /// sequence, skipping the <see cref="Err{TOk,TErr}" /> ones.
+    /// </summary>
+    /// <remarks>
+    /// This is the sequence counterpart of Rust's <c>iter().flatten()</c>, which
+    /// works because <c>Result</c> is itself iterable. It is lazy and streams.
+    /// Unlike collecting into a single result, it does not stop at the first
+    /// failure.
+    /// </remarks>
+    /// <param name="results">
+    /// An <see cref="IEnumerable{T}" /> of
+    /// <see cref="Result{TOk,TErr}" />
+    /// </param>
+    /// <typeparam name="TOk">The result's ok value type</typeparam>
+    /// <typeparam name="TErr">The result's error value type</typeparam>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}" /> yielding the value of every
+    /// <see cref="Ok{TOk,TErr}" /> in the source, in order
+    /// </returns>
+    public static IEnumerable<TOk> Flatten<TOk, TErr>(
+        this IEnumerable<Result<TOk, TErr>> results)
+        where TOk : notnull where TErr : notnull =>
+        results.SelectMany(result => result.AsEnumerable());
+
+    /// <summary>
+    /// Returns the errors contained by the <see cref="Err{TOk,TErr}" /> elements of
+    /// a sequence, skipping the <see cref="Ok{TOk,TErr}" /> ones.
+    /// </summary>
+    /// <remarks>
+    /// Rust has no name for this direction. The <c>Err</c> suffix follows
+    /// <c>MapErr</c>, <c>InspectErr</c>, <c>ExpectErr</c> and <c>UnwrapErr</c>. It is
+    /// lazy and streams.
+    /// </remarks>
+    /// <param name="results">
+    /// An <see cref="IEnumerable{T}" /> of
+    /// <see cref="Result{TOk,TErr}" />
+    /// </param>
+    /// <typeparam name="TOk">The result's ok value type</typeparam>
+    /// <typeparam name="TErr">The result's error value type</typeparam>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}" /> yielding the error of every
+    /// <see cref="Err{TOk,TErr}" /> in the source, in order
+    /// </returns>
+    public static IEnumerable<TErr> FlattenErr<TOk, TErr>(
+        this IEnumerable<Result<TOk, TErr>> results)
+        where TOk : notnull where TErr : notnull =>
+        results.SelectMany(
+            result => result.Match(
+                _ => Enumerable.Empty<TErr>(),
+                error => new[] { error }.AsEnumerable()));
+
+    /// <summary>
+    /// Splits a sequence of results into its ok values and its errors, enumerating
+    /// the source exactly once.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not the all-or-nothing shape: this reports every failure rather
+    /// than stopping at the first one.
+    /// </remarks>
+    /// <param name="results">
+    /// An <see cref="IEnumerable{T}" /> of
+    /// <see cref="Result{TOk,TErr}" />
+    /// </param>
+    /// <typeparam name="TOk">The result's ok value type</typeparam>
+    /// <typeparam name="TErr">The result's error value type</typeparam>
+    /// <returns>
+    /// A tuple of the ok values and the errors, each in the order they appeared
+    /// in the source
+    /// </returns>
+    public static (IReadOnlyList<TOk> Oks, IReadOnlyList<TErr> Errs)
+        Partition<TOk, TErr>(this IEnumerable<Result<TOk, TErr>> results)
+        where TOk : notnull where TErr : notnull
+    {
+        List<TOk> oks = new List<TOk>();
+        List<TErr> errs = new List<TErr>();
+
+        foreach (Result<TOk, TErr> result in results)
+        {
+            result.Match(oks.Add, errs.Add);
+        }
+
+        return (oks, errs);
+    }
+}

--- a/test/Waystone.Monads.Tests/Options/Extensions/OptionsCollectionExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/OptionsCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Waystone.Monads.Options.Extensions
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Shouldly;
@@ -133,6 +134,57 @@
             results.Count(x => x.IsSome).ShouldBe(3);
             results.First(x => x.IsSome).Unwrap().ShouldBe("11");
             results.First(x => x.IsSome).Unwrap().ShouldBe("11");
+        }
+
+        [Fact]
+        public void
+            GivenCollectionOfOptions_WhenInvokingFlatten_ThenReturnTheSomeValues()
+        {
+            List<int> results = Values.Flatten().ToList();
+
+            results.ShouldBe(new[] { 11, 12, 2 });
+        }
+
+        [Fact]
+        public void
+            GivenEmptyCollection_WhenInvokingFlatten_ThenReturnAnEmptySequence() =>
+            new List<Option<int>>().Flatten().ShouldBeEmpty();
+
+        [Fact]
+        public void GivenCollectionOfNone_WhenInvokingFlatten_ThenReturnAnEmptySequence() =>
+            new List<Option<int>> { Option.None<int>(), Option.None<int>() }
+               .Flatten()
+               .ShouldBeEmpty();
+
+        [Fact]
+        public void GivenThrowingSource_WhenInvokingFlatten_ThenDoNotEnumerate()
+        {
+            IEnumerable<int> flattened = ThrowingSource().Flatten();
+
+            flattened.Take(1).ToList().ShouldBe(new[] { 1 });
+            Should.Throw<InvalidOperationException>(() => flattened.ToList());
+        }
+
+        [Fact]
+        public void
+            GivenCollectionOfNestedOptions_WhenInvokingFlatten_ThenTheSequenceOverloadIsChosen()
+        {
+            List<Option<Option<int>>> nested = new List<Option<Option<int>>>
+            {
+                Option.Some(Option.Some(1)),
+                Option.None<Option<int>>(),
+            };
+
+            List<Option<int>> results = nested.Flatten().ToList();
+
+            results.ShouldBe(new[] { Option.Some(1) });
+        }
+
+        private static IEnumerable<Option<int>> ThrowingSource()
+        {
+            yield return Option.Some(1);
+
+            throw new InvalidOperationException("Enumerated too far.");
         }
     }
 }

--- a/test/Waystone.Monads.Tests/Results/Extensions/ResultsCollectionExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Extensions/ResultsCollectionExtensionsTests.cs
@@ -1,0 +1,121 @@
+namespace Waystone.Monads.Results.Extensions;
+
+using JetBrains.Annotations;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+[TestSubject(typeof(ResultsCollectionExtensions))]
+public sealed class ResultsCollectionExtensionsTests
+{
+    private static readonly List<Result<int, string>> Mixed =
+        new List<Result<int, string>>
+        {
+            Result.Ok<int, string>(1),
+            Result.Err<int, string>("first"),
+            Result.Ok<int, string>(2),
+            Result.Err<int, string>("second"),
+        };
+
+    [Fact]
+    public void GivenMixedResults_WhenFlatten_ThenReturnTheOkValues() =>
+        Mixed.Flatten().ShouldBe(new[] { 1, 2 });
+
+    [Fact]
+    public void GivenMixedResults_WhenFlattenErr_ThenReturnTheErrors() =>
+        Mixed.FlattenErr().ShouldBe(new[] { "first", "second" });
+
+    [Fact]
+    public void GivenEmptySequence_WhenFlatten_ThenReturnAnEmptySequence() =>
+        new List<Result<int, string>>().Flatten().ShouldBeEmpty();
+
+    [Fact]
+    public void GivenEmptySequence_WhenFlattenErr_ThenReturnAnEmptySequence() =>
+        new List<Result<int, string>>().FlattenErr().ShouldBeEmpty();
+
+    [Fact]
+    public void GivenAllErr_WhenFlatten_ThenReturnAnEmptySequence() =>
+        new List<Result<int, string>> { Result.Err<int, string>("failed") }
+           .Flatten()
+           .ShouldBeEmpty();
+
+    [Fact]
+    public void GivenMixedResults_WhenPartition_ThenReturnBothSides()
+    {
+        (IReadOnlyList<int> oks, IReadOnlyList<string> errs) =
+            Mixed.Partition();
+
+        oks.ShouldBe(new[] { 1, 2 });
+        errs.ShouldBe(new[] { "first", "second" });
+    }
+
+    [Fact]
+    public void GivenEmptySequence_WhenPartition_ThenReturnTwoEmptySides()
+    {
+        (IReadOnlyList<int> oks, IReadOnlyList<string> errs) =
+            new List<Result<int, string>>().Partition();
+
+        oks.ShouldBeEmpty();
+        errs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenCountingSource_WhenPartition_ThenEnumerateOnce()
+    {
+        CountingSource source = new CountingSource(Mixed);
+
+        source.Partition();
+
+        source.Enumerations.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenThrowingSource_WhenFlatten_ThenDoNotEnumerateEagerly()
+    {
+        IEnumerable<int> flattened = ThrowingSource().Flatten();
+
+        flattened.Take(1).ToList().ShouldBe(new[] { 1 });
+        Should.Throw<InvalidOperationException>(() => flattened.ToList());
+    }
+
+    [Fact]
+    public void GivenThrowingSource_WhenFlattenErr_ThenDoNotEnumerateEagerly()
+    {
+        IEnumerable<string> flattened = ThrowingSource().FlattenErr();
+
+        flattened.Take(1).ToList().ShouldBe(new[] { "first" });
+        Should.Throw<InvalidOperationException>(() => flattened.ToList());
+    }
+
+    private static IEnumerable<Result<int, string>> ThrowingSource()
+    {
+        yield return Result.Ok<int, string>(1);
+        yield return Result.Err<int, string>("first");
+
+        throw new InvalidOperationException("Enumerated too far.");
+    }
+
+    private sealed class CountingSource
+        : IEnumerable<Result<int, string>>
+    {
+        private readonly IEnumerable<Result<int, string>> _source;
+
+        public CountingSource(IEnumerable<Result<int, string>> source) =>
+            _source = source;
+
+        public int Enumerations { get; private set; }
+
+        public IEnumerator<Result<int, string>> GetEnumerator()
+        {
+            Enumerations++;
+
+            return _source.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator
+            System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+    }
+}


### PR DESCRIPTION
There was no way to collect across a sequence of Results without insisting
they all agree. Results/Extensions had no collection file at all, and
OptionsCollectionExtensions had Filter, Map, FirstOrNone and LastOrNone but
nothing that extracted the contained values, so getting the successes out of
an IEnumerable<Result<TOk, TErr>> meant a hand-rolled Where/Select.

Flatten is Rust's name for this: Option and Result both implement
IntoIterator, so iter().flatten() yields the contained values for either. The
name therefore holds for both types. Rust has no name for the Err branch, so
FlattenErr follows this library's own Err suffix — MapErr, InspectErr,
ExpectErr, UnwrapErr. Partition is itertools::partition_result, deliberately
not collect::<Result<Vec<_>, E>>(), which short-circuits on the first Err and
is the all-or-nothing behaviour this exists to avoid.

Flatten and FlattenErr are lazy; both have a test against a source that
throws part-way, which fails if they ever become eager. Partition enumerates
once and materialises both sides, pinned by a counting enumerable.

Flatten builds on the AsEnumerable added in 4040a24, so it is a SelectMany
rather than a fresh Where/Select pair.

The feared overload ambiguity with the existing nested-monad Flatten does not
arise: that one takes Option<Option<T>>, this one IEnumerable<Option<T>>, and
no receiver is both. A test pins the resolution for a sequence of nested
options.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>