### PR TITLE
feat(analyzers): add WM1010 warning where the v6 Some relaxation changes behaviour

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
+++ b/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
@@ -10,6 +10,8 @@ internal class Misuse
 {
     internal Option<int> SomeOfADefault() => Option.Some(0);
 
+    internal Option<string> SomeOfANull() => Option.Some(default(string)!);
+
     internal Option<Guid> SomeOfAnEmptyGuid() => Option.Some(Guid.Empty);
 
     internal Option<int> NullInsteadOfNone() => null;

--- a/src/Waystone.Monads.Analyzers.CodeFixes/UseNoneCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/UseNoneCodeFix.cs
@@ -11,7 +11,12 @@ using System.Composition;
 public sealed class UseNoneCodeFix : MonadCodeFix
 {
     public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create("WM1001", "WM1002", "WM1003", "WM1004");
+        ImmutableArray.Create(
+            "WM1001",
+            "WM1002",
+            "WM1003",
+            "WM1004",
+            "WM1010");
 
     protected override void Register(
         CodeFixContext context,
@@ -25,7 +30,7 @@ public sealed class UseNoneCodeFix : MonadCodeFix
             return;
         }
 
-        var target = diagnostic.Id == "WM1001"
+        var target = diagnostic.Id is "WM1001" or "WM1010"
             ? expression.FirstAncestorOrSelf<InvocationExpressionSyntax>()
             : expression;
 

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -40,3 +40,11 @@ WM1008 | Reliability | Warning | An Option or Result is declared nullable
 WM1009 | Reliability | Warning | Option of bool or of an enum with a zero member
 WM2014 | Usage | Info | FlatMap has been renamed to AndThen
 WM2015 | Usage | Info | OrDefault on a value type cannot express the absent case
+
+## Release 5.5.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+WM1010 | Reliability | Warning | The default of a value type is used as an Option value

--- a/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
@@ -11,6 +11,7 @@ public sealed class OptionCreationAnalyzer : MonadAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             Rules.SomeFromDefaultValue,
+            Rules.DefaultOfValueTypeInOption,
             Rules.PossiblyNullPassedToSome);
 
     protected override void Register(
@@ -39,15 +40,23 @@ public sealed class OptionCreationAnalyzer : MonadAnalyzer
 
         var argument = invocation.Arguments[0].Value;
 
-        string type = Semantics.Display(method.TypeArguments[0]);
+        var valueType = method.TypeArguments[0];
+
+        string type = Semantics.Display(valueType);
 
         if (Semantics.IsDefaultValue(argument))
         {
             context.ReportDiagnostic(
-                Diagnostic.Create(
-                    Rules.SomeFromDefaultValue,
-                    argument.Syntax.GetLocation(),
-                    type));
+                valueType.IsValueType
+                    ? Diagnostic.Create(
+                        Rules.DefaultOfValueTypeInOption,
+                        argument.Syntax.GetLocation(),
+                        argument.Syntax.ToString(),
+                        type)
+                    : Diagnostic.Create(
+                        Rules.SomeFromDefaultValue,
+                        argument.Syntax.GetLocation(),
+                        type));
 
             return;
         }

--- a/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
@@ -42,10 +42,10 @@ public sealed class OptionCreationAnalyzer : MonadAnalyzer
 
         var valueType = method.TypeArguments[0];
 
-        string type = Semantics.Display(valueType);
-
         if (Semantics.IsDefaultValue(argument))
         {
+            string type = Semantics.Display(valueType);
+
             context.ReportDiagnostic(
                 valueType.IsValueType
                     ? Diagnostic.Create(

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -8,11 +8,18 @@ public static class Rules
     private const string Usage = nameof(Usage);
     private const string Design = nameof(Design);
 
+    /// <remarks>
+    /// Narrowed to the null case. The value-type half moved to WM1010, which
+    /// forecasts the v6 relaxation, because no single messageFormat is true of
+    /// both: in v6 a null still throws and a value-type default becomes an
+    /// ordinary Some. This rule survives v6 with only its exception type
+    /// changing, so keep the message about null rather than about default(T).
+    /// </remarks>
     public static readonly DiagnosticDescriptor SomeFromDefaultValue = Bug(
         "WM1001",
         "Do not pass a default value to Some",
-        "'Option.Some' throws at runtime when the value equals the default of '{0}'. Use 'Option.None<{0}>()' to express the absence of a value.",
-        "The constructor of Some rejects a value equal to default(T), so this call always throws an InvalidOperationException.");
+        "'Option.Some' throws at runtime when the value is null. Use 'Option.None<{0}>()' to express the absence of a value.",
+        "The constructor of Some rejects null, so this call always throws an InvalidOperationException.");
 
     public static readonly DiagnosticDescriptor NullAssignedToMonad = Bug(
         "WM1002",
@@ -26,11 +33,20 @@ public static class Rules
         "'default({0})' is null, not an empty value. Construct the absent or failed case explicitly.",
         "Option and Result are reference types, so their default is null rather than None or Err.");
 
+    /// <remarks>
+    /// Not narrowed alongside WM1001, because it never covered the null case in
+    /// the first place: <see cref="NullAndDefaultAnalyzer" /> returns early on a
+    /// null-constant operand, so this rule only ever fires on the default of a
+    /// value type. That is why the v6 forecast goes in this message rather than
+    /// into WM1010 as a second position — one sentence is true of everything the
+    /// rule reports. It follows that the rule becomes wholly false in v6 and is
+    /// retired there, rather than surviving narrowed as WM1001 does.
+    /// </remarks>
     public static readonly DiagnosticDescriptor DefaultValueConvertsToNone = Bug(
         "WM1004",
         "Do not convert a default value to an Option implicitly",
-        "The implicit conversion maps the default of '{0}' to None, so this produces None rather than a Some holding {1}",
-        "Option<T>'s implicit conversion returns None when the value equals default(T). A default value silently becomes an absent one.");
+        "The implicit conversion maps the default of '{0}' to None, so this produces None rather than a Some holding {1} today. In v6 it produces a Some holding {1}.",
+        "Option<T>'s implicit conversion returns None when the value equals default(T), so a default value silently becomes an absent one. In v6 only null maps onto None, and this expression changes meaning rather than failing to compile.");
 
     public static readonly DiagnosticDescriptor PossiblyNullPassedToSome = Bug(
         "WM1005",
@@ -84,6 +100,26 @@ public static class Rules
         "Do not use Option over bool or a zero-member enum",
         "'{0}' cannot hold the default of '{1}', because 'Option.Some' throws on it. {2}.",
         "Option.Some rejects a value equal to default(T), so an Option over a type whose zero is a meaningful value cannot represent part of its own domain.");
+
+    /// <remarks>
+    /// Exists only to forecast the v6 relaxation, and is retired there rather
+    /// than reworded — see DRA-92. It is a separate id from WM1001 rather than a
+    /// reworded one because a descriptor has exactly one messageFormat and no
+    /// single sentence covers both a null and a value-type default once v6
+    /// treats them differently. It covers the Option.Some argument position
+    /// only: the implicit conversion is WM1004's, which never reported a null
+    /// and so carries its own forecast, and Option.FromNullable is deliberately
+    /// left out because the analyzer would only see a literal nobody writes.
+    /// Warning is earned on the present tense of the message — every span
+    /// reported throws today — and it is the severity these spans already
+    /// reported at under WM1001, so no consumer sees a new count.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor DefaultOfValueTypeInOption =
+        Bug(
+            "WM1010",
+            "Do not use the default of a value type as an Option value",
+            "{0} is the default of '{1}', so 'Option.Some' throws today. In v6 it returns a Some holding {0}. Use 'Option.None<{1}>()' if you mean the absent case.",
+            "Option.Some rejects a value equal to default(T). That changes in v6, where only null is rejected and the default of a value type becomes an ordinary Some, so code relying on the current behaviour changes meaning on upgrade rather than failing to compile.");
 
     public static readonly DiagnosticDescriptor UnwrapUsed = Idiom(
         "WM2001",

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -17,7 +17,7 @@ public static class Rules
     /// </remarks>
     public static readonly DiagnosticDescriptor SomeFromDefaultValue = Bug(
         "WM1001",
-        "Do not pass a default value to Some",
+        "Do not pass null to Some",
         "'Option.Some' throws at runtime when the value is null. Use 'Option.None<{0}>()' to express the absence of a value.",
         "The constructor of Some rejects null, so this call always throws an InvalidOperationException.");
 

--- a/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
@@ -6,13 +6,22 @@ using Xunit;
 public class CodeFixTests
 {
     [Fact]
-    public Task ReplacesSomeOfADefaultWithNone() =>
+    public Task ReplacesSomeOfAValueTypeDefaultWithNone() =>
         Verify.CodeFixAsync<OptionCreationAnalyzer, UseNoneCodeFix>(
             "internal Option<int> Make() => Option.Some({|#0:0|});",
             "internal Option<int> Make() => Option.None<int>();",
+            Verify.Diagnostic(Rules.DefaultOfValueTypeInOption)
+               .WithLocation(0)
+               .WithArguments("0", "int"));
+
+    [Fact]
+    public Task ReplacesSomeOfANullWithNone() =>
+        Verify.CodeFixAsync<OptionCreationAnalyzer, UseNoneCodeFix>(
+            "internal Option<string> Make() => Option.Some({|#0:default(string)|}!);",
+            "internal Option<string> Make() => Option.None<string>();",
             Verify.Diagnostic(Rules.SomeFromDefaultValue)
                .WithLocation(0)
-               .WithArguments("int"));
+               .WithArguments("string"));
 
     [Fact]
     public Task ReplacesNullWithNone() =>

--- a/test/Waystone.Monads.Analyzers.Tests/NullAndDefaultAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/NullAndDefaultAnalyzerTests.cs
@@ -95,6 +95,22 @@ public class NullAndDefaultAnalyzerTests
                .WithArguments("int", "0"));
 
     [Fact]
+    public Task RendersTheV6ForecastInTheConversionMessage() =>
+        Verify.AnalyzerAsync<NullAndDefaultAnalyzer>(
+            "internal Option<int> Make() => {|#0:0|};",
+            Verify.Diagnostic(Rules.DefaultValueConvertsToNone)
+               .WithLocation(0)
+               .WithMessage(
+                    "The implicit conversion maps the default of 'int' to "
+                  + "None, so this produces None rather than a Some holding 0 "
+                  + "today. In v6 it produces a Some holding 0."));
+
+    [Fact]
+    public Task IgnoresTheDefaultOfAReferenceTypeConvertedToAnOption() =>
+        Verify.NoDiagnosticAsync<NullAndDefaultAnalyzer>(
+            "internal Option<string> Make() => default(string)!;");
+
+    [Fact]
     public Task IgnoresANonDefaultValueConvertedToAnOption() =>
         Verify.NoDiagnosticAsync<NullAndDefaultAnalyzer>(
             "internal Option<int> Make() => 1;");

--- a/test/Waystone.Monads.Analyzers.Tests/OptionCreationAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/OptionCreationAnalyzerTests.cs
@@ -14,9 +14,30 @@ public class OptionCreationAnalyzerTests
     [InlineData("Guid.Empty", "Guid")]
     [InlineData("DateTime.MinValue", "DateTime")]
     [InlineData("TimeSpan.Zero", "TimeSpan")]
-    public Task FlagsAValueEqualToTheDefault(string value, string type) =>
+    public Task FlagsTheDefaultOfAValueType(string value, string type) =>
         Verify.AnalyzerAsync<OptionCreationAnalyzer>(
             $"internal Option<{type}> Make() => Option.Some({{|#0:{value}|}});",
+            Verify.Diagnostic(Rules.DefaultOfValueTypeInOption)
+               .WithLocation(0)
+               .WithArguments(value, type));
+
+    [Fact]
+    public Task RendersEveryPlaceholderInTheValueTypeMessage() =>
+        Verify.AnalyzerAsync<OptionCreationAnalyzer>(
+            "internal Option<int> Make() => Option.Some({|#0:0|});",
+            Verify.Diagnostic(Rules.DefaultOfValueTypeInOption)
+               .WithLocation(0)
+               .WithMessage(
+                    "0 is the default of 'int', so 'Option.Some' throws today. "
+                  + "In v6 it returns a Some holding 0. Use "
+                  + "'Option.None<int>()' if you mean the absent case."));
+
+    [Theory]
+    [InlineData("default(string)", "string")]
+    [InlineData("default(object)", "object")]
+    public Task FlagsTheDefaultOfAReferenceType(string value, string type) =>
+        Verify.AnalyzerAsync<OptionCreationAnalyzer>(
+            $"internal Option<{type}> Make() => Option.Some({{|#0:{value}|}}!);",
             Verify.Diagnostic(Rules.SomeFromDefaultValue)
                .WithLocation(0)
                .WithArguments(type));

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -62,7 +62,7 @@ public class RulesTests
     [Fact]
     public void EveryTierIsPopulated()
     {
-        MisuseRules().Count.ShouldBe(9);
+        MisuseRules().Count.ShouldBe(10);
         IdiomRules().Count.ShouldBe(15);
         MigrationRules().Count.ShouldBe(2);
     }


### PR DESCRIPTION
Closes DRA-92. **Stacked on #72** — middle PR of the v6 preparation stack. [DRA-77](https://linear.app/draekien-industries/issue/DRA-77) goes on top. This PR's `feat` title is what makes the stack's single release a minor rather than a patch.

## Why a new id rather than a reworded WM1001

[DRA-87](https://linear.app/draekien-industries/issue/DRA-87) relaxes the `Some` invariant with no compile error anywhere: `Option.Some(0)` stops throwing and starts returning `Some(0)`. A descriptor has exactly one `messageFormat`, and WM1001 fired on a null *and* a value-type default — in v6 the first still throws while the second becomes an ordinary `Some`, so no single sentence stays true.

So WM1001 is **narrowed to null**, where its message survives v6 with only its exception type changing, and the value-type spans move to **WM1010**, whose message is entirely about the forecast. Same severity, same lines — the spans WM1001 stops reporting are exactly the spans WM1010 picks up.

## A premise in DRA-92 was wrong, and the design changed

The issue assumed WM1004 split the same way and needed the same narrowing. It does not. `AnalyzeConversion` already returns early on a null-constant operand (`NullAndDefaultAnalyzer.cs:107-112`), so **WM1004 only ever fired on the default of a value type** — I confirmed it with a `NoDiagnostic` test on `Option<string> x = default(string)!`, now committed as `IgnoresTheDefaultOfAReferenceTypeConvertedToAnOption`.

Two consequences:

1. One sentence covers everything WM1004 reports, so its v6 forecast goes in **its own message** rather than becoming a second position on WM1010. WM1010 loses the `{2}` clause it was drafted with and covers the `Option.Some` argument position only.
2. WM1004 becomes *wholly* false in v6, not half-false, so it cannot survive narrowed the way WM1001 does. **DRA-87 must give it a `### Removed Rules` row** — that is recorded on DRA-87 and DRA-92.

`Option.FromNullable` is deliberately out of scope. It appears nowhere in the analyzer project, and detection could only ever reach a literal like `FromNullable((int?)0)`; the real hazard, `FromNullable(user.Age)`, is undecidable. It gets prose on the v5.x–v6.x docs page instead.

## Severity, and what it costs

`Warning`, enabled, per the WM1 tier. It is earned on the present tense: every span reported throws `InvalidOperationException` today.

**One accepted cost, called out so it is not a surprise:** a consumer with `dotnet_diagnostic.WM1001.severity = none` in `.editorconfig` builds green today and gets WM1010 on the same lines after this minor, with nothing suppressing it. That was raised and accepted — they were suppressing a genuine defect — and the `#wm1010` docs section will say so.

## Checked against `/writing-diagnostic-descriptors`

Tier and factory, `Do not …` title shape at 56 characters, RS1031/RS1032/RS1033, no tags (the fix rewrites rather than removes, so `Unnecessary` does not apply), a code fix so a `Warning` is not a dead end, and consumer-facing reasoning in the description with author-facing reasoning in XML docs on the fields.

The skill's warning about silent placeholder mismatches applies here: `WithArguments` renders expected and actual through the same format string, so it cannot catch a count error. Both reworded messages are now asserted with `WithMessage` against their fully substituted text, and I verified that assertion fails when the expected string is altered.

## Changes

- `Rules.DefaultOfValueTypeInOption` (WM1010); WM1001 narrowed; WM1004 reworded
- `OptionCreationAnalyzer` splits on `method.TypeArguments[0].IsValueType`
- WM1010 registered in `UseNoneCodeFix`, reusing the WM1001 invocation-target branch
- `RulesTests.EveryTierIsPopulated`: misuse 9 → 10
- Release row filed in `Shipped.md` under **5.5.0** rather than left unshipped, since merging publishes. Latest tag is `v5.4.0` and the stack's highest bump is this PR's `feat` — **worth confirming against the `Calculate Version` check before merge**
- A `SomeOfANull` case in the analyzer sample, so WM1001 stays demonstrated now that its value-type case moved

## Verification

- 230 analyzer tests green, whole solution green, Monads matrix green on all five frameworks
- Sample project build shows both rules firing on real code with correctly rendered messages and working help links
- No documented severity or enablement change, so no `### Changed Rules` row. A message reword needs none — the WM2005 precedent

## Docs

Contributes the `#wm1010` section, the suppression note, and edits to the WM1001 and WM1004 sections. Covered by the single docs PR for the whole stack, merged after all three code PRs land.
