### PR TITLE
docs: require gh stack for stacked pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,23 @@ the colon forces a major bump on *any* type. PRs are squash-merged, so the PR
 title becomes a version-determining subject — a `!` in a PR title ships a
 major release. Use `!` only when something is actually being removed.
 
+**Build a stack with `gh stack`, never by hand.** `gh stack init <bottom> … <top>`
+takes the branches bottom to top, adopting ones that already exist and creating
+the rest, and `gh stack submit` then pushes them, repoints each PR's base onto the
+one below it, and registers the stack on GitHub. Do the same thing by passing
+`--base` to `gh pr create` and you get the right base branches and *no stack*:
+reviewers see unrelated PRs with no chain, `gh stack view` shows nothing, and
+`gh stack merge` — the only supported way to land one — has nothing to merge.
+
+`gh stack submit` opens an editor that an agent cannot drive, so pass `--auto`,
+which is also what a non-interactive terminal falls back to. Note that `--auto`
+creates *new* PRs as drafts unless you add `--open`.
+
+Adopting a hand-built chain after the fact does work: `gh stack init` reports
+"Found PRs for N of N branches" and `gh stack submit --auto` reports each one "up
+to date" and links them without creating duplicates. That is a repair, not a
+route — run `gh stack init` before opening the first PR.
+
 **A stack contributes every one of its PR titles.** `gh stack merge` squashes each
 PR in the stack separately, so an eleven-PR stack lands eleven commits and
 GitVersion reads all eleven subjects. It applies one increment for the highest bump


### PR DESCRIPTION
Written after building the v6 preparation stack the wrong way round. AGENTS.md already covered what a stack does to the computed version and the two CI traps it sets off, but never said how to build one — so I chained #72, #73 and #74 with `gh pr create --base`, which produces the correct base branches and **no stack at all**.

That distinction is not cosmetic. Without a registered stack there is no chain for a reviewer to follow, `gh stack view` shows nothing, and `gh stack merge` — which AGENTS.md already names as the way a stack lands — has nothing to merge.

## What this adds

The route: `gh stack init <bottom> … <top>`, then `gh stack submit`. Plus two things an agent specifically needs:

- `gh stack submit` opens an editor that cannot be driven programmatically, so `--auto` is required. It is also the non-interactive fallback.
- `--auto` creates **new** PRs as drafts unless you add `--open`.

And the repair, since I needed it: `gh stack init` adopts existing branches and reports "Found PRs for N of N branches", then `gh stack submit --auto` reports each one "up to date" and links them into a stack **without creating duplicates**. Recorded so the next person in that position does not close and reopen three PRs. The three PRs above are now stack #75, adopted exactly that way.

## Why this is not part of the stack it describes

It touches only `AGENTS.md`, which matches no path in `pull-request.yml`'s filter. AGENTS.md documents the consequence itself: the workflow never runs, `codecov/patch`, `Calculate Version` and `Build and run tests` never report, and the PR sits `BLOCKED` with nothing pending.

Harmless on its own — it lands with `gh pr merge --admin` like any docs-only change here. Inside the stack it would be **actively bad**: a mid-stack PR that can never satisfy a required check blocks every PR above it. So it sits on its own branch off `main` and can merge in any order relative to the stack.
