### PR TITLE
chore(analyzers): file every new rule under the one version that ships

### DIFF
--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -35,36 +35,8 @@ WM3002 | Design | Disabled | A throw could be a Result
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-WM2014 | Usage | Info | FlatMap has been renamed to AndThen
-
-## Release 5.6.0
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
 WM1007 | Reliability | Warning | A type derives from Option or Result
-
-## Release 5.7.0
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
 WM1008 | Reliability | Warning | An Option or Result is declared nullable
-
-## Release 5.8.0
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
 WM1009 | Reliability | Warning | Option of bool or of an enum with a zero member
-
-## Release 5.10.0
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
+WM2014 | Usage | Info | FlatMap has been renamed to AndThen
 WM2015 | Usage | Info | OrDefault on a value type cannot express the absent case


### PR DESCRIPTION
The stack merges atomically, so all ten pull requests land on main in a
single push and release.yml runs once. GitVersion takes one minor bump
from v5.3.0 across the whole set, which makes 5.4.0 the only version
published and the release blocks for 5.6.0, 5.7.0, 5.8.0 and 5.10.0
versions that will never exist.

Collapse them into the 5.4.0 block, ordered by rule id. The 5.3.0 block
is untouched: it is already published.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>