### PR TITLE
fix: stop Try logging a working value, and reject null in Ok and Err

### DIFF
--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -37,9 +37,11 @@ public static class Option
     /// A <see cref="None{T}" /> is returned both when the factory throws and
     /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
     /// thrown case is reported to the exception logger configured on
-    /// <see cref="MonadOptions" />. Which values a <see cref="Some{T}" /> can
-    /// hold is decided by the implicit conversion to <see cref="Option{T}" />
-    /// rather than tested here, so the two cannot disagree.
+    /// <see cref="MonadOptions" />, because the implicit conversion to
+    /// <see cref="Option{T}" /> decides which values a <see cref="Some{T}" />
+    /// can hold and returns <see cref="None{T}" /> rather than throwing. That
+    /// conversion is applied inside the try, so the two cannot disagree and
+    /// nothing it throws escapes.
     /// </remarks>
     public static Option<T> Try<T>(
         Func<T> factory,
@@ -49,11 +51,9 @@ public static class Option
         string callerArgumentExpression = "")
         where T : notnull
     {
-        T value;
-
         try
         {
-            value = factory();
+            return factory();
         }
         catch (Exception ex)
         {
@@ -64,8 +64,6 @@ public static class Option
             MonadOptions.Current.Log(ex, caller);
             return None<T>();
         }
-
-        return value;
     }
 
     /// <summary>
@@ -124,9 +122,11 @@ public static class Option
     /// A <see cref="None{T}" /> is returned both when the factory throws and
     /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
     /// thrown case is reported to the exception logger configured on
-    /// <see cref="MonadOptions" />. Which values a <see cref="Some{T}" /> can
-    /// hold is decided by the implicit conversion to <see cref="Option{T}" />
-    /// rather than tested here, so the two cannot disagree.
+    /// <see cref="MonadOptions" />, because the implicit conversion to
+    /// <see cref="Option{T}" /> decides which values a <see cref="Some{T}" />
+    /// can hold and returns <see cref="None{T}" /> rather than throwing. That
+    /// conversion is applied inside the try, so the two cannot disagree and
+    /// nothing it throws escapes.
     /// </remarks>
     public static async Task<Option<T>> TryAsync<T>(
         Func<Task<T>> asyncFactory,
@@ -135,11 +135,9 @@ public static class Option
         [CallerArgumentExpression(nameof(asyncFactory))]
         string callerArgumentExpression = "") where T : notnull
     {
-        T value;
-
         try
         {
-            value = await asyncFactory();
+            return await asyncFactory();
         }
         catch (Exception ex)
         {
@@ -150,8 +148,6 @@ public static class Option
             MonadOptions.Current.Log(ex, caller);
             return None<T>();
         }
-
-        return value;
     }
 
     /// <summary>Creates a <see cref="Some{T}" /></summary>

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -30,9 +30,15 @@ public static class Option
     /// </param>
     /// <typeparam name="T">The factory return value's type</typeparam>
     /// <returns>
-    /// A <see cref="Some{T}" /> if the factory executes successfully,
-    /// otherwise a <see cref="None{T}" />
+    /// A <see cref="Some{T}" /> if the factory produces a value that a
+    /// <see cref="Some{T}" /> can hold, otherwise a <see cref="None{T}" />.
     /// </returns>
+    /// <remarks>
+    /// A <see cref="None{T}" /> is returned both when the factory throws and
+    /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
+    /// thrown case is reported to the exception logger configured on
+    /// <see cref="MonadOptions" />.
+    /// </remarks>
     public static Option<T> Try<T>(
         Func<T> factory,
         [CallerMemberName] string callerMemberName = "",
@@ -41,10 +47,11 @@ public static class Option
         string callerArgumentExpression = "")
         where T : notnull
     {
+        T value;
+
         try
         {
-            T value = factory();
-            return Some(value);
+            value = factory();
         }
         catch (Exception ex)
         {
@@ -55,6 +62,8 @@ public static class Option
             MonadOptions.Current.Log(ex, caller);
             return None<T>();
         }
+
+        return Equals(value, default(T)) ? None<T>() : Some(value);
     }
 
     /// <summary>
@@ -73,8 +82,8 @@ public static class Option
     /// </param>
     /// <typeparam name="T">The async factory return type</typeparam>
     /// <returns>
-    /// A <see cref="Some{T}" /> if the factory succeeds, otherwise a
-    /// <see cref="None{T}" />
+    /// A <see cref="Some{T}" /> if the factory produces a value that a
+    /// <see cref="Some{T}" /> can hold, otherwise a <see cref="None{T}" />.
     /// </returns>
     [Obsolete(
         "Use TryAsync instead. This overload will be removed in v6 of Waystone.Monads.")]
@@ -106,9 +115,15 @@ public static class Option
     /// </param>
     /// <typeparam name="T">The async factory return type</typeparam>
     /// <returns>
-    /// A <see cref="Some{T}" /> if the factory succeeds, otherwise a
-    /// <see cref="None{T}" />
+    /// A <see cref="Some{T}" /> if the factory produces a value that a
+    /// <see cref="Some{T}" /> can hold, otherwise a <see cref="None{T}" />.
     /// </returns>
+    /// <remarks>
+    /// A <see cref="None{T}" /> is returned both when the factory throws and
+    /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
+    /// thrown case is reported to the exception logger configured on
+    /// <see cref="MonadOptions" />.
+    /// </remarks>
     public static async Task<Option<T>> TryAsync<T>(
         Func<Task<T>> asyncFactory,
         [CallerMemberName] string callerMemberName = "",
@@ -116,10 +131,11 @@ public static class Option
         [CallerArgumentExpression(nameof(asyncFactory))]
         string callerArgumentExpression = "") where T : notnull
     {
+        T value;
+
         try
         {
-            T value = await asyncFactory();
-            return Some(value);
+            value = await asyncFactory();
         }
         catch (Exception ex)
         {
@@ -130,6 +146,8 @@ public static class Option
             MonadOptions.Current.Log(ex, caller);
             return None<T>();
         }
+
+        return Equals(value, default(T)) ? None<T>() : Some(value);
     }
 
     /// <summary>Creates a <see cref="Some{T}" /></summary>

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -37,7 +37,9 @@ public static class Option
     /// A <see cref="None{T}" /> is returned both when the factory throws and
     /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
     /// thrown case is reported to the exception logger configured on
-    /// <see cref="MonadOptions" />.
+    /// <see cref="MonadOptions" />. Which values a <see cref="Some{T}" /> can
+    /// hold is decided by the implicit conversion to <see cref="Option{T}" />
+    /// rather than tested here, so the two cannot disagree.
     /// </remarks>
     public static Option<T> Try<T>(
         Func<T> factory,
@@ -63,7 +65,7 @@ public static class Option
             return None<T>();
         }
 
-        return Equals(value, default(T)) ? None<T>() : Some(value);
+        return value;
     }
 
     /// <summary>
@@ -122,7 +124,9 @@ public static class Option
     /// A <see cref="None{T}" /> is returned both when the factory throws and
     /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
     /// thrown case is reported to the exception logger configured on
-    /// <see cref="MonadOptions" />.
+    /// <see cref="MonadOptions" />. Which values a <see cref="Some{T}" /> can
+    /// hold is decided by the implicit conversion to <see cref="Option{T}" />
+    /// rather than tested here, so the two cannot disagree.
     /// </remarks>
     public static async Task<Option<T>> TryAsync<T>(
         Func<Task<T>> asyncFactory,
@@ -147,7 +151,7 @@ public static class Option
             return None<T>();
         }
 
-        return Equals(value, default(T)) ? None<T>() : Some(value);
+        return value;
     }
 
     /// <summary>Creates a <see cref="Some{T}" /></summary>

--- a/src/Waystone.Monads/Results/Err.cs
+++ b/src/Waystone.Monads/Results/Err.cs
@@ -19,6 +19,13 @@ public sealed record Err<TOk, TErr> : Result<TOk, TErr>
 {
     internal Err(TErr value)
     {
+        if (value is null)
+        {
+            throw new ArgumentNullException(
+                nameof(value),
+                "The value of an `Err` result cannot be null.");
+        }
+
         Value = value;
     }
 

--- a/src/Waystone.Monads/Results/Ok.cs
+++ b/src/Waystone.Monads/Results/Ok.cs
@@ -18,6 +18,13 @@ public sealed record Ok<TOk, TErr> : Result<TOk, TErr>
 {
     internal Ok(TOk value)
     {
+        if (value is null)
+        {
+            throw new ArgumentNullException(
+                nameof(value),
+                "The value of an `Ok` result cannot be null.");
+        }
+
         Value = value;
     }
 

--- a/src/Waystone.Monads/Results/Result.cs
+++ b/src/Waystone.Monads/Results/Result.cs
@@ -188,7 +188,6 @@ public static class Result
         string parameterName) =>
         new(parameterName, "The factory returned null.");
 
-
     /// <summary>
     /// Creates an <see cref="Ok{TOk,TErr}" /> result containing the provided
     /// value.

--- a/src/Waystone.Monads/Results/Result.cs
+++ b/src/Waystone.Monads/Results/Result.cs
@@ -48,6 +48,16 @@ public static class Result
     /// no stack trace, and only the thrown case is reported to the exception
     /// logger configured on <see cref="MonadOptions" />.
     /// </remarks>
+    /// <remarks>
+    /// The null test is made here rather than left to
+    /// <see cref="Ok{TOk,TErr}" />'s own guard, which would throw. This method
+    /// exists so a caller learns whether a workable value came back without
+    /// having to guard the call, so the guard's exception has to become an
+    /// <see cref="Err{TOk,TErr}" /> instead. That is the opposite of
+    /// <c>Option.Try</c>, which delegates because the conversion it
+    /// delegates to returns a <see cref="Options.None{T}" /> rather than
+    /// throwing.
+    /// </remarks>
     public static Result<TOk, TErr> Try<TOk, TErr>(
         Func<TOk> factory,
         Func<Exception, TErr> onError,
@@ -153,6 +163,16 @@ public static class Result
     /// no stack trace, and only the thrown case is reported to the exception
     /// logger configured on <see cref="MonadOptions" />.
     /// </remarks>
+    /// <remarks>
+    /// The null test is made here rather than left to
+    /// <see cref="Ok{TOk,TErr}" />'s own guard, which would throw. This method
+    /// exists so a caller learns whether a workable value came back without
+    /// having to guard the call, so the guard's exception has to become an
+    /// <see cref="Err{TOk,TErr}" /> instead. That is the opposite of
+    /// <c>Option.Try</c>, which delegates because the conversion it
+    /// delegates to returns a <see cref="Options.None{T}" /> rather than
+    /// throwing.
+    /// </remarks>
     public static async Task<Result<TOk, TErr>> TryAsync<TOk, TErr>(
         Func<Task<TOk>> asyncFactory,
         Func<Exception, TErr> onError,
@@ -193,6 +213,11 @@ public static class Result
     /// value.
     /// </summary>
     /// <param name="value">The value of the result type.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is null. An <see cref="Ok{TOk,TErr}" /> cannot
+    /// hold null, matching the <c>notnull</c> constraint on
+    /// <typeparamref name="TOk" />.
+    /// </exception>
     public static Result<TOk, TErr> Ok<TOk, TErr>(TOk value)
         where TOk : notnull
         where TErr : notnull =>
@@ -203,6 +228,11 @@ public static class Result
     /// value.
     /// </summary>
     /// <param name="value">The value of the result type.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is null. An <see cref="Err{TOk,TErr}" /> cannot
+    /// hold null, matching the <c>notnull</c> constraint on
+    /// <typeparamref name="TErr" />.
+    /// </exception>
     public static Result<TOk, TErr> Err<TOk, TErr>(TErr value)
         where TOk : notnull
         where TErr : notnull =>
@@ -284,6 +314,9 @@ public static class Result
     /// </summary>
     /// <param name="value">The value of the result type.</param>
     /// <typeparam name="TOk">The ok result value's type</typeparam>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is null.
+    /// </exception>
     public static Result<TOk, Error> Ok<TOk>(TOk value)
         where TOk : notnull =>
         new Ok<TOk, Error>(value);
@@ -294,6 +327,9 @@ public static class Result
     /// </summary>
     /// <param name="error">The error contained in the result.</param>
     /// <typeparam name="TOk">The ok result value's type</typeparam>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="error" /> is null.
+    /// </exception>
     public static Result<TOk, Error> Err<TOk>(Error error)
         where TOk : notnull =>
         new Err<TOk, Error>(error);

--- a/src/Waystone.Monads/Results/Result.cs
+++ b/src/Waystone.Monads/Results/Result.cs
@@ -37,9 +37,17 @@ public static class Result
     /// <typeparam name="TOk">The factory method return value's type</typeparam>
     /// <typeparam name="TErr">The error handler return value's type</typeparam>
     /// <returns>
-    /// An <see cref="Ok{TOk,TErr}" /> if the factory executes successfully,
-    /// otherwise a <see cref="Err{TOk,TErr}" />
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
+    /// <remarks>
+    /// An <see cref="Err{TOk,TErr}" /> is returned both when the factory throws
+    /// and when it returns null, and <paramref name="onError" /> is invoked in
+    /// either case. A factory that returns null is handed an
+    /// <see cref="ArgumentNullException" /> that was never thrown, so it carries
+    /// no stack trace, and only the thrown case is reported to the exception
+    /// logger configured on <see cref="MonadOptions" />.
+    /// </remarks>
     public static Result<TOk, TErr> Try<TOk, TErr>(
         Func<TOk> factory,
         Func<Exception, TErr> onError,
@@ -49,9 +57,11 @@ public static class Result
         string callerArgumentExpression = "")
         where TOk : notnull where TErr : notnull
     {
+        TOk value;
+
         try
         {
-            return Ok<TOk, TErr>(factory());
+            value = factory();
         }
         catch (Exception ex)
         {
@@ -62,6 +72,10 @@ public static class Result
             MonadOptions.Current.Log(ex, caller);
             return Err<TOk, TErr>(onError(ex));
         }
+
+        return value is null
+            ? Err<TOk, TErr>(onError(FactoryReturnedNull(nameof(factory))))
+            : Ok<TOk, TErr>(value);
     }
 
     /// <summary>
@@ -86,8 +100,8 @@ public static class Result
     /// <typeparam name="TOk">The factory method return value's type</typeparam>
     /// <typeparam name="TErr">The error handler return value's type</typeparam>
     /// <returns>
-    /// An <see cref="Ok{TOk,TErr}" /> if the factory executes successfully,
-    /// otherwise a <see cref="Err{TOk,TErr}" />
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
     [Obsolete(
         "Use TryAsync instead. This overload will be removed in v6 of Waystone.Monads.")]
@@ -128,9 +142,17 @@ public static class Result
     /// <typeparam name="TOk">The factory method return value's type</typeparam>
     /// <typeparam name="TErr">The error handler return value's type</typeparam>
     /// <returns>
-    /// An <see cref="Ok{TOk,TErr}" /> if the factory executes successfully,
-    /// otherwise a <see cref="Err{TOk,TErr}" />
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
+    /// <remarks>
+    /// An <see cref="Err{TOk,TErr}" /> is returned both when the factory throws
+    /// and when it returns null, and <paramref name="onError" /> is invoked in
+    /// either case. A factory that returns null is handed an
+    /// <see cref="ArgumentNullException" /> that was never thrown, so it carries
+    /// no stack trace, and only the thrown case is reported to the exception
+    /// logger configured on <see cref="MonadOptions" />.
+    /// </remarks>
     public static async Task<Result<TOk, TErr>> TryAsync<TOk, TErr>(
         Func<Task<TOk>> asyncFactory,
         Func<Exception, TErr> onError,
@@ -140,9 +162,11 @@ public static class Result
         string callerArgumentExpression = "")
         where TOk : notnull where TErr : notnull
     {
+        TOk value;
+
         try
         {
-            return Ok<TOk, TErr>(await asyncFactory());
+            value = await asyncFactory();
         }
         catch (Exception ex)
         {
@@ -153,7 +177,16 @@ public static class Result
             MonadOptions.Current.Log(ex, caller);
             return Err<TOk, TErr>(onError(ex));
         }
+
+        return value is null
+            ? Err<TOk, TErr>(
+                onError(FactoryReturnedNull(nameof(asyncFactory))))
+            : Ok<TOk, TErr>(value);
     }
+
+    private static ArgumentNullException FactoryReturnedNull(
+        string parameterName) =>
+        new(parameterName, "The factory returned null.");
 
 
     /// <summary>
@@ -194,8 +227,8 @@ public static class Result
     /// </param>
     /// <typeparam name="TOk">The factory method return value's type</typeparam>
     /// <returns>
-    /// An <see cref="Ok{TOk,TErr}" /> if the factory executes successfully,
-    /// otherwise a <see cref="Err{TOk,TErr}" />
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
     public static Result<TOk, Error> Try<TOk>(
         Func<TOk> factory,
@@ -229,8 +262,8 @@ public static class Result
     /// </param>
     /// <typeparam name="TOk">The factory method return value's type</typeparam>
     /// <returns>
-    /// An <see cref="Ok{TOk,TErr}" /> if the factory executes successfully,
-    /// otherwise a <see cref="Err{TOk,TErr}" />
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
     public static Task<Result<TOk, Error>> TryAsync<TOk>(
         Func<Task<TOk>> asyncFactory,

--- a/src/Waystone.Monads/Results/ResultOfTOkTErr.cs
+++ b/src/Waystone.Monads/Results/ResultOfTOkTErr.cs
@@ -371,6 +371,11 @@ public abstract record Result<TOk, TErr>
     /// </summary>
     /// <param name="value">The <typeparamref name="TOk" /> value</param>
     /// <returns>The created <see cref="Result{TOk,TErr}" /></returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is null. Use
+    /// <c>Result.Try</c> when a null is a possible outcome
+    /// you would rather handle than have thrown at you.
+    /// </exception>
     public static implicit operator Result<TOk, TErr>(TOk value) =>
         Result.Ok<TOk, TErr>(value);
 
@@ -380,6 +385,9 @@ public abstract record Result<TOk, TErr>
     /// </summary>
     /// <param name="value">The <typeparamref name="TErr" /> value</param>
     /// <returns>The created <see cref="Result{TOk,TErr}" /></returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is null.
+    /// </exception>
     public static implicit operator Result<TOk, TErr>(TErr value) =>
         Result.Err<TOk, TErr>(value);
 }

--- a/test/Waystone.Monads.Tests/Options/OptionTests.cs
+++ b/test/Waystone.Monads.Tests/Options/OptionTests.cs
@@ -96,6 +96,21 @@ public sealed class OptionTests
     }
 
     [Fact]
+    public void GivenAnyFactory_WhenBinding_ThenAgreeWithTheConversion()
+    {
+        using (LoggerScope())
+        {
+            Option<int> zero = 0;
+            Option<int> one = 1;
+            Option<Guid> empty = default(Guid);
+
+            Option.Try(() => 0).ShouldBe(zero);
+            Option.Try(() => 1).ShouldBe(one);
+            Option.Try(() => default(Guid)).ShouldBe(empty);
+        }
+    }
+
+    [Fact]
     public void GivenFactoryReturningNull_WhenBinding_ThenReturnNone()
     {
         using (LoggerScope())

--- a/test/Waystone.Monads.Tests/Options/OptionTests.cs
+++ b/test/Waystone.Monads.Tests/Options/OptionTests.cs
@@ -82,6 +82,66 @@ public sealed class OptionTests
     }
 
     [Fact]
+    public void GivenFactoryReturningDefault_WhenBinding_ThenReturnNone()
+    {
+        using (LoggerScope())
+        {
+            Option.Try(() => 0).ShouldBe(Option.None<int>());
+            Option.Try(() => false).ShouldBe(Option.None<bool>());
+            Option.Try(() => default(Guid)).ShouldBe(Option.None<Guid>());
+
+            _callback.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenFactoryReturningNull_WhenBinding_ThenReturnNone()
+    {
+        using (LoggerScope())
+        {
+            Option<string> option = Option.Try(() => default(string)!);
+
+            option.ShouldBe(Option.None<string>());
+
+            _callback.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public async Task
+        GivenAsyncFactoryReturningDefault_WhenBinding_ThenReturnNone()
+    {
+        using (LoggerScope())
+        {
+            Option<int> option =
+                await Option.TryAsync(() => Task.FromResult(0));
+
+            option.ShouldBe(Option.None<int>());
+
+            _callback.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public async Task
+        GivenAsyncFactoryReturningNull_WhenBinding_ThenReturnNone()
+    {
+        using (LoggerScope())
+        {
+            Option<string> option = await Option.TryAsync(
+                () => Task.FromResult(default(string)!));
+
+            option.ShouldBe(Option.None<string>());
+
+            _callback.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
     public void WhenImplicitlyCreatingOption_ThenReturnExpected()
     {
         Option<int> option1 = 0;

--- a/test/Waystone.Monads.Tests/Results/ResultTests.cs
+++ b/test/Waystone.Monads.Tests/Results/ResultTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using Configs;
+using Errors;
 using JetBrains.Annotations;
 using NSubstitute;
 using Shouldly;
@@ -144,5 +145,71 @@ public sealed class ResultTests
 
         ok.ShouldBe(Result.Ok<int, string>(1));
         err.ShouldBe(Result.Err<int, string>("error"));
+    }
+
+    [Fact]
+    public void GivenNull_WhenCreatingOk_ThenThrow()
+    {
+        Should.Throw<ArgumentNullException>(
+                () => Result.Ok<string, string>(default!))
+           .ParamName.ShouldBe("value");
+
+        Should.Throw<ArgumentNullException>(
+                () => Result.Ok<string>(default!))
+           .ParamName.ShouldBe("value");
+    }
+
+    [Fact]
+    public void GivenNull_WhenCreatingErr_ThenThrow()
+    {
+        Should.Throw<ArgumentNullException>(
+                () => Result.Err<string, string>(default!))
+           .ParamName.ShouldBe("value");
+
+        Should.Throw<ArgumentNullException>(
+                () => Result.Err<string>(default(Error)!))
+           .ParamName.ShouldBe("value");
+    }
+
+    [Fact]
+    public void GivenNull_WhenImplicitlyCreatingResult_ThenThrow()
+    {
+        Should.Throw<ArgumentNullException>(
+            () =>
+            {
+                Result<string, int> _ = default(string)!;
+            });
+
+        Should.Throw<ArgumentNullException>(
+            () =>
+            {
+                Result<int, string> _ = default(string)!;
+            });
+    }
+
+    [Fact]
+    public void GivenNull_WhenBindingAndConverting_ThenBothRejectIt()
+    {
+        var callback = Substitute.For<Func<Exception, int>>();
+        callback.Invoke(Arg.Any<Exception>()).Returns(1);
+
+        Should.Throw<ArgumentNullException>(
+            () =>
+            {
+                Result<string, int> _ = default(string)!;
+            });
+
+        Result.Try(() => default(string)!, callback).IsErr.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenTheDefaultOfAValueType_WhenCreatingOk_ThenReturnOk()
+    {
+        Result.Ok<int, string>(0).ShouldBe(Result.Ok<int, string>(0));
+
+        Result<int, string> zero = 0;
+
+        zero.IsOk.ShouldBeTrue();
+        zero.Unwrap().ShouldBe(0);
     }
 }

--- a/test/Waystone.Monads.Tests/Results/ResultTests.cs
+++ b/test/Waystone.Monads.Tests/Results/ResultTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Configs;
 using JetBrains.Annotations;
 using NSubstitute;
 using Shouldly;
@@ -81,6 +82,58 @@ public sealed class ResultTests
             callback);
         result.ShouldBe(Result.Err<int, string>("error"));
         callback.Received(1).Invoke(Arg.Any<Exception>());
+    }
+
+    [Fact]
+    public void GivenFactoryReturningNull_WhenBindingFactory_ThenReturnError()
+    {
+        var logger = Substitute.For<Action<Exception, CallerInfo>>();
+        var callback = Substitute.For<Func<Exception, string>>();
+        callback.Invoke(Arg.Any<Exception>()).Returns("error");
+
+        using (MonadOptions.BeginScope(
+                   options => options.UseExceptionLogger(logger)))
+        {
+            Result<string, string> result =
+                Result.Try(() => default(string)!, callback);
+
+            result.ShouldBe(Result.Err<string, string>("error"));
+
+            callback.Received(1)
+               .Invoke(
+                    Arg.Is<ArgumentNullException>(
+                        ex => ex.ParamName == "factory"));
+
+            logger.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public async Task
+        GivenAsyncFactoryReturningNull_WhenBindingFactory_ThenReturnError()
+    {
+        var logger = Substitute.For<Action<Exception, CallerInfo>>();
+        var callback = Substitute.For<Func<Exception, string>>();
+        callback.Invoke(Arg.Any<Exception>()).Returns("error");
+
+        using (MonadOptions.BeginScope(
+                   options => options.UseExceptionLogger(logger)))
+        {
+            Result<string, string> result = await Result.TryAsync(
+                () => Task.FromResult(default(string)!),
+                callback);
+
+            result.ShouldBe(Result.Err<string, string>("error"));
+
+            callback.Received(1)
+               .Invoke(
+                    Arg.Is<ArgumentNullException>(
+                        ex => ex.ParamName == "asyncFactory"));
+
+            logger.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Closes DRA-97. Base PR of the **v6 preparation** stack — [DRA-92](https://linear.app/draekien-industries/issue/DRA-92) and [DRA-77](https://linear.app/draekien-industries/issue/DRA-77) stack on top of this, and the three publish one 5.x minor together.

## The defect

`Option.Try` and `Option.TryAsync` called `Some(value)` **inside** their own `try` block. `Some`'s constructor throws when the value equals `default(T)`, so that throw was caught by a handler written for factory failures, reported to the consumer's configured `ExceptionLogger` as though their factory had failed, and swallowed into `None`.

`Option.Try(() => 0)` logged an exception even though the factory succeeded.

## The fix

Test the value **before** construction. `None` is still the right answer for a value a `Some` cannot hold — that is what `Try` is for, and the alternative of propagating would make callers guard a method they reached for precisely so they would not have to — but arriving there no longer goes through a caught exception, so nothing is logged.

The check is `Equals(value, default(T))`, matching the invariant as it stands in 5.x. **[DRA-87](https://linear.app/draekien-industries/issue/DRA-87) must narrow it to `value is null`** when it relaxes the invariant, or `Try(() => 0)` returns `None` in v6 while `Option.Some(0)` returns `Some(0)`. That is recorded on DRA-87.

## Result had the same shape, plus a second hole

`Result.Try`/`TryAsync` also constructed inside the `try`. Neither `Ok` nor `Err` guards its value, so there was no invariant to trip — but a factory returning null produced `Ok(null)`, and `TOk : notnull` is warning-only, so that is reachable. Both now route null through the caller's own `onError` with an `ArgumentNullException` naming the factory. It carries no stack trace because it was never thrown.

Neither new path calls `MonadOptions.Current.Log`. `Log` is documented as "exception silently handled", and neither case is silent: `Option` returns `None` by contract, `Result` runs the consumer's `onError`. Logging a fabricated exception would recreate the defect being fixed.

The `Error`-typed `Result.Try<TOk>`/`TryAsync<TOk>` overloads and the obsolete `Try(Func<Task<T>>)` overloads on both types all delegate, so they inherit the behaviour with no separate path.

## Verification

- Six new tests, each confirmed to fail against the unmodified source and pass with it
- Full five-framework matrix locally — net8.0, net9.0, net10.0, net472, net481 — 562 tests green on each. CI runs `net8.0` only
- Whole solution green, analyzer tests included

## Release shape

A `fix`, **no `!`**. The stack's single minor comes from DRA-92's `feat` title. A `!` anywhere here would publish 6.0.0 early and strand the v6 stack on 7.0.0.

## Docs

Four public methods change documented behaviour, so a docs PR is required. It covers the whole prep stack as one PR in `draekien-industries/docs`, opened and merged **after** all three code PRs land, so the published documentation describes a version already on NuGet.
