### PR TITLE
ci: drop the base branch filter so mid-stack checks run

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,8 +8,6 @@ concurrency:
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'src/**'
       - 'test/**'


### PR DESCRIPTION
## What

Removes `branches: main` from the `Pull Request` workflow trigger.

## Why

GitHub's documentation says a stacked pull request triggers [*"as if each pull request in the stack targets the base of the stack"*](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests), and that *"no workflow changes are required"*.

That did not hold. Submitting stack #68 ran `Build and run tests` on the bottom pull request only. The eight mid-stack pull requests received `CodeQL` and dependency submission — neither of which filters on a base branch — but no build or test check, leaving them mergeable with nothing verifying them.

Dropping the filter costs nothing for an ordinary pull request against `main` and is what a stack needs.

## Verification

This pull request exercises the change, since it matches its own paths filter. Stack #68 will be rebased onto this and its checks re-triggered.

No public API surface changes, so no paired documentation pull request.