### PR TITLE
chore: add a BenchmarkDotNet harness for Option and Result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ docs/generated
 TestResults/
 
 out/
+
+# BenchmarkDotNet
+# Runs write to artifacts/<label>/. Keep the GitHub markdown reports so a v5
+# baseline can be diffed against a v6 run in review; drop the logs, csv and html.
+BenchmarkDotNet.Artifacts/
+artifacts/**
+!artifacts/**/
+!artifacts/**/*-report-github.md

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,48 +1,49 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="FluentValidation" Version="11.11.0"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2"/>
-        <PackageVersion Include="PolySharp" Version="1.15.0"/>
-        <PackageVersion Include="Reqnroll.xunit.v3" Version="3.2.1"/>
-        <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.12.27"/>
-        <PackageVersion Include="Serilog" Version="4.3.0"/>
-        <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0"/>
-        <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0"/>
-        <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0"/>
-        <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1"/>
-        <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0"/>
-        <PackageVersion Include="Shouldly" Version="4.3.0"/>
-        <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
-        <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3"/>
-        <PackageVersion Include="System.ValueTuple" Version="4.6.1"/>
-        <PackageVersion Include="xunit.v3" Version="3.2.0"/>
-    </ItemGroup>
-    <ItemGroup Label="Analysers">
-        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0"/>
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0"/>
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0"/>
-        <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-        <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17"/>
-    </ItemGroup>
-    <ItemGroup Label="Testing">
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4"/>
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4"/>
-        <PackageVersion Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageVersion>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageVersion>
-        <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-        <PackageVersion Include="AutoFixture" Version="4.18.1"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="FluentValidation" Version="11.11.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="Reqnroll.xunit.v3" Version="3.2.1" />
+    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.12.27" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
+    <PackageVersion Include="xunit.v3" Version="3.2.0" />
+  </ItemGroup>
+  <ItemGroup Label="Analysers">
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+  </ItemGroup>
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+  </ItemGroup>
 </Project>

--- a/Waystone.Net.sln
+++ b/Waystone.Net.sln
@@ -46,6 +46,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Waystone.Monads.Analyzers.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Waystone.Monads.Analyzers.Sample", "sample\Waystone.Monads.Analyzers.Sample\Waystone.Monads.Analyzers.Sample.csproj", "{C521A0E0-4443-419E-94E1-5A6C7BAAF9EF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bench", "bench", "{760AB15A-8938-8D9B-BEDE-5CE1484B84C3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Waystone.Monads.Benchmarks", "bench\Waystone.Monads.Benchmarks\Waystone.Monads.Benchmarks.csproj", "{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -224,6 +228,18 @@ Global
 		{C521A0E0-4443-419E-94E1-5A6C7BAAF9EF}.Release|x64.Build.0 = Release|Any CPU
 		{C521A0E0-4443-419E-94E1-5A6C7BAAF9EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{C521A0E0-4443-419E-94E1-5A6C7BAAF9EF}.Release|x86.Build.0 = Release|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Debug|x86.Build.0 = Debug|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Release|x64.Build.0 = Release|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -243,5 +259,6 @@ Global
 		{FB14BA5E-6225-4E21-8D38-E1AF34B5F8F9} = {5FB28234-858F-4E64-920E-245F92529D8F}
 		{AAC795B6-7936-4226-A8F5-265A02258107} = {67A04439-B9B7-4420-A229-6353EAD7E265}
 		{C521A0E0-4443-419E-94E1-5A6C7BAAF9EF} = {F0B7769E-388B-4FA6-B0F4-1599CE75C5D6}
+		{3B8663EA-CFAB-4E32-ACDD-7F91C020A5B5} = {760AB15A-8938-8D9B-BEDE-5CE1484B84C3}
 	EndGlobalSection
 EndGlobal

--- a/artifacts/v5-baseline/results/Waystone.Monads.Benchmarks.AsyncChainBenchmarks-report-github.md
+++ b/artifacts/v5-baseline/results/Waystone.Monads.Benchmarks.AsyncChainBenchmarks-report-github.md
@@ -1,0 +1,18 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  
+WarmupCount=3  
+
+```
+| Method               | Mean     | Error     | StdDev   | Gen0   | Allocated |
+|--------------------- |---------:|----------:|---------:|-------:|----------:|
+| SingleLinkOnSome     | 16.87 ns | 11.164 ns | 0.612 ns | 0.0029 |     144 B |
+| SingleLinkOnNone     | 10.06 ns |  7.095 ns | 0.389 ns | 0.0005 |      24 B |
+| ThreeLinkChainOnSome | 46.80 ns | 70.557 ns | 3.867 ns | 0.0086 |     432 B |
+| ThreeLinkChainOnNone | 27.00 ns | 28.734 ns | 1.575 ns | 0.0043 |     216 B |

--- a/artifacts/v5-baseline/results/Waystone.Monads.Benchmarks.OptionBenchmarks-report-github.md
+++ b/artifacts/v5-baseline/results/Waystone.Monads.Benchmarks.OptionBenchmarks-report-github.md
@@ -1,0 +1,26 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  
+WarmupCount=3  
+
+```
+| Method             | Mean      | Error      | StdDev    | Median    | Gen0   | Allocated |
+|------------------- |----------:|-----------:|----------:|----------:|-------:|----------:|
+| SomeConstruction   | 5.5756 ns |  3.2414 ns | 0.1777 ns | 5.6270 ns | 0.0014 |      72 B |
+| NoneConstruction   | 1.9409 ns |  3.3880 ns | 0.1857 ns | 1.8669 ns | 0.0005 |      24 B |
+| ImplicitConversion | 7.0191 ns |  0.9092 ns | 0.0498 ns | 7.0207 ns | 0.0024 |     120 B |
+| FromNullable       | 8.9815 ns | 28.1271 ns | 1.5417 ns | 8.1246 ns | 0.0019 |      96 B |
+| MatchOnSome        | 4.0094 ns |  1.2018 ns | 0.0659 ns | 3.9912 ns |      - |         - |
+| MatchOnNone        | 2.7702 ns |  2.1224 ns | 0.1163 ns | 2.7361 ns |      - |         - |
+| MapOnSome          | 9.6447 ns |  2.2819 ns | 0.1251 ns | 9.5951 ns | 0.0024 |     120 B |
+| MapOnNone          | 4.3308 ns |  0.7980 ns | 0.0437 ns | 4.3500 ns | 0.0005 |      24 B |
+| FilterKeeping      | 0.2529 ns |  0.3834 ns | 0.0210 ns | 0.2421 ns |      - |         - |
+| FilterRejecting    | 1.9651 ns |  0.2917 ns | 0.0160 ns | 1.9720 ns | 0.0005 |      24 B |
+| UnwrapOrOnSome     | 0.0070 ns |  0.1408 ns | 0.0077 ns | 0.0057 ns |      - |         - |
+| UnwrapOrOnNone     | 0.0063 ns |  0.1671 ns | 0.0092 ns | 0.0021 ns |      - |         - |

--- a/artifacts/v5-baseline/results/Waystone.Monads.Benchmarks.ResultBenchmarks-report-github.md
+++ b/artifacts/v5-baseline/results/Waystone.Monads.Benchmarks.ResultBenchmarks-report-github.md
@@ -1,0 +1,23 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  
+WarmupCount=3  
+
+```
+| Method          | Mean       | Error     | StdDev    | Gen0   | Allocated |
+|---------------- |-----------:|----------:|----------:|-------:|----------:|
+| OkConstruction  |  1.7617 ns | 0.3002 ns | 0.0165 ns | 0.0005 |      24 B |
+| ErrConstruction |  1.7827 ns | 0.1962 ns | 0.0108 ns | 0.0005 |      24 B |
+| MatchOnOk       |  4.3346 ns | 1.5549 ns | 0.0852 ns |      - |         - |
+| MatchOnErr      |  2.6633 ns | 0.9228 ns | 0.0506 ns |      - |         - |
+| MapOnOk         |  6.4611 ns | 5.0836 ns | 0.2786 ns | 0.0005 |      24 B |
+| MapOnErr        |  7.4263 ns | 3.4197 ns | 0.1874 ns | 0.0005 |      24 B |
+| MapErrOnErr     | 10.0962 ns | 5.7980 ns | 0.3178 ns | 0.0011 |      56 B |
+| UnwrapOrOnOk    |  0.0223 ns | 0.1107 ns | 0.0061 ns |      - |         - |
+| UnwrapOrOnErr   |  0.0166 ns | 0.2958 ns | 0.0162 ns |      - |         - |

--- a/bench/Waystone.Monads.Benchmarks/AsyncChainBenchmarks.cs
+++ b/bench/Waystone.Monads.Benchmarks/AsyncChainBenchmarks.cs
@@ -1,0 +1,40 @@
+namespace Waystone.Monads.Benchmarks;
+
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Options;
+using Options.Extensions;
+
+[MemoryDiagnoser]
+public class AsyncChainBenchmarks
+{
+    private Option<int> _some = null!;
+    private Option<int> _none = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _some = Option.Some(42);
+        _none = Option.None<int>();
+    }
+
+    [Benchmark]
+    public ValueTask<Option<int>> SingleLinkOnSome() =>
+        _some.MapAsync(static value => Task.FromResult(value + 1));
+
+    [Benchmark]
+    public ValueTask<Option<int>> SingleLinkOnNone() =>
+        _none.MapAsync(static value => Task.FromResult(value + 1));
+
+    [Benchmark]
+    public Task<Option<int>> ThreeLinkChainOnSome() =>
+        _some.MapAsync(static value => Task.FromResult(value + 1))
+             .MapAsync(static value => value + 1)
+             .MapAsync(static value => value + 1);
+
+    [Benchmark]
+    public Task<Option<int>> ThreeLinkChainOnNone() =>
+        _none.MapAsync(static value => Task.FromResult(value + 1))
+             .MapAsync(static value => value + 1)
+             .MapAsync(static value => value + 1);
+}

--- a/bench/Waystone.Monads.Benchmarks/OptionBenchmarks.cs
+++ b/bench/Waystone.Monads.Benchmarks/OptionBenchmarks.cs
@@ -1,0 +1,60 @@
+namespace Waystone.Monads.Benchmarks;
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Options;
+
+[MemoryDiagnoser]
+public class OptionBenchmarks
+{
+    private static readonly Func<int, int> Increment = value => value + 1;
+    private static readonly Func<int, bool> IsPositive = value => value > 0;
+    private static readonly Func<int, string> Describe = value => value.ToString();
+    private static readonly Func<string> DescribeNone = () => "none";
+
+    private Option<int> _some = null!;
+    private Option<int> _none = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _some = Option.Some(42);
+        _none = Option.None<int>();
+    }
+
+    [Benchmark]
+    public Option<int> SomeConstruction() => Option.Some(42);
+
+    [Benchmark]
+    public Option<int> NoneConstruction() => Option.None<int>();
+
+    [Benchmark]
+    public Option<int> ImplicitConversion() => 42;
+
+    [Benchmark]
+    public Option<int> FromNullable() => Option.FromNullable((int?)42);
+
+    [Benchmark]
+    public string MatchOnSome() => _some.Match(Describe, DescribeNone);
+
+    [Benchmark]
+    public string MatchOnNone() => _none.Match(Describe, DescribeNone);
+
+    [Benchmark]
+    public Option<int> MapOnSome() => _some.Map(Increment);
+
+    [Benchmark]
+    public Option<int> MapOnNone() => _none.Map(Increment);
+
+    [Benchmark]
+    public Option<int> FilterKeeping() => _some.Filter(IsPositive);
+
+    [Benchmark]
+    public Option<int> FilterRejecting() => _some.Filter(static value => value < 0);
+
+    [Benchmark]
+    public int UnwrapOrOnSome() => _some.UnwrapOr(0);
+
+    [Benchmark]
+    public int UnwrapOrOnNone() => _none.UnwrapOr(0);
+}

--- a/bench/Waystone.Monads.Benchmarks/Program.cs
+++ b/bench/Waystone.Monads.Benchmarks/Program.cs
@@ -1,0 +1,49 @@
+namespace Waystone.Monads.Benchmarks;
+
+using System;
+using System.IO;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+public static class Program
+{
+    private const string LabelVariable = "WAYSTONE_BENCH_LABEL";
+    private const string SolutionFile = "Waystone.Net.sln";
+
+    public static void Main(string[] args)
+    {
+        IConfig config =
+            DefaultConfig.Instance.WithArtifactsPath(ResolveArtifactsPath());
+
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
+                         .Run(args, config);
+    }
+
+    private static string ResolveArtifactsPath()
+    {
+        string label =
+            Environment.GetEnvironmentVariable(LabelVariable) is
+                { Length: > 0 } set
+                ? set
+                : "local";
+
+        return Path.Combine(FindRepositoryRoot(), "artifacts", label);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, SolutionFile)))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+}

--- a/bench/Waystone.Monads.Benchmarks/README.md
+++ b/bench/Waystone.Monads.Benchmarks/README.md
@@ -1,0 +1,103 @@
+# Waystone.Monads.Benchmarks
+
+Allocation and throughput benchmarks for `Option<T>` and `Result<TOk, TErr>`.
+
+The harness exists to keep the v6 performance work honest: no optimisation in
+that milestone merges without a before/after figure from this project pasted
+into its pull request. `[MemoryDiagnoser]` is on every class because allocated
+bytes, not wall time, is the metric this library is judged on.
+
+## Running
+
+```
+dotnet run -c Release --project bench/Waystone.Monads.Benchmarks -- --filter '*'
+```
+
+Release configuration is mandatory — BenchmarkDotNet refuses to run a Debug
+build, and the numbers would be meaningless anyway. Narrow a run with a filter
+(`--filter '*Option*'`) and shorten it with `--job short` while iterating; take
+the final numbers from a default job.
+
+## Artifacts, and comparing releases
+
+Runs write to `artifacts/<label>/` at the repository root, not to the
+`BenchmarkDotNet.Artifacts/` directory BenchmarkDotNet uses by default. The
+label comes from the `WAYSTONE_BENCH_LABEL` environment variable and falls back
+to `local`.
+
+```
+WAYSTONE_BENCH_LABEL=v5-baseline dotnet run -c Release --project bench/Waystone.Monads.Benchmarks -- --filter '*'
+```
+
+The point of the label is to keep more than one release's numbers side by side.
+`artifacts/v5-baseline/` holds the numbers from `main` at 5.5.0, captured before
+any v6 change landed. Capture the v6 run under its own label and the two sit in
+the same tree, ready to diff:
+
+```
+git diff --no-index artifacts/v5-baseline/results/*.OptionBenchmarks-report-github.md artifacts/v6/results/*.OptionBenchmarks-report-github.md
+```
+
+Only the `*-report-github.md` reports are committed. The logs, CSV and HTML a
+run also produces are ignored — they are large, machine-specific, and nobody
+reviews them. Numbers taken on different machines are not comparable, so a
+release comparison has to come from one machine in one sitting.
+
+Passing `--artifacts <path>` on the command line overrides all of this, which is
+the escape hatch for a throwaway run you do not want in the tree.
+
+## What is covered
+
+| Class | Covers |
+| --- | --- |
+| `OptionBenchmarks` | `Some`/`None` construction, the implicit conversion, `FromNullable`, `Match`, `Map`, `Filter`, `UnwrapOr`, each on both cases |
+| `ResultBenchmarks` | `Ok`/`Err` construction, `Match`, `Map`, `MapErr`, `UnwrapOr`, each on both cases |
+| `AsyncChainBenchmarks` | A single async link and a three-link chain off a synchronous receiver, on both cases |
+
+`AsyncChainBenchmarks` is the one to watch across the v6 stack. A chain today
+starts as `ValueTask` off an `Option<T>` receiver and degrades to `Task` at the
+second link, so the allocation-free short-circuit survives exactly one hop.
+
+## Deliberate omissions
+
+**`net8.0` only.** The five-framework matrix is a correctness concern. Nobody
+acts on a `net472` throughput number, and building BenchmarkDotNet for it costs
+more than it tells us.
+
+**Not wired into CI.** A benchmark job on a shared GitHub runner produces noise,
+not signal, and gating a merge on it would be gating on the weather. Run it
+locally and paste the numbers.
+
+**Outside `src/`.** `release.yml` packs and pushes everything under `src/**` on
+a push to `main`. A benchmark harness must never reach NuGet, so it lives here
+and sets `IsPackable=false` as well.
+
+## Baseline
+
+`artifacts/v5-baseline/` holds the full reports, captured on `main` at 5.5.0
+before any v6 change, with `--job short` on an AMD Ryzen 7 9800X3D under
+Windows 11, .NET SDK 10.0.111, host runtime .NET 8.0.30. Short-run error bars
+are wide and the means jitter between runs; the allocation column is
+deterministic and is the one to read.
+
+Three things in those numbers drive the v6 performance work.
+
+**`Some` costs three times what `Ok` costs, and holds the same thing.**
+`SomeConstruction` allocates 72 B against `OkConstruction`'s 24 B. The object is
+the same size; the extra 48 B is two boxed `int`s, because `Some`'s constructor
+guard calls the static `object.Equals(value, default(T))` and boxes both
+operands. `Ok` has no guard and allocates only itself.
+
+**The implicit conversion pays that tax twice.** `ImplicitConversion` allocates
+120 B: 48 B boxing in the conversion's own `Equals(value, default(T))`, 48 B
+again in the `Some` constructor it calls, and 24 B for the object. That is the
+measurable cost of encoding one invariant in two places. `MapOnSome` allocates
+the same 120 B because `Map` returns a bare value and goes back through the
+conversion — against 24 B for `MapOnOk`, which does the same work.
+
+**Absence is not free.** `NoneConstruction`, `MapOnNone` and `FilterRejecting`
+each allocate 24 B for a `None<T>` that holds nothing and is indistinguishable
+from every other `None<T>` of its type.
+
+The async rows show the `ValueTask` to `Task` degradation: `ThreeLinkChainOnNone`
+allocates 216 B to short-circuit three times and produce nothing.

--- a/bench/Waystone.Monads.Benchmarks/ResultBenchmarks.cs
+++ b/bench/Waystone.Monads.Benchmarks/ResultBenchmarks.cs
@@ -1,0 +1,52 @@
+namespace Waystone.Monads.Benchmarks;
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Results;
+
+[MemoryDiagnoser]
+public class ResultBenchmarks
+{
+    private static readonly Func<int, int> Increment = value => value + 1;
+    private static readonly Func<string, string> Shout = error => error + "!";
+    private static readonly Func<int, string> Describe = value => value.ToString();
+    private static readonly Func<string, string> DescribeErr = error => error;
+
+    private Result<int, string> _ok = null!;
+    private Result<int, string> _err = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _ok = Result.Ok<int, string>(42);
+        _err = Result.Err<int, string>("boom");
+    }
+
+    [Benchmark]
+    public Result<int, string> OkConstruction() => Result.Ok<int, string>(42);
+
+    [Benchmark]
+    public Result<int, string> ErrConstruction() =>
+        Result.Err<int, string>("boom");
+
+    [Benchmark]
+    public string MatchOnOk() => _ok.Match(Describe, DescribeErr);
+
+    [Benchmark]
+    public string MatchOnErr() => _err.Match(Describe, DescribeErr);
+
+    [Benchmark]
+    public Result<int, string> MapOnOk() => _ok.Map(Increment);
+
+    [Benchmark]
+    public Result<int, string> MapOnErr() => _err.Map(Increment);
+
+    [Benchmark]
+    public Result<int, string> MapErrOnErr() => _err.MapErr(Shout);
+
+    [Benchmark]
+    public int UnwrapOrOnOk() => _ok.UnwrapOr(0);
+
+    [Benchmark]
+    public int UnwrapOrOnErr() => _err.UnwrapOr(0);
+}

--- a/bench/Waystone.Monads.Benchmarks/Waystone.Monads.Benchmarks.csproj
+++ b/bench/Waystone.Monads.Benchmarks/Waystone.Monads.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>latestMajor</LangVersion>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Waystone.Monads\Waystone.Monads.csproj"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The v6 milestone carries performance work, and two of its items cannot be
verified without a harness: DRA-84 requires a benchmark proving the state
overloads avoid the closure's display-class allocation, and DRA-100 needs a
baseline captured before any v6 change lands.

Runs write to artifacts/<label>/ rather than BenchmarkDotNet.Artifacts, with
the label taken from WAYSTONE_BENCH_LABEL, so a v5 and a v6 run sit side by
side in one tree and can be diffed. Only the GitHub markdown reports are
committed; the logs, CSV and HTML are ignored.

artifacts/v5-baseline holds the numbers from main at 5.5.0. They confirm the
three wins DRA-100 predicted from reading the source:

- Some allocates 72 B against Ok's 24 B for the same object, because Some's
  constructor guard calls the static object.Equals(value, default(T)) and
  boxes both operands.
- The implicit conversion allocates 120 B, paying that boxing tax twice: once
  in its own Equals and again in the Some constructor it calls. Map on a Some
  costs the same 120 B against 24 B for Map on an Ok.
- None<T> allocates 24 B per call despite holding nothing.

The project sits outside src/ so release.yml cannot publish it, and sets
IsPackable=false as well. It targets net8.0 only: the five-framework matrix is
a correctness concern, and nobody acts on a net472 throughput number. It is not
wired into CI, because a benchmark on a shared runner measures the weather.

Directory.Packages.props is reformatted to dotnet add package's canonical
layout so future package adds produce a one-line diff instead of rewriting the
file.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>