### PR TITLE
refactor(analyzers): bring every descriptor in line with the skill

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/README.md
+++ b/sample/Waystone.Monads.Analyzers.Sample/README.md
@@ -25,7 +25,7 @@ nullable, which is what `WM1005` needs to see that a value may be null.
 
 ## Trying the code fixes
 
-Open either file in an IDE and invoke the lightbulb. Thirteen of the twenty-five rules
+Open either file in an IDE and invoke the lightbulb. Thirteen of the twenty-six rules
 offer a fix; the rest are reported without one, either because the correction is
 ambiguous (`Ok` or `Err`?) or because it changes a signature and cascades to
 callers the fix cannot see.

--- a/src/Waystone.Monads.Analyzers/DiscardedMonadAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/DiscardedMonadAnalyzer.cs
@@ -56,7 +56,7 @@ public sealed class DiscardedMonadAnalyzer : MonadAnalyzer
             Diagnostic.Create(
                 rule,
                 Semantics.NameLocationOf(invocation),
-                returned!.ToDisplayString(
-                    SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                invocation.TargetMethod.Name,
+                Semantics.Display(returned!)));
     }
 }

--- a/src/Waystone.Monads.Analyzers/NullAndDefaultAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/NullAndDefaultAnalyzer.cs
@@ -120,8 +120,7 @@ public sealed class NullAndDefaultAnalyzer : MonadAnalyzer
             Diagnostic.Create(
                 Rules.DefaultValueConvertsToNone,
                 operand.Syntax.GetLocation(),
-                valueType.ToDisplayString(
-                    SymbolDisplayFormat.MinimallyQualifiedFormat),
+                Semantics.Display(valueType),
                 operand.Syntax.ToString()));
     }
 

--- a/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
@@ -39,8 +39,7 @@ public sealed class OptionCreationAnalyzer : MonadAnalyzer
 
         var argument = invocation.Arguments[0].Value;
 
-        string type = method.TypeArguments[0]
-           .ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        string type = Semantics.Display(method.TypeArguments[0]);
 
         if (Semantics.IsDefaultValue(argument))
         {

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -10,157 +10,196 @@ public static class Rules
 
     public static readonly DiagnosticDescriptor SomeFromDefaultValue = Bug(
         "WM1001",
-        "Some cannot hold a default value",
+        "Do not pass a default value to Some",
         "'Option.Some' throws at runtime when the value equals the default of '{0}'. Use 'Option.None<{0}>()' to express the absence of a value.",
         "The constructor of Some rejects a value equal to default(T), so this call always throws an InvalidOperationException.");
 
     public static readonly DiagnosticDescriptor NullAssignedToMonad = Bug(
         "WM1002",
-        "Null assigned where an Option or Result is expected",
+        "Do not assign null to an Option or Result",
         "'{0}' is never null in correct use. Null here defeats the type and throws on the next member access.",
         "Option and Result are records, so the compiler permits null where one is expected. None and Err express absence and failure; null expresses neither.");
 
     public static readonly DiagnosticDescriptor DefaultOfMonad = Bug(
         "WM1003",
-        "The default of an Option or Result is null",
+        "Do not use the default of an Option or Result",
         "'default({0})' is null, not an empty value. Construct the absent or failed case explicitly.",
         "Option and Result are reference types, so their default is null rather than None or Err.");
 
     public static readonly DiagnosticDescriptor DefaultValueConvertsToNone = Bug(
         "WM1004",
-        "A default value converts to None",
+        "Do not convert a default value to an Option implicitly",
         "The implicit conversion maps the default of '{0}' to None, so this produces None rather than a Some holding {1}",
         "Option<T>'s implicit conversion returns None when the value equals default(T). A default value silently becomes an absent one.");
 
     public static readonly DiagnosticDescriptor PossiblyNullPassedToSome = Bug(
         "WM1005",
-        "A possibly null value is passed to Some",
+        "Prefer FromNullable over Some for a possibly null value",
         "'Option.Some' throws when this value is null. Use 'Option.FromNullable' to map null onto None.",
         "Some rejects a value equal to default(T), and the default of a reference type is null.");
 
     public static readonly DiagnosticDescriptor ResultDiscarded = Bug(
         "WM1006",
-        "The Result of this call is discarded",
-        "This call returns '{0}' and the value is unused, so a failure is silently ignored",
+        "Do not discard a Result",
+        "'{0}' returns '{1}' and the value is unused, so a failure is silently ignored",
         "A discarded Result throws nothing and reports nothing. Match on it, or propagate it to a caller that will.");
 
+    /// <remarks>
+    /// Warning severity with no code fix is deliberate, and is the exception to
+    /// the rule that the two go together: the correction rewrites the type and
+    /// cascades to every caller, which a fixer cannot see. It is earned because
+    /// both hierarchies close in v6, so the marked code stops compiling. Do not
+    /// treat it as precedent for another rule.
+    /// </remarks>
     public static readonly DiagnosticDescriptor DerivesFromMonad = Bug(
         "WM1007",
-        "A type derives from Option or Result",
+        "Do not derive from Option or Result",
         "'{0}' derives from '{1}', which has exactly two cases. Compose the monad instead of inheriting from it.",
         "Option and Result exist to have two states, and every member that switches on them handles two. A third case is invisible to Match, so it takes whichever branch the base case falls into. Both hierarchies close in v6, and a derived type will not compile against it.");
 
+    /// <remarks>
+    /// Reports alongside WM2011 on a nullable derived case such as
+    /// <c>Some&lt;int&gt;?</c>. The overlap is deliberate — both statements are
+    /// independently true and each has its own code fix — so the report is made
+    /// ahead of the early returns in <see cref="DeclaredTypeAnalyzer" /> that
+    /// would otherwise suppress one of them.
+    /// </remarks>
     public static readonly DiagnosticDescriptor NullableMonadDeclared = Bug(
         "WM1008",
-        "An Option or Result is declared nullable",
+        "Do not declare an Option or Result as nullable",
         "'{0}?' has three states where two are meaningful. Drop the annotation — '{1}' already expresses the case you are reaching for.",
-        "Option and Result are records, so the compiler accepts a nullable annotation on one. The annotation adds a third state to a type whose whole purpose is to have exactly two, and the null it admits throws on the next member access rather than being handled as an absence. This reports alongside WM2011 on a nullable derived case such as 'Some<int>?' deliberately: both statements are independently true and each has its own fix.");
+        "Option and Result are records, so the compiler accepts a nullable annotation on one. The annotation adds a third state to a type whose whole purpose is to have exactly two, and the null it admits throws on the next member access rather than being handled as an absence.");
 
+    /// <remarks>
+    /// Scoped to bool and enums with a zero member deliberately. The hazard is
+    /// general — <c>Option&lt;int&gt;</c> breaks on 0 and
+    /// <c>Option&lt;Guid&gt;</c> on <c>Guid.Empty</c> — but widening a
+    /// declaration rule to every value type would fire across code that works
+    /// today, and a Warning ships enabled to every consumer on upgrade. WM1001
+    /// and WM1004 already cover the call site that provably passes a default;
+    /// this rule covers the declaration.
+    /// </remarks>
     public static readonly DiagnosticDescriptor OptionOfZeroValuedType = Bug(
         "WM1009",
-        "Option of bool or of an enum with a zero member",
+        "Do not use Option over bool or a zero-member enum",
         "'{0}' cannot hold the default of '{1}', because 'Option.Some' throws on it. {2}.",
-        "Option.Some rejects a value equal to default(T), so an Option over a type whose zero is a meaningful value cannot represent part of its own domain. WM1001 and WM1004 catch a call site that provably passes a default; this rule catches the declaration, before anything reaches the throwing path. The scope is bool and enums with a zero member deliberately — widening it to every value type would fire on Option<int> throughout code that works today, and a Warning ships enabled to every consumer on upgrade.");
+        "Option.Some rejects a value equal to default(T), so an Option over a type whose zero is a meaningful value cannot represent part of its own domain.");
 
     public static readonly DiagnosticDescriptor UnwrapUsed = Idiom(
         "WM2001",
-        "Unwrap throws on the failure case",
+        "Prefer UnwrapOr or Match over Unwrap",
         "'{0}' throws when there is no value. Prefer 'UnwrapOr', 'UnwrapOrElse', 'UnwrapOrDefault' or 'Match'.",
         "Unwrap converts a handled absence back into an unhandled exception, which is the thing Option and Result exist to avoid.");
 
+    /// <remarks>
+    /// Separate from WM2001 so that a codebase can leave this one disabled on
+    /// its own. Expect states an invariant, which is defensible where the
+    /// invariant is genuine, and that is a different judgement from the one
+    /// WM2001 asks for.
+    /// </remarks>
     public static readonly DiagnosticDescriptor ExpectUsed = Idiom(
         "WM2002",
-        "Expect throws on the failure case",
+        "Prefer UnwrapOr or Match over Expect",
         "'{0}' throws when there is no value. Prefer 'UnwrapOr', 'UnwrapOrElse', 'UnwrapOrDefault' or 'Match'.",
-        "Expect states an invariant and throws when it does not hold. That is defensible where the invariant is genuine, which is why this rule is separate from WM2001 and can be left disabled on its own.");
+        "Expect states an invariant and throws when it does not hold, so it converts a handled absence into an unhandled exception wherever the invariant turns out not to be genuine.");
 
     public static readonly DiagnosticDescriptor ThrowInResultMember = Idiom(
         "WM2003",
-        "Throw inside a member that returns Result",
-        "This member returns '{0}', so a thrown exception bypasses the failure channel its signature promises",
+        "Do not throw from a member that returns Result",
+        "'{0}' returns '{1}', so a thrown exception bypasses the failure channel its signature promises",
         "A member returning Result declares that its failures are values. Throwing from it leaves callers with two failure mechanisms to handle.");
 
     public static readonly DiagnosticDescriptor GuardedUnwrap = Idiom(
         "WM2004",
-        "A guarded unwrap can be a Match",
+        "Prefer Match over a guarded unwrap",
         "The '{0}' check and the unwrap inside it duplicate the same test. 'Match' or 'Inspect' expresses both branches once.",
         "Checking IsSome and then unwrapping asks the same question twice and relies on the reader to see that the answers agree.");
 
     public static readonly DiagnosticDescriptor MapThenFlatten = Idiom(
         "WM2005",
-        "Map followed by Flatten is AndThen",
+        "Prefer AndThen over Map followed by Flatten",
         "'Map' followed by 'Flatten' is 'AndThen'",
-        "AndThen exists for this composition and avoids materialising the nested monad.");
+        "AndThen exists for this composition and avoids materialising the nested monad.",
+        WellKnownDiagnosticTags.Unnecessary);
 
     public static readonly DiagnosticDescriptor CheckCombinedWithUnwrap = Idiom(
         "WM2006",
-        "A check combined with an unwrap can be IsSomeAnd",
+        "Prefer IsSomeAnd over a check combined with an unwrap",
         "'{0}' combined with an unwrap of the same instance is '{1}'",
         "IsSomeAnd, IsNoneOr, IsOkAnd and IsErrAnd take the predicate and supply the value, removing the unwrap.");
 
     public static readonly DiagnosticDescriptor UnwrapOrWithDefault = Idiom(
         "WM2007",
-        "UnwrapOr with a default is UnwrapOrDefault",
+        "Prefer UnwrapOrDefault over UnwrapOr with a default",
         "'UnwrapOr' given the default of '{0}' is 'UnwrapOrDefault'",
         "UnwrapOrDefault states the intent directly and does not repeat the type.");
 
     public static readonly DiagnosticDescriptor MonadComparedToNull = Idiom(
         "WM2008",
-        "An Option or Result is compared to null",
+        "Do not compare an Option or Result to null",
         "'{0}' is never null in correct use, so this comparison tests the wrong thing. Use '{1}'.",
         "A null check on an Option or Result reads as an absence check but is not one. The absent case is None, and the failed case is Err.");
 
     public static readonly DiagnosticDescriptor NestedOption = Idiom(
         "WM2009",
-        "A nested Option carries no more information than a flat one",
+        "Flatten a nested Option",
         "'{0}' has three states where two are meaningful. Flatten it.",
         "Option<Option<T>> distinguishes an absent outer from an absent inner, a distinction callers almost never act on.");
 
     public static readonly DiagnosticDescriptor ResultWithIdenticalTypeArguments = Idiom(
         "WM2010",
-        "Result with identical type arguments cannot convert implicitly",
+        "Do not give a Result identical type arguments",
         "'{0}' has the same type for its Ok and its Err, which makes both implicit conversions ambiguous",
         "Result declares an implicit conversion from TOk and another from TErr. When those are the same type the compiler cannot choose, so every implicit conversion becomes a compile error and Ok and Err become indistinguishable to a reader.");
 
     public static readonly DiagnosticDescriptor DerivedMonadTypeDeclared = Idiom(
         "WM2011",
-        "Declare the Option or Result base rather than one of its cases",
+        "Prefer the Option or Result base over one of its cases",
         "'{0}' names one case of '{1}'. Declare '{1}' so both cases are representable.",
         "A declaration naming Some, None, Ok or Err can only hold one of the two states, which defeats the point of the type.");
 
     public static readonly DiagnosticDescriptor NullableMemberAlongsideMonads = Idiom(
         "WM2012",
-        "A nullable member sits alongside Option or Result members",
+        "Do not mix nullable members with Option or Result members",
         "'{0}' returns a nullable type while '{1}' expresses absence through '{2}'. Two conventions for absence in one type leaves callers guessing which applies.",
         "This type has already adopted Option or Result. A nullable return here is a second, weaker way of saying the same thing.");
 
     public static readonly DiagnosticDescriptor OptionDiscarded = Idiom(
         "WM2013",
-        "The Option of this call is discarded",
-        "This call returns '{0}' and the value is unused, so the call has no observable effect beyond its side effects",
+        "Do not discard an Option",
+        "'{0}' returns '{1}' and the value is unused, so the call has no observable effect beyond its side effects",
         "Discarding an Option is less harmful than discarding a Result, but it is usually a sign the return value was meant to be handled.");
 
     public static readonly DiagnosticDescriptor RenamedToAndThen = Idiom(
         "WM2014",
-        "FlatMap has been renamed to AndThen",
+        "Prefer AndThen over the obsolete FlatMap",
         "'{0}' is obsolete and will be removed in v6. Use '{1}'.",
         "Rust names this operation and_then, and Result already spelled it AndThen. FlatMap remains only as a forwarding member until the next major version.");
 
+    /// <remarks>
+    /// Points the opposite way to WM2007 for a value type, deliberately: that
+    /// rule removes a repeated type from UnwrapOr, this one asks whether the
+    /// default was meant as a value. Both inform rather than warn so the
+    /// context around each is surfaced and the caller decides. Applying
+    /// WM2007's code fix therefore produces code this rule reports, which
+    /// <c>CodeFixTests.ReplacesUnwrapOrOfADefaultWithUnwrapOrDefault</c>
+    /// asserts in its fixed state rather than hides.
+    /// </remarks>
     public static readonly DiagnosticDescriptor OrDefaultOnAValueType = Idiom(
         "WM2015",
-        "OrDefault on a value type cannot express the absent case",
+        "Prefer UnwrapOrNull over UnwrapOrDefault on a value type",
         "'{0}' hands back the default of '{1}' when there is no value, which is indistinguishable from a real one. '{2}' returns null instead.",
-        "T? on a type parameter constrained only to notnull is an annotation, not a Nullable<T>, so for a value type UnwrapOrDefault and MapOrDefault return 0, false or default(Guid) for the absent case. That is legitimate where the caller genuinely wants the default, which is why this rule informs rather than warns. It does not contradict WM2007: that rule removes a repeated type from UnwrapOr, and this one asks whether the default was meant as a value.");
+        "T? on a type parameter constrained only to notnull is an annotation rather than a Nullable<T>, so for a value type UnwrapOrDefault and MapOrDefault return 0, false or default(Guid) for the absent case. That is legitimate where the caller genuinely wants the default.");
 
     public static readonly DiagnosticDescriptor NullableReturnCouldBeOption = Migration(
         "WM3001",
-        "A nullable return could be an Option",
+        "Prefer an Option over a nullable return",
         "'{0}' returns '{1}'. An 'Option<{2}>' makes the absent case impossible to ignore.",
         "Disabled by default. Enable it while migrating a codebase onto Option; it fires on every nullable-returning member, not only those already using the library.");
 
     public static readonly DiagnosticDescriptor ThrowCouldBeResult = Migration(
         "WM3002",
-        "A throw could be a Result",
+        "Prefer a Result over a throw",
         "This throw makes a failure invisible in the signature of '{0}'. A 'Result<TOk, Error>' return states it.",
         "Disabled by default. Enable it while migrating a codebase onto Result; it fires on every throw statement, including those a Result would not improve.");
 

--- a/src/Waystone.Monads.Analyzers/ThrowAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/ThrowAnalyzer.cs
@@ -69,6 +69,7 @@ public sealed class ThrowAnalyzer : MonadAnalyzer
                 Diagnostic.Create(
                     Rules.ThrowInResultMember,
                     thrown.Syntax.GetLocation(),
+                    member.Name,
                     Semantics.Display(returned!)));
 
             return;

--- a/test/Waystone.Monads.Analyzers.Tests/DiscardedMonadAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/DiscardedMonadAnalyzerTests.cs
@@ -18,7 +18,7 @@ public class DiscardedMonadAnalyzerTests
             """,
             Verify.Diagnostic(Rules.ResultDiscarded)
                .WithLocation(0)
-               .WithArguments("Result<int, string>"));
+               .WithArguments("Save", "Result<int, string>"));
 
     [Fact]
     public Task FlagsADiscardedOptionAtItsOwnSeverity() =>
@@ -33,7 +33,7 @@ public class DiscardedMonadAnalyzerTests
             """,
             Verify.Diagnostic(Rules.OptionDiscarded)
                .WithLocation(0)
-               .WithArguments("Option<int>"));
+               .WithArguments("Find", "Option<int>"));
 
     [Fact]
     public Task FlagsADiscardedAwaitedResult() =>
@@ -49,7 +49,7 @@ public class DiscardedMonadAnalyzerTests
             """,
             Verify.Diagnostic(Rules.ResultDiscarded)
                .WithLocation(0)
-               .WithArguments("Result<int, string>"));
+               .WithArguments("SaveAsync", "Result<int, string>"));
 
     [Fact]
     public Task IgnoresAnExplicitDiscard() =>
@@ -99,5 +99,5 @@ public class DiscardedMonadAnalyzerTests
             """,
             Verify.Diagnostic(Rules.ResultDiscarded)
                .WithLocation(0)
-               .WithArguments("Result<int, string>"));
+               .WithArguments("SaveAsync", "Result<int, string>"));
 }

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -47,6 +47,18 @@ public class RulesTests
                 "https://draekien-industries.wpei.me/using-the-library/analyzer-rules#"
               + id.ToLowerInvariant());
 
+    [Theory]
+    [MemberData(nameof(AllRules))]
+    public void EveryTitleFitsAnErrorListColumn(string id) =>
+        Rule(id).Title.ToString().Length.ShouldBeLessThanOrEqualTo(60);
+
+    [Theory]
+    [MemberData(nameof(MigrationRules))]
+    public void MigrationDescriptionsSayTheyAreOff(string id) =>
+        Rule(id)
+           .Description.ToString()
+           .ShouldStartWith("Disabled by default.");
+
     [Fact]
     public void EveryTierIsPopulated()
     {

--- a/test/Waystone.Monads.Analyzers.Tests/ThrowAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/ThrowAnalyzerTests.cs
@@ -16,7 +16,7 @@ public class ThrowAnalyzerTests
             """,
             Verify.Diagnostic(Rules.ThrowInResultMember)
                .WithLocation(0)
-               .WithArguments("Result<int, string>"));
+               .WithArguments("Parse", "Result<int, string>"));
 
     [Fact]
     public Task FlagsAThrowInAnAsyncResultReturningMember() =>
@@ -30,7 +30,7 @@ public class ThrowAnalyzerTests
             """,
             Verify.Diagnostic(Rules.ThrowInResultMember)
                .WithLocation(0)
-               .WithArguments("Result<int, string>"));
+               .WithArguments("ParseAsync", "Result<int, string>"));
 
     [Fact]
     public Task IgnoresArgumentValidation() =>


### PR DESCRIPTION
No rule changes tier, severity or enablement, so there is no release row —
the skill wants those in Unshipped.md and none is warranted. Shipped.md keeps
the titles the shipped versions actually carried, because that table is
history and is never edited.

Titles. The skill's shape is an expectation of the code, the way the CA corpus
reads, so all 26 changed: "Do not ..." for a prohibition, "Prefer X over Y"
for a replacement, an imperative for a transformation. WM1002's old title is
the skill's own example of the poor form. WM2010 and WM2011 were also over the
60-character ceiling, which is now a test rather than a review note.

Messages. Only three changed, per the gotcha that a shipped message is
reworded only when the old one was wrong. WM1006, WM2013 and WM2003 opened
with "This call" or "This member" and left the reader to find which one — the
exact failure the skill names, with WM1006's old text quoted there. Each now
takes the member name as {0}. Every other message is untouched.

Descriptions. The skill scopes these to a consumer seeing the diagnostic for
the first time, so reasoning aimed at the next author moved to XML doc
comments on the fields: WM1007's severity trade-off, WM1008's deliberate
WM2011 overlap, WM1009's scope limit, WM2002's independence from WM2001, and
WM2015's opposition to WM2007. The descriptions left behind explain why the
compiler permits the mistake, and nothing else.

Tags. Exactly one rule earns one. WM2005's fix deletes the Flatten call its
diagnostic is located on, so Unnecessary is true and an IDE should fade it.
Every other fix renames or substitutes rather than removes, and the skill says
not to pass a tag that does not apply — so none do.

Placeholders. Three sites used ToDisplayString directly and now go through
Semantics.Display. A fourth, WM3001, was reverted: Display strips the nullable
annotation, and that rule's whole subject is that the return is nullable, so
it needs 'string?' where the others do not. Its test caught this.

Two new guards: a title-length assertion and one requiring every WM3
description to open with "Disabled by default.".

Also fixes the sample README's rule count, which has said one fewer than the
truth since WM1007 landed without bumping it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>