### PR TITLE
docs: record the stacked-PR CI traps and the WM3001 display exception

### DIFF
--- a/.claude/skills/writing-diagnostic-descriptors/SKILL.md
+++ b/.claude/skills/writing-diagnostic-descriptors/SKILL.md
@@ -172,6 +172,15 @@ Fill type and member placeholders through `Semantics.Display`, not
 annotation, so messages read `Option<int>` rather than a fully-qualified name
 with a stray `?`.
 
+**A rule whose message is *about* nullability is the exception.** `WM3001` reports
+a nullable return, so the annotation is the payload rather than noise —
+`Semantics.Display` strips it and the message reads `string` where it has to read
+`string?`. `NullableReturnAnalyzer` fills that placeholder with
+`returned.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)` directly
+and reserves `Semantics.Display` for the non-nullable form it suggests. Reach for
+`ToDisplayString` only when you can say which part of the message would otherwise
+be lost; a preference for the longer name is not a reason.
+
 ## Custom tags
 
 All three factories take `params string[] tags` and forward them to the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,16 @@ in one package implies nothing about the others.
 **The commit type determines the published version.** GitVersion parses commit
 subjects, so `feat` bumps minor, `fix` and `perf` bump patch, and a `!` before
 the colon forces a major bump on *any* type. PRs are squash-merged, so the PR
-title becomes the version-determining subject — a `!` in a PR title ships a
+title becomes a version-determining subject — a `!` in a PR title ships a
 major release. Use `!` only when something is actually being removed.
+
+**A stack contributes every one of its PR titles.** `gh stack merge` squashes each
+PR in the stack separately, so an eleven-PR stack lands eleven commits and
+GitVersion reads all eleven subjects. It applies one increment for the highest bump
+among them, so ten `feat` commits give a single minor bump rather than ten. The trap
+runs the other way: a `!` in *any* title in the stack takes the whole release major,
+including a mid-stack PR nobody was thinking of as the release. Read the titles
+together before merging, not one at a time as you open them.
 
 **Deprecate; never remove.** Public API is obsoleted with a message naming both
 its replacement and the version that removes it, and removed only in the next
@@ -144,6 +152,28 @@ its code fix produced `option is Option.None<int>()`, which does not compile.
 everywhere, so a rule that unwraps the inner call's type goes quiet on exactly the
 style the library teaches. Read `IAwaitOperation.Type` instead when there is an
 await.
+
+**A `branches` filter on `pull_request` stops mid-stack checks, whatever the docs
+say.** GitHub's stacked-pull-request documentation states that workflows trigger as
+if each PR in the stack targeted the base of the stack, and that no workflow changes
+are required. That is not what happens. With `branches: [main]` on the trigger, only
+the bottom PR of an eleven-PR stack ran build and test — the other ten target their
+parent branch and were filtered out. The filter is gone from `pull-request.yml` and
+should not come back. Since the checks are required by the `main` ruleset, a PR that
+never ran one can never satisfy it, so this blocks the entire stack rather than
+failing visibly.
+
+**A stack cancels its own checks without a per-PR concurrency group.** `gh stack
+submit` pushes every branch at once. A `concurrency.group` that does not vary by PR
+puts all of them in one group, and `cancel-in-progress` then kills every run but the
+last to start. The group is keyed on `github.event.pull_request.number` for that
+reason.
+
+**`codecov/patch` counts every line the diff touches, not the lines that added
+logic.** Stripping a nullable annotation across a dozen untested async overloads
+puts all of their untested lines in the patch, so a change that added no behaviour
+at all fails the check. It is a required check, so it blocks the merge. Close the
+test gap rather than moving the threshold — the gap it found in 5.4.0 was real.
 
 **Move the release-tracking row to `Shipped.md` before merging, not after.**
 Merging publishes, and there is no separate release step that would move it later,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,16 @@ puts all of their untested lines in the patch, so a change that added no behavio
 at all fails the check. It is a required check, so it blocks the merge. Close the
 test gap rather than moving the threshold — the gap it found in 5.4.0 was real.
 
+**A PR that touches no filtered path cannot satisfy the required checks.** The
+`main` ruleset requires `codecov/patch`, `Calculate Version` and `Build and run
+tests`, and all three come from `pull-request.yml`, which has a `paths` filter. A
+documentation-only PR matches nothing in it, so the workflow never runs, the three
+checks never report, and the PR sits `BLOCKED` with nothing pending to wait for.
+The ruleset grants `OrganizationAdmin` a standing bypass, so these land with
+`gh pr merge --admin`. That is the accepted trade rather than an oversight —
+widening the filter would run the five-framework matrix over prose. Do not wait on
+checks for a docs-only PR; nothing is coming.
+
 **Move the release-tracking row to `Shipped.md` before merging, not after.**
 Merging publishes, and there is no separate release step that would move it later,
 so a row left in `Unshipped.md` is wrong from the moment the PR lands. File it


### PR DESCRIPTION
Closes DRA-80 and DRA-79.

Nothing here touches `src/**`, so no publish and no paired docs-repo PR.

## What and why

**The stacked-PR CI traps (DRA-80).** Three things cost real time shipping 5.4.0 and none were written down:

- A `branches` filter on the `pull_request` trigger gates mid-stack PRs. GitHub's stacked-PR documentation states the opposite — that workflows fire as if each PR targeted the base of the stack, and that no workflow changes are required. Only the bottom PR of the eleven ran build and test. The failure mode is nasty: the checks are required by the `main` ruleset, so a PR that never ran one can never satisfy it, and the stack sits blocked with nothing showing as failed.
- A `concurrency.group` that does not vary by PR makes a submitted stack cancel its own checks, because `gh stack submit` pushes every branch in the same second.
- `codecov/patch` counts every line a diff *touches*, not the lines that added logic. Stripping a nullable annotation across a dozen untested async overloads failed a required check on a change containing no behaviour.

**A versioning correction.** The Conventions section said "the PR title becomes the version-determining subject", singular. `gh stack merge` squashes each PR separately, so GitVersion reads every title in the stack and applies one increment for the highest bump among them. Ten `feat` titles gave one minor bump. The trap is the other direction — a `!` in any mid-stack title would have taken the whole release major.

**The WM3001 display exception (DRA-79).** The descriptor skill says to fill placeholders through `Semantics.Display`. WM3001 cannot: it reports a nullable return, so stripping the annotation strips the point of the message. `NullableReturnAnalyzer` already uses `ToDisplayString` there deliberately; the skill now says so, with a test for when the exception applies rather than a blanket escape hatch.

## Verification

Documentation only — no code, no tests, no public surface. The claims about the workflow behaviour are from the 5.4.0 stack itself: eleven PRs, one build-and-test run before the filter came off and eleven after.