### PR TITLE
chore(analyzers): record the false-positive verdict for WM1002 and WM1003

### DIFF
--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -21,12 +21,34 @@ public static class Rules
         "'Option.Some' throws at runtime when the value is null. Use 'Option.None<{0}>()' to express the absence of a value.",
         "The constructor of Some rejects null, so this call always throws an InvalidOperationException.");
 
+    /// <remarks>
+    /// Warning survives the false-positive question, examined in DRA-77. The
+    /// worst case found is a null reaching a target the analyzer cannot prove is
+    /// non-nullable, which happens in a tuple element, a collection-initializer
+    /// element and a local function return, because
+    /// <see cref="NullAndDefaultAnalyzer.TargetIsExplicitlyNullable" /> matches
+    /// an enumerated set of positions and defaults to reporting. None of those
+    /// is working code: reaching them requires declaring the monad as
+    /// <c>Option&lt;T&gt;?</c>, which WM1008 forbids outright. So the rule fires
+    /// on code that is already wrong, and reports alongside WM1008 where that
+    /// rule sees the declaration. Do not lower the tier to accommodate them, and
+    /// do not widen the exclusion either — it would silence a real null.
+    /// </remarks>
     public static readonly DiagnosticDescriptor NullAssignedToMonad = Bug(
         "WM1002",
         "Do not assign null to an Option or Result",
         "'{0}' is never null in correct use. Null here defeats the type and throws on the next member access.",
         "Option and Result are records, so the compiler permits null where one is expected. None and Err express absence and failure; null expresses neither.");
 
+    /// <remarks>
+    /// Warning survives the false-positive question, examined in DRA-77, on the
+    /// same reasoning as WM1002: every position where the target's nullability
+    /// cannot be proven requires an <c>Option&lt;T&gt;?</c> declaration, which
+    /// WM1008 forbids. The generic case that prompted the question is safe —
+    /// <c>default</c> written for an unconstrained <c>T</c> has <c>T</c> as its
+    /// type rather than the monad, so the rule stays quiet however <c>T</c> is
+    /// instantiated.
+    /// </remarks>
     public static readonly DiagnosticDescriptor DefaultOfMonad = Bug(
         "WM1003",
         "Do not use the default of an Option or Result",

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -29,10 +29,14 @@ public static class Rules
     /// <see cref="NullAndDefaultAnalyzer.TargetIsExplicitlyNullable" /> matches
     /// an enumerated set of positions and defaults to reporting. None of those
     /// is working code: reaching them requires declaring the monad as
-    /// <c>Option&lt;T&gt;?</c>, which WM1008 forbids outright. So the rule fires
-    /// on code that is already wrong, and reports alongside WM1008 where that
-    /// rule sees the declaration. Do not lower the tier to accommodate them, and
-    /// do not widen the exclusion either — it would silence a real null.
+    /// <c>Option&lt;T&gt;?</c>, which WM1008 forbids. It reports alongside
+    /// WM1008 for the collection-initializer element and the local-function
+    /// return, but not for the tuple element:
+    /// <see cref="Semantics.IsDeclarationTypePosition" /> has no case for a
+    /// tuple element, so WM1008 never sees that declaration and this rule is the
+    /// only one that fires there. That gap is WM1008's, tracked in DRA-98, not a
+    /// reason to change this rule. Do not lower the tier to accommodate them,
+    /// and do not widen the exclusion either — it would silence a real null.
     /// </remarks>
     public static readonly DiagnosticDescriptor NullAssignedToMonad = Bug(
         "WM1002",
@@ -44,7 +48,9 @@ public static class Rules
     /// Warning survives the false-positive question, examined in DRA-77, on the
     /// same reasoning as WM1002: every position where the target's nullability
     /// cannot be proven requires an <c>Option&lt;T&gt;?</c> declaration, which
-    /// WM1008 forbids. The generic case that prompted the question is safe —
+    /// WM1008 forbids — though it does not see the declaration in a tuple
+    /// element, so there this rule reports alone, which is DRA-98's gap rather
+    /// than this rule's. The generic case that prompted the question is safe —
     /// <c>default</c> written for an unconstrained <c>T</c> has <c>T</c> as its
     /// type rather than the monad, so the rule stays quiet however <c>T</c> is
     /// instantiated.

--- a/test/Waystone.Monads.Analyzers.Tests/NullAndDefaultAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/NullAndDefaultAnalyzerTests.cs
@@ -71,6 +71,27 @@ public class NullAndDefaultAnalyzerTests
             $"internal bool Test(Option<int> option) => {test};");
 
     [Fact]
+    public Task FlagsNullInANullableTupleElement() =>
+        Verify.AnalyzerAsync<NullAndDefaultAnalyzer>(
+            "internal (Option<int>? a, int b) Make() => ({|#0:null|}, 1);",
+            Verify.Diagnostic(Rules.NullAssignedToMonad)
+               .WithLocation(0)
+               .WithArguments("Option<int>"));
+
+    [Fact]
+    public Task FlagsTheDefaultInANullableTupleElement() =>
+        Verify.AnalyzerAsync<NullAndDefaultAnalyzer>(
+            "internal (Option<int>? a, int b) Make() => ({|#0:default|}, 1);",
+            Verify.Diagnostic(Rules.DefaultOfMonad)
+               .WithLocation(0)
+               .WithArguments("Option<int>"));
+
+    [Fact]
+    public Task IgnoresTheDefaultOfAnUnconstrainedTypeParameter() =>
+        Verify.NoDiagnosticAsync<NullAndDefaultAnalyzer>(
+            "internal T Get<T>() => default!;");
+
+    [Fact]
     public Task FlagsTheDefaultOfAnOption() =>
         Verify.AnalyzerAsync<NullAndDefaultAnalyzer>(
             "internal Option<int> Make() => {|#0:default(Option<int>)|};",


### PR DESCRIPTION
Closes DRA-77. **Stacked on #73** — top PR of the v6 preparation stack. A `chore`, so it bumps nothing; the stack's single 5.x minor comes from #73's `feat`.

## The question

Both rules ship at `Warning`, enabled, and both fire on code that compiles. Neither had ever been examined against the descriptor skill's first question — **can this rule fire on code that works today?** — because the skill did not exist when they were written.

## The verdict: no change, and the reason is not the one expected

`NullAndDefaultAnalyzer.TargetIsExplicitlyNullable` matches an enumerated set of positions — argument, arrow body, return statement, equals-value clause — and **defaults to reporting** when it recognises none. So a null or a default does get flagged in three positions where the annotation is sitting right there in the source:

```csharp
(Option<int>? a, int b) Make() => (null, 1);          // WM1002
(Option<int>? a, int b) Make() => (default, 1);       // WM1003
new List<Option<int>?> { null };                       // WM1002
Option<int>? Inner() => null;                          // WM1002, local function
```

That looked like grounds to lower the tier. It is not: **reaching any of those requires declaring the monad as `Option<T>?`, which WM1008 forbids outright.** None of it is working code. WM1008 fires on the collection-element and local-function cases, so those spans already carry a warning and WM1002 sits alongside it — the same deliberate overlap already documented on `Rules.NullableMonadDeclared` for WM2011.

The generic case the issue specifically asked about is clean: `default` written for an unconstrained `T` has `T` as its type rather than the monad, so WM1003 stays quiet however `T` is instantiated.

So no severity moves, and **no release-tracking row is needed** — `### Changed Rules` records category, severity and enablement, none of which change.

## What I tried and rejected

Replacing the position-enumerating walk with a semantic check on the converted type's nullable annotation. It does not work: a null literal's converted type is annotated regardless of the target, so it suppressed three true positives and three code-fix tests. Reverted, and the XML docs now say explicitly not to widen the exclusion, because doing so silences a real null.

## What this PR ships

- Three tests pinning the verdict, so the analysis is not repeated from scratch
- The verdict per rule in an XML doc comment on the descriptor, naming the worst case found and why the tier survives it

## Found on the way, filed not fixed

**WM1008 misses the tuple-element position entirely** — `(Option<int>? a, int b)` is reported by nothing. That is a coverage gap in the rule meant to catch this class, not a false positive in these two, and fixing it is a different change from the one this issue scoped. **DRA-98.**

The consequence is worth knowing while it is open: in the tuple position a consumer gets "null here defeats the type" on the `null` and nothing about the annotation that admitted it, so the fix they are offered leaves the offending declaration in place.

## Verification

- 233 analyzer tests green, whole solution green, Monads matrix green on all five frameworks
- No warnings from the analyzer project build, so the new crefs resolve
