### PR TITLE
feat!: every async Option/Result extension returns ValueTask uniformly

### DIFF
--- a/artifacts/v6-dra66/results/Waystone.Monads.Benchmarks.AsyncChainBenchmarks-report-github.md
+++ b/artifacts/v6-dra66/results/Waystone.Monads.Benchmarks.AsyncChainBenchmarks-report-github.md
@@ -1,0 +1,20 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  
+WarmupCount=3  
+
+```
+| Method                        | Mean       | Error     | StdDev    | Gen0   | Allocated |
+|------------------------------ |-----------:|----------:|----------:|-------:|----------:|
+| SingleLinkOnSome              |  13.956 ns | 12.470 ns | 0.6835 ns | 0.0029 |     144 B |
+| SingleLinkOnNone              |   8.461 ns |  3.538 ns | 0.1940 ns | 0.0005 |      24 B |
+| ThreeLinkChainOnSome          |  33.999 ns |  5.649 ns | 0.3097 ns | 0.0057 |     288 B |
+| ThreeLinkChainOnNone          |  22.498 ns |  6.829 ns | 0.3743 ns | 0.0014 |      72 B |
+| ThreeLinkChainOnCompletedTask |  41.914 ns | 38.502 ns | 2.1104 ns | 0.0072 |     360 B |
+| ThreeLinkChainOnPendingTask   | 619.115 ns | 31.040 ns | 1.7014 ns | 0.0172 |     866 B |

--- a/artifacts/v6-dra66/results/Waystone.Monads.Benchmarks.OptionBenchmarks-report-github.md
+++ b/artifacts/v6-dra66/results/Waystone.Monads.Benchmarks.OptionBenchmarks-report-github.md
@@ -1,0 +1,26 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  
+WarmupCount=3  
+
+```
+| Method             | Mean      | Error     | StdDev    | Gen0   | Allocated |
+|------------------- |----------:|----------:|----------:|-------:|----------:|
+| SomeConstruction   | 5.0852 ns | 3.0118 ns | 0.1651 ns | 0.0014 |      72 B |
+| NoneConstruction   | 1.6389 ns | 0.8895 ns | 0.0488 ns | 0.0005 |      24 B |
+| ImplicitConversion | 7.2088 ns | 6.5636 ns | 0.3598 ns | 0.0024 |     120 B |
+| FromNullable       | 8.1177 ns | 1.7245 ns | 0.0945 ns | 0.0019 |      96 B |
+| MatchOnSome        | 4.1024 ns | 0.8693 ns | 0.0476 ns |      - |         - |
+| MatchOnNone        | 2.7529 ns | 1.3574 ns | 0.0744 ns |      - |         - |
+| MapOnSome          | 9.2446 ns | 0.8126 ns | 0.0445 ns | 0.0024 |     120 B |
+| MapOnNone          | 4.1512 ns | 0.6097 ns | 0.0334 ns | 0.0005 |      24 B |
+| FilterKeeping      | 0.2765 ns | 0.3737 ns | 0.0205 ns |      - |         - |
+| FilterRejecting    | 2.0426 ns | 1.6300 ns | 0.0893 ns | 0.0005 |      24 B |
+| UnwrapOrOnSome     | 0.0061 ns | 0.0534 ns | 0.0029 ns |      - |         - |
+| UnwrapOrOnNone     | 0.0066 ns | 0.0932 ns | 0.0051 ns |      - |         - |

--- a/artifacts/v6-dra66/results/Waystone.Monads.Benchmarks.ResultBenchmarks-report-github.md
+++ b/artifacts/v6-dra66/results/Waystone.Monads.Benchmarks.ResultBenchmarks-report-github.md
@@ -1,0 +1,23 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]   : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  ShortRun : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+Job=ShortRun  IterationCount=3  LaunchCount=1  
+WarmupCount=3  
+
+```
+| Method          | Mean      | Error     | StdDev    | Median    | Gen0   | Allocated |
+|---------------- |----------:|----------:|----------:|----------:|-------:|----------:|
+| OkConstruction  | 1.7137 ns | 0.2466 ns | 0.0135 ns | 1.7171 ns | 0.0005 |      24 B |
+| ErrConstruction | 1.7241 ns | 0.3773 ns | 0.0207 ns | 1.7350 ns | 0.0005 |      24 B |
+| MatchOnOk       | 4.2647 ns | 0.9305 ns | 0.0510 ns | 4.2892 ns |      - |         - |
+| MatchOnErr      | 2.6638 ns | 0.5031 ns | 0.0276 ns | 2.6584 ns |      - |         - |
+| MapOnOk         | 6.1086 ns | 3.4975 ns | 0.1917 ns | 6.0620 ns | 0.0005 |      24 B |
+| MapOnErr        | 7.4728 ns | 6.7275 ns | 0.3688 ns | 7.5452 ns | 0.0005 |      24 B |
+| MapErrOnErr     | 9.6964 ns | 4.7454 ns | 0.2601 ns | 9.7792 ns | 0.0011 |      56 B |
+| UnwrapOrOnOk    | 0.0025 ns | 0.0585 ns | 0.0032 ns | 0.0014 ns |      - |         - |
+| UnwrapOrOnErr   | 0.0148 ns | 0.2824 ns | 0.0155 ns | 0.0134 ns |      - |         - |

--- a/bench/Waystone.Monads.Benchmarks/AsyncChainBenchmarks.cs
+++ b/bench/Waystone.Monads.Benchmarks/AsyncChainBenchmarks.cs
@@ -27,14 +27,43 @@ public class AsyncChainBenchmarks
         _none.MapAsync(static value => Task.FromResult(value + 1));
 
     [Benchmark]
-    public Task<Option<int>> ThreeLinkChainOnSome() =>
+    public ValueTask<Option<int>> ThreeLinkChainOnSome() =>
         _some.MapAsync(static value => Task.FromResult(value + 1))
              .MapAsync(static value => value + 1)
              .MapAsync(static value => value + 1);
 
     [Benchmark]
-    public Task<Option<int>> ThreeLinkChainOnNone() =>
+    public ValueTask<Option<int>> ThreeLinkChainOnNone() =>
         _none.MapAsync(static value => Task.FromResult(value + 1))
              .MapAsync(static value => value + 1)
              .MapAsync(static value => value + 1);
+
+    [Benchmark]
+    public async Task<Option<int>> ThreeLinkChainOnCompletedTask()
+    {
+        var chain = Task.FromResult(_some)
+                        .MapAsync(static value => value + 1)
+                        .MapAsync(static value => value + 1)
+                        .MapAsync(static value => value + 1);
+
+        return await chain;
+    }
+
+    [Benchmark]
+    public async Task<Option<int>> ThreeLinkChainOnPendingTask()
+    {
+        var chain = PendingAsync(_some)
+                   .MapAsync(static value => value + 1)
+                   .MapAsync(static value => value + 1)
+                   .MapAsync(static value => value + 1);
+
+        return await chain;
+    }
+
+    private static async Task<Option<int>> PendingAsync(Option<int> option)
+    {
+        await Task.Yield();
+
+        return option;
+    }
 }

--- a/bench/Waystone.Monads.Benchmarks/README.md
+++ b/bench/Waystone.Monads.Benchmarks/README.md
@@ -101,3 +101,37 @@ from every other `None<T>` of its type.
 
 The async rows show the `ValueTask` to `Task` degradation: `ThreeLinkChainOnNone`
 allocates 216 B to short-circuit three times and produce nothing.
+
+## The uniform `ValueTask` result
+
+`artifacts/v6-dra66/` holds the run after DRA-66, on the same machine and
+settings. It is the reason the two `Task`-receiver chain benchmarks exist.
+
+| Three-link chain, by head | before | after | Δ |
+| -- | --: | --: | --: |
+| sync `Option`, `Some` | 432 B | 288 B | −144 B |
+| sync `Option`, `None` | 216 B | 72 B | −144 B |
+| completed `Task` | 576 B | 360 B | −216 B |
+| pending `Task` | 782 B | 866 B | **+84 B** |
+
+The last row is a real regression and was measured rather than predicted. A
+fluent chain is built eagerly, so every link attaches before the one above it
+completes: if the head is pending, link two awaits an incomplete `ValueTask`
+and suspends as well, and so does link three. The chain is either wholly
+synchronous or wholly pending, and there is no partial case where `ValueTask`
+saves one hop out of three. When it is wholly pending, `ValueTask` costs more
+than `Task`, because an `AsyncValueTaskMethodBuilder` box holds the state
+machine inline and is larger than the `Task` it replaces.
+
+`ValueTask` therefore pays only when the head completes synchronously — which
+is why the first three rows win and the fourth loses. The trade was taken
+deliberately: the loss lands on a chain that has just done real I/O, where 84 B
+against a 619 ns await is noise, and the win lands on the synchronous path,
+which is the hot one.
+
+The `before` column for the first two rows comes from `artifacts/v5-baseline/`.
+The last two benchmarks did not exist at 5.5.0, so their `before` column was
+captured from a scratch build with the `Task`-receiver row left on `Task` and
+the `ValueTask`-receiver row converted. For a chain whose head is a `Task`,
+every link binds to the `Task`-receiver row and never reaches the other one, so
+that configuration is byte-identical to 5.5.0 for these two rows only.

--- a/src/Waystone.Monads/Options/Extensions/AndExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/AndExtensions.cs
@@ -17,11 +17,11 @@ public static class AndExtensions
         /// <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" /> containing
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" /> containing
         /// <paramref name="other" /> if the awaited option was a <see cref="Some{T}" />,
         /// or <see cref="None{T}" /> otherwise.
         /// </returns>
-        public async Task<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
+        public async ValueTask<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -43,11 +43,11 @@ public static class AndExtensions
         /// <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" /> containing
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" /> containing
         /// <paramref name="other" /> if the awaited option was a <see cref="Some{T}" />,
         /// or <see cref="None{T}" /> otherwise.
         /// </returns>
-        public async Task<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
+        public async ValueTask<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Options/Extensions/AndThenExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/AndThenExtensions.cs
@@ -50,12 +50,12 @@ public static class AndThenExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the <see cref="Option{TOut}" />, with
+        /// A <see cref="ValueTask{TResult}" /> containing the <see cref="Option{TOut}" />, with
         /// the mapped value if the original <see cref="Option{T}" /> was
         /// <see cref="Some{T}" />, or
         /// <see cref="None{T}" /> otherwise.
         /// </returns>
-        public async Task<Option<TOut>> AndThenAsync<TOut>(
+        public async ValueTask<Option<TOut>> AndThenAsync<TOut>(
             Func<T, Task<Option<TOut>>> map)
             where TOut : notnull
         {
@@ -81,12 +81,12 @@ public static class AndThenExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" />, containing the
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" />, containing the
         /// mapped
         /// value if the original <see cref="Option{T}" /> was <see cref="Some{T}" />, or
         /// <see cref="None{T}" /> otherwise.
         /// </returns>
-        public async Task<Option<TOut>> AndThenAsync<TOut>(
+        public async ValueTask<Option<TOut>> AndThenAsync<TOut>(
             Func<T, Option<TOut>> map)
             where TOut : notnull
         {
@@ -115,12 +115,12 @@ public static class AndThenExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" />, containing
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" />, containing
         /// the mapped value if the original <see cref="Option{T}" /> was
         /// <see cref="Some{T}" />, or
         /// <see cref="None{T}" /> otherwise.
         /// </returns>
-        public async Task<Option<TOut>> AndThenAsync<TOut>(
+        public async ValueTask<Option<TOut>> AndThenAsync<TOut>(
             Func<T, Task<Option<TOut>>> map)
             where TOut : notnull
         {
@@ -146,12 +146,12 @@ public static class AndThenExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" />, containing
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" />, containing
         /// the mapped value if the original <see cref="Option{T}" /> was
         /// <see cref="Some{T}" />,
         /// or <see cref="None{T}" /> otherwise.
         /// </returns>
-        public async Task<Option<TOut>> AndThenAsync<TOut>(
+        public async ValueTask<Option<TOut>> AndThenAsync<TOut>(
             Func<T, Option<TOut>> map)
             where TOut : notnull
         {

--- a/src/Waystone.Monads/Options/Extensions/AsEnumerableExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/AsEnumerableExtensions.cs
@@ -12,11 +12,11 @@ public static class AsEnumerableExtensions
         /// possibly contained value.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// A <see cref="ValueTask{TResult}" /> containing a sequence that yields the
         /// contained value once if the awaited option was a <see cref="Some{T}" />,
         /// otherwise an empty sequence.
         /// </returns>
-        public async Task<IEnumerable<T>> AsEnumerableAsync()
+        public async ValueTask<IEnumerable<T>> AsEnumerableAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -31,11 +31,11 @@ public static class AsEnumerableExtensions
         /// possibly contained value.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// A <see cref="ValueTask{TResult}" /> containing a sequence that yields the
         /// contained value once if the awaited option was a <see cref="Some{T}" />,
         /// otherwise an empty sequence.
         /// </returns>
-        public async Task<IEnumerable<T>> AsEnumerableAsync()
+        public async ValueTask<IEnumerable<T>> AsEnumerableAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/ExpectExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/ExpectExtensions.cs
@@ -19,7 +19,7 @@ public static class ExpectExtensions
         /// Thrown when the awaited
         /// option is a <see cref="None{T}" />
         /// </exception>
-        public async Task<T> ExpectAsync(string message)
+        public async ValueTask<T> ExpectAsync(string message)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -41,7 +41,7 @@ public static class ExpectExtensions
         /// Thrown when the awaited
         /// option is a <see cref="None{T}" />
         /// </exception>
-        public async Task<T> ExpectAsync(string message)
+        public async ValueTask<T> ExpectAsync(string message)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/FilterExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/FilterExtensions.cs
@@ -48,11 +48,11 @@ public static class FilterExtensions
         /// value contained in the <see cref="Option{T}" /> satisfies the condition.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing an <see cref="Option{T}" /> of type
+        /// A <see cref="ValueTask{TResult}" /> containing an <see cref="Option{T}" /> of type
         /// <typeparamref name="T" /> that contains the initial value if it satisfies the
         /// predicate, or an empty <see cref="Option{T}" /> if it does not.
         /// </returns>
-        public async Task<Option<T>>
+        public async ValueTask<Option<T>>
             FilterAsync(Func<T, Task<bool>> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -76,13 +76,13 @@ public static class FilterExtensions
         /// satisfies the condition.
         /// </param>
         /// <returns>
-        /// An asynchronous <see cref="Task{TResult}" /> containing an
+        /// An asynchronous <see cref="ValueTask{TResult}" /> containing an
         /// <see cref="Option{T}" /> of
         /// type <typeparamref name="T" /> that contains the initial value if it satisfies
         /// the
         /// predicate, or an empty <see cref="Option{T}" /> if it does not.
         /// </returns>
-        public async Task<Option<T>>
+        public async ValueTask<Option<T>>
             FilterAsync(Func<T, bool> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -109,12 +109,12 @@ public static class FilterExtensions
         /// in the <see cref="Option{T}" /> satisfies the condition.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing an <see cref="Option{T}" /> of type
+        /// A <see cref="ValueTask{TResult}" /> containing an <see cref="Option{T}" /> of type
         /// <typeparamref name="T" /> that contains the initial value if it satisfies the
         /// predicate,
         /// or an empty <see cref="Option{T}" /> if it does not.
         /// </returns>
-        public async Task<Option<T>>
+        public async ValueTask<Option<T>>
             FilterAsync(Func<T, Task<bool>> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -138,11 +138,11 @@ public static class FilterExtensions
         /// satisfies the condition.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing an <see cref="Option{T}" /> of type
+        /// A <see cref="ValueTask{TResult}" /> containing an <see cref="Option{T}" /> of type
         /// <typeparamref name="T" /> that contains the initial value if it satisfies
         /// the predicate, or an empty <see cref="Option{T}" /> if it does not.
         /// </returns>
-        public async Task<Option<T>>
+        public async ValueTask<Option<T>>
             FilterAsync(Func<T, bool> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Options/Extensions/FlatMapExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/FlatMapExtensions.cs
@@ -44,14 +44,14 @@ public static class FlatMapExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the <see cref="Option{TOut}" />, with
+        /// A <see cref="ValueTask{TResult}" /> containing the <see cref="Option{TOut}" />, with
         /// the mapped value if the original <see cref="Option{T}" /> was
         /// <see cref="Some{T}" />, or
         /// <see cref="None{T}" /> otherwise.
         /// </returns>
         [Obsolete(
             "Use AndThenAsync instead. This method will be removed in v6 of Waystone.Monads.")]
-        public Task<Option<TOut>> FlatMapAsync<TOut>(
+        public ValueTask<Option<TOut>> FlatMapAsync<TOut>(
             Func<T, Task<Option<TOut>>> map)
             where TOut : notnull =>
             optionTask.AndThenAsync(map);
@@ -68,14 +68,14 @@ public static class FlatMapExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" />, containing the
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" />, containing the
         /// mapped
         /// value if the original <see cref="Option{T}" /> was <see cref="Some{T}" />, or
         /// <see cref="None{T}" /> otherwise.
         /// </returns>
         [Obsolete(
             "Use AndThenAsync instead. This method will be removed in v6 of Waystone.Monads.")]
-        public Task<Option<TOut>> FlatMapAsync<TOut>(
+        public ValueTask<Option<TOut>> FlatMapAsync<TOut>(
             Func<T, Option<TOut>> map)
             where TOut : notnull =>
             optionTask.AndThenAsync(map);
@@ -93,14 +93,14 @@ public static class FlatMapExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" />, containing
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" />, containing
         /// the mapped value if the original <see cref="Option{T}" /> was
         /// <see cref="Some{T}" />, or
         /// <see cref="None{T}" /> otherwise.
         /// </returns>
         [Obsolete(
             "Use AndThenAsync instead. This method will be removed in v6 of Waystone.Monads.")]
-        public Task<Option<TOut>> FlatMapAsync<TOut>(
+        public ValueTask<Option<TOut>> FlatMapAsync<TOut>(
             Func<T, Task<Option<TOut>>> map)
             where TOut : notnull =>
             optionTask.AndThenAsync(map);
@@ -115,14 +115,14 @@ public static class FlatMapExtensions
         /// <see cref="Option{T}" /> to another <see cref="Option{TOut}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> of <see cref="Option{TOut}" />, containing
+        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" />, containing
         /// the mapped value if the original <see cref="Option{T}" /> was
         /// <see cref="Some{T}" />,
         /// or <see cref="None{T}" /> otherwise.
         /// </returns>
         [Obsolete(
             "Use AndThenAsync instead. This method will be removed in v6 of Waystone.Monads.")]
-        public Task<Option<TOut>> FlatMapAsync<TOut>(
+        public ValueTask<Option<TOut>> FlatMapAsync<TOut>(
             Func<T, Option<TOut>> map)
             where TOut : notnull =>
             optionTask.AndThenAsync(map);

--- a/src/Waystone.Monads/Options/Extensions/FlattenExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/FlattenExtensions.cs
@@ -15,7 +15,7 @@ public static class FlattenExtensions
         /// <see cref="Option{T}" /> to a single-level
         /// <see cref="Option{T}" />.
         /// </returns>
-        public async Task<Option<T>> FlattenAsync()
+        public async ValueTask<Option<T>> FlattenAsync()
         {
             Option<Option<T>> nestedOption =
                 await nestedOptionTask.ConfigureAwait(false);
@@ -36,7 +36,7 @@ public static class FlattenExtensions
         /// the
         /// nested <see cref="Option{T}" /> into a single-level <see cref="Option{T}" />.
         /// </returns>
-        public async Task<Option<T>> FlattenAsync()
+        public async ValueTask<Option<T>> FlattenAsync()
         {
             Option<Option<T>> nestedOption =
                 await nestedOptionTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Options/Extensions/InspectExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/InspectExtensions.cs
@@ -20,7 +20,7 @@ public static class InspectExtensions
 
     extension<T>(Task<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Option<T>> InspectAsync(Func<T, Task> action)
+        public async ValueTask<Option<T>> InspectAsync(Func<T, Task> action)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -32,7 +32,7 @@ public static class InspectExtensions
             return option;
         }
 
-        public async Task<Option<T>> InspectAsync(Action<T> action)
+        public async ValueTask<Option<T>> InspectAsync(Action<T> action)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -47,7 +47,7 @@ public static class InspectExtensions
 
     extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Option<T>> InspectAsync(Func<T, Task> action)
+        public async ValueTask<Option<T>> InspectAsync(Func<T, Task> action)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -59,7 +59,7 @@ public static class InspectExtensions
             return option;
         }
 
-        public async Task<Option<T>> InspectAsync(Action<T> action)
+        public async ValueTask<Option<T>> InspectAsync(Action<T> action)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/IsNoneOrExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/IsNoneOrExtensions.cs
@@ -44,13 +44,13 @@ public static class IsNoneOrExtensions
         /// if it is in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "None" state or if in a "Some" state
         /// and the predicate evaluates to <see langword="false" /> for the contained
         /// value;
         /// otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsNoneOrAsync(Func<T, bool> predicate)
+        public async ValueTask<bool> IsNoneOrAsync(Func<T, bool> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -66,12 +66,12 @@ public static class IsNoneOrExtensions
         /// <see cref="Option{T}" /> if it is in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "None" state or the predicate evaluates to
         /// <see langword="true" /> for the contained value; otherwise,
         /// <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsNoneOrAsync(Func<T, Task<bool>> predicate)
+        public async ValueTask<bool> IsNoneOrAsync(Func<T, Task<bool>> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -90,12 +90,12 @@ public static class IsNoneOrExtensions
         /// <see cref="Option{T}" /> if it is in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "None" state, or if it is in a "Some" state
         /// and the predicate evaluates to <see langword="true" /> for the contained value;
         /// otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsNoneOrAsync(Func<T, Task<bool>> predicate)
+        public async ValueTask<bool> IsNoneOrAsync(Func<T, Task<bool>> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -111,12 +111,12 @@ public static class IsNoneOrExtensions
         /// if it is in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "None" state or the predicate evaluates to
         /// <see langword="true" /> for the contained value; otherwise,
         /// <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsNoneOrAsync(Func<T, bool> predicate)
+        public async ValueTask<bool> IsNoneOrAsync(Func<T, bool> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/IsSomeAndExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/IsSomeAndExtensions.cs
@@ -47,12 +47,12 @@ public static class IsSomeAndExtensions
         /// <see cref="Option{T}" /> if it is in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "Some" state
         /// and the predicate evaluates to <see langword="true" /> for the contained value;
         /// otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsSomeAndAsync(Func<T, Task<bool>> predicate)
+        public async ValueTask<bool> IsSomeAndAsync(Func<T, Task<bool>> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -69,12 +69,12 @@ public static class IsSomeAndExtensions
         /// in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "Some" state and the predicate evaluates to
         /// <see langword="true" /> for the contained value; otherwise,
         /// <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsSomeAndAsync(Func<T, bool> predicate)
+        public async ValueTask<bool> IsSomeAndAsync(Func<T, bool> predicate)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -94,12 +94,12 @@ public static class IsSomeAndExtensions
         /// <see cref="Option{T}" /> if it is in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "Some" state
         /// and the predicate evaluates to <see langword="true" /> for the contained value;
         /// otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsSomeAndAsync(Func<T, Task<bool>> predicate)
+        public async ValueTask<bool> IsSomeAndAsync(Func<T, Task<bool>> predicate)
         {
             Option<T> option = await optionValueTask.ConfigureAwait(false);
 
@@ -116,12 +116,12 @@ public static class IsSomeAndExtensions
         /// if it is in a "Some" state.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// <see cref="Option{T}" /> is in a "Some" state and the predicate evaluates
         /// to <see langword="true" /> for the contained value; otherwise,
         /// <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsSomeAndAsync(Func<T, bool> predicate)
+        public async ValueTask<bool> IsSomeAndAsync(Func<T, bool> predicate)
         {
             Option<T> option = await optionValueTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/MapExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapExtensions.cs
@@ -36,7 +36,7 @@ public static class MapExtensions
         /// A task containing an <see cref="Option{TOut}" /> with the transformed value if
         /// the original option was in a "Some" state; otherwise, an empty option.
         /// </returns>
-        public async Task<Option<TOut>> MapAsync<TOut>(Func<T, Task<TOut>> map)
+        public async ValueTask<Option<TOut>> MapAsync<TOut>(Func<T, Task<TOut>> map)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -66,7 +66,7 @@ public static class MapExtensions
         /// A task containing an <see cref="Option{TOut}" /> with the transformed value if
         /// the original option was in a "Some" state; otherwise, an empty option.
         /// </returns>
-        public async Task<Option<TOut>> MapAsync<TOut>(Func<T, TOut> map)
+        public async ValueTask<Option<TOut>> MapAsync<TOut>(Func<T, TOut> map)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -97,7 +97,7 @@ public static class MapExtensions
         /// the original <see cref="Option{T}" /> was in a "Some" state; otherwise, an
         /// empty option.
         /// </returns>
-        public async Task<Option<TOut>> MapAsync<TOut>(Func<T, Task<TOut>> map)
+        public async ValueTask<Option<TOut>> MapAsync<TOut>(Func<T, Task<TOut>> map)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -126,7 +126,7 @@ public static class MapExtensions
         /// transformed value
         /// if the original option was in a "Some" state; otherwise, an empty option.
         /// </returns>
-        public async Task<Option<TOut>> MapAsync<TOut>(Func<T, TOut> map)
+        public async ValueTask<Option<TOut>> MapAsync<TOut>(Func<T, TOut> map)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Options/Extensions/MapOrDefaultExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrDefaultExtensions.cs
@@ -47,11 +47,11 @@ public static class MapOrDefaultExtensions
         /// a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -71,11 +71,11 @@ public static class MapOrDefaultExtensions
         /// option if it is a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
             Func<T, Task<TOut>> map)
             where TOut : notnull
         {
@@ -103,11 +103,11 @@ public static class MapOrDefaultExtensions
         /// a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
             where TOut : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -127,11 +127,11 @@ public static class MapOrDefaultExtensions
         /// option if it is a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
             Func<T, Task<TOut>> map)
             where TOut : notnull
         {

--- a/src/Waystone.Monads/Options/Extensions/MapOrElseExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrElseExtensions.cs
@@ -7,7 +7,7 @@ public static class MapOrElseExtensions
 {
     extension<T>(Option<T> option) where T : notnull
     {
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<Task<TOut>> defaultFunc,
             Func<T, Task<TOut>> map)
         {
@@ -21,7 +21,7 @@ public static class MapOrElseExtensions
             return await map.Invoke(some).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TOut> defaultFunc,
             Func<T, Task<TOut>> map)
         {
@@ -35,7 +35,7 @@ public static class MapOrElseExtensions
             return await map.Invoke(some).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<Task<TOut>> defaultFunc,
             Func<T, TOut> map)
         {
@@ -52,7 +52,7 @@ public static class MapOrElseExtensions
 
     extension<T>(Task<Option<T>> optionTask) where T : notnull
     {
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TOut> defaultFunc,
             Func<T, TOut> map)
         {
@@ -68,7 +68,7 @@ public static class MapOrElseExtensions
             return map.Invoke(some);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<Task<TOut>> defaultFunc,
             Func<T, Task<TOut>> map)
         {
@@ -84,7 +84,7 @@ public static class MapOrElseExtensions
             return await map.Invoke(some).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TOut> defaultFunc,
             Func<T, Task<TOut>> map)
         {
@@ -100,7 +100,7 @@ public static class MapOrElseExtensions
             return await map.Invoke(some).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<Task<TOut>> defaultFunc,
             Func<T, TOut> map)
         {
@@ -119,7 +119,7 @@ public static class MapOrElseExtensions
 
     extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
     {
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TOut> defaultFunc,
             Func<T, TOut> map)
         {
@@ -135,7 +135,7 @@ public static class MapOrElseExtensions
             return map.Invoke(some);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<Task<TOut>> defaultFunc,
             Func<T, Task<TOut>> map)
         {
@@ -151,7 +151,7 @@ public static class MapOrElseExtensions
             return await map.Invoke(some).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TOut> defaultFunc,
             Func<T, Task<TOut>> map)
         {
@@ -167,7 +167,7 @@ public static class MapOrElseExtensions
             return await map.Invoke(some).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<Task<TOut>> defaultFunc,
             Func<T, TOut> map)
         {

--- a/src/Waystone.Monads/Options/Extensions/MapOrExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrExtensions.cs
@@ -44,7 +44,7 @@ public static class MapOrExtensions
         /// of type <typeparamref name="TOut" /> if the option is <see cref="Some{T}" />,
         /// or the provided default value if the option is <see cref="None{T}" />
         /// </returns>
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<T, TOut> map)
         {
@@ -80,7 +80,7 @@ public static class MapOrExtensions
         /// of type <typeparamref name="TOut" /> if the option is <see cref="Some{T}" />,
         /// or the provided default value if the option is <see cref="None{T}" />
         /// </returns>
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<T, Task<TOut>> map)
         {
@@ -119,7 +119,7 @@ public static class MapOrExtensions
         /// of type <typeparamref name="TOut" /> if the option is <see cref="Some{T}" />,
         /// or the provided default value if the option is <see cref="None{T}" />.
         /// </returns>
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<T, TOut> map)
         {
@@ -155,7 +155,7 @@ public static class MapOrExtensions
         /// of type <typeparamref name="TOut" /> if the option is <see cref="Some{T}" />,
         /// or the provided default value if the option is <see cref="None{T}" />
         /// </returns>
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<T, Task<TOut>> map)
         {

--- a/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
@@ -67,10 +67,10 @@ public static class MapOrNullExtensions
         /// a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
             where TOut : struct
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -89,10 +89,10 @@ public static class MapOrNullExtensions
         /// option if it is a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
             where TOut : struct
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -118,10 +118,10 @@ public static class MapOrNullExtensions
         /// a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
             where TOut : struct
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -140,10 +140,10 @@ public static class MapOrNullExtensions
         /// option if it is a <see cref="Some{T}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
             where TOut : struct
         {
             Option<T> option = await optionTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Options/Extensions/MatchExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MatchExtensions.cs
@@ -32,7 +32,7 @@ public static class MatchExtensions
         /// contains the result of
         /// either the <paramref name="onSome" /> or <paramref name="onNone" /> function.
         /// </returns>
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, Task<TOut>> onSome,
             Func<Task<TOut>> onNone)
         {
@@ -41,7 +41,7 @@ public static class MatchExtensions
             return await option.Match(onSome, onNone);
         }
 
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, TOut> onSome,
             Func<Task<TOut>> onNone)
         {
@@ -54,7 +54,7 @@ public static class MatchExtensions
             return onSome(some);
         }
 
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, Task<TOut>> onSome,
             Func<TOut> onNone)
         {
@@ -90,7 +90,7 @@ public static class MatchExtensions
         /// the result of either the <paramref name="onSome" /> or
         /// <paramref name="onNone" /> function.
         /// </returns>
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, TOut> onSome,
             Func<TOut> onNone)
         {
@@ -126,7 +126,7 @@ public static class MatchExtensions
         /// the result of either the <paramref name="onSome" /> or
         /// <paramref name="onNone" /> function.
         /// </returns>
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, Task<TOut>> onSome,
             Func<Task<TOut>> onNone)
         {
@@ -135,7 +135,7 @@ public static class MatchExtensions
             return await option.Match(onSome, onNone);
         }
 
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, TOut> onSome,
             Func<Task<TOut>> onNone)
         {
@@ -148,7 +148,7 @@ public static class MatchExtensions
             return onSome(some);
         }
 
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, Task<TOut>> onSome,
             Func<TOut> onNone)
         {
@@ -184,7 +184,7 @@ public static class MatchExtensions
         /// contains the result of either the <paramref name="onSome" /> or
         /// <paramref name="onNone" /> function.
         /// </returns>
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<T, TOut> onSome,
             Func<TOut> onNone)
         {

--- a/src/Waystone.Monads/Options/Extensions/OkOrElseExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/OkOrElseExtensions.cs
@@ -27,7 +27,7 @@ public static class OkOrElseExtensions
 
     extension<T>(Task<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Result<T, TErr>> OkOrElseAsync<TErr>(
+        public async ValueTask<Result<T, TErr>> OkOrElseAsync<TErr>(
             Func<TErr> errFunc)
             where TErr : notnull
         {
@@ -36,7 +36,7 @@ public static class OkOrElseExtensions
             return option.OkOrElse(errFunc);
         }
 
-        public Task<Result<T, TErr>> OkOrElseAsync<TErr>(
+        public ValueTask<Result<T, TErr>> OkOrElseAsync<TErr>(
             Func<Task<TErr>> errFunc)
             where TErr : notnull =>
             optionTask.MatchAsync(
@@ -51,7 +51,7 @@ public static class OkOrElseExtensions
 
     extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Result<T, TErr>> OkOrElseAsync<TErr>(
+        public async ValueTask<Result<T, TErr>> OkOrElseAsync<TErr>(
             Func<TErr> errFunc)
             where TErr : notnull
         {
@@ -60,7 +60,7 @@ public static class OkOrElseExtensions
             return option.OkOrElse(errFunc);
         }
 
-        public Task<Result<T, TErr>> OkOrElseAsync<TErr>(
+        public ValueTask<Result<T, TErr>> OkOrElseAsync<TErr>(
             Func<Task<TErr>> errFunc)
             where TErr : notnull =>
             optionTask.MatchAsync(

--- a/src/Waystone.Monads/Options/Extensions/OkOrExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/OkOrExtensions.cs
@@ -7,7 +7,7 @@ public static class OkOrExtensions
 {
     extension<T>(Task<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Result<T, TErr>> OkOrAsync<TErr>(TErr err)
+        public async ValueTask<Result<T, TErr>> OkOrAsync<TErr>(TErr err)
             where TErr : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
@@ -18,7 +18,7 @@ public static class OkOrExtensions
 
     extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Result<T, TErr>> OkOrAsync<TErr>(TErr err)
+        public async ValueTask<Result<T, TErr>> OkOrAsync<TErr>(TErr err)
             where TErr : notnull
         {
             Option<T> option = await optionTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Options/Extensions/OrElseExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/OrElseExtensions.cs
@@ -18,14 +18,14 @@ public static class OrElseExtensions
 
     extension<T>(Task<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Option<T>> OrElseAsync(Func<Option<T>> elseFunc)
+        public async ValueTask<Option<T>> OrElseAsync(Func<Option<T>> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
             return option.IsSome ? option : elseFunc.Invoke();
         }
 
-        public async Task<Option<T>> OrElseAsync(Func<Task<Option<T>>> elseFunc)
+        public async ValueTask<Option<T>> OrElseAsync(Func<Task<Option<T>>> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -37,14 +37,14 @@ public static class OrElseExtensions
 
     extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
     {
-        public async Task<Option<T>> OrElseAsync(Func<Option<T>> elseFunc)
+        public async ValueTask<Option<T>> OrElseAsync(Func<Option<T>> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
             return option.IsSome ? option : elseFunc.Invoke();
         }
 
-        public async Task<Option<T>> OrElseAsync(Func<Task<Option<T>>> elseFunc)
+        public async ValueTask<Option<T>> OrElseAsync(Func<Task<Option<T>>> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/ReduceExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/ReduceExtensions.cs
@@ -45,11 +45,11 @@ public static class ReduceExtensions
         /// <param name="other">The option to merge with.</param>
         /// <param name="reduce">The function that combines two present values.</param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
         /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
         /// one of them is, and <see cref="None{T}" /> when neither is.
         /// </returns>
-        public async Task<Option<T>> ReduceAsync(
+        public async ValueTask<Option<T>> ReduceAsync(
             Option<T> other,
             Func<T, T, T> reduce)
         {
@@ -69,11 +69,11 @@ public static class ReduceExtensions
         /// values.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
         /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
         /// one of them is, and <see cref="None{T}" /> when neither is.
         /// </returns>
-        public async Task<Option<T>> ReduceAsync(
+        public async ValueTask<Option<T>> ReduceAsync(
             Option<T> other,
             Func<T, T, Task<T>> reduce)
         {
@@ -93,11 +93,11 @@ public static class ReduceExtensions
         /// <param name="other">The option to merge with.</param>
         /// <param name="reduce">The function that combines two present values.</param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
         /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
         /// one of them is, and <see cref="None{T}" /> when neither is.
         /// </returns>
-        public async Task<Option<T>> ReduceAsync(
+        public async ValueTask<Option<T>> ReduceAsync(
             Option<T> other,
             Func<T, T, T> reduce)
         {
@@ -117,11 +117,11 @@ public static class ReduceExtensions
         /// values.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the combined option when both are a
+        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
         /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
         /// one of them is, and <see cref="None{T}" /> when neither is.
         /// </returns>
-        public async Task<Option<T>> ReduceAsync(
+        public async ValueTask<Option<T>> ReduceAsync(
             Option<T> other,
             Func<T, T, Task<T>> reduce)
         {

--- a/src/Waystone.Monads/Options/Extensions/UnwrapExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnwrapExtensions.cs
@@ -15,7 +15,7 @@ public static class UnwrapExtensions
         /// Thrown when the awaited option is a
         /// <see cref="None{T}" />
         /// </exception>
-        public async Task<T> UnwrapAsync()
+        public async ValueTask<T> UnwrapAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -28,7 +28,7 @@ public static class UnwrapExtensions
         /// <see cref="None{T}" />.
         /// </summary>
         /// <param name="value">The value to return when the option is none.</param>
-        public async Task<T> UnwrapOrAsync(T value)
+        public async ValueTask<T> UnwrapOrAsync(T value)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -40,7 +40,7 @@ public static class UnwrapExtensions
         /// contained <see cref="Some{T}" /> value, or the default value of
         /// <typeparamref name="T" /> when it is a <see cref="None{T}" />.
         /// </summary>
-        public async Task<T?> UnwrapOrDefaultAsync()
+        public async ValueTask<T?> UnwrapOrDefaultAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -58,7 +58,7 @@ public static class UnwrapExtensions
         /// Thrown when the awaited option is a
         /// <see cref="None{T}" />
         /// </exception>
-        public async Task<T> UnwrapAsync()
+        public async ValueTask<T> UnwrapAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -71,7 +71,7 @@ public static class UnwrapExtensions
         /// <see cref="None{T}" />.
         /// </summary>
         /// <param name="value">The value to return when the option is none.</param>
-        public async Task<T> UnwrapOrAsync(T value)
+        public async ValueTask<T> UnwrapOrAsync(T value)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -83,7 +83,7 @@ public static class UnwrapExtensions
         /// contained <see cref="Some{T}" /> value, or the default value of
         /// <typeparamref name="T" /> when it is a <see cref="None{T}" />.
         /// </summary>
-        public async Task<T?> UnwrapOrDefaultAsync()
+        public async ValueTask<T?> UnwrapOrDefaultAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/UnwrapOrElseExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnwrapOrElseExtensions.cs
@@ -15,7 +15,7 @@ public static class UnwrapOrElseExtensions
 
     extension<T>(Task<Option<T>> optionTask) where T : notnull
     {
-        public async Task<T> UnwrapOrElseAsync(Func<T> elseFunc)
+        public async ValueTask<T> UnwrapOrElseAsync(Func<T> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -24,7 +24,7 @@ public static class UnwrapOrElseExtensions
                 : elseFunc.Invoke();
         }
 
-        public async Task<T> UnwrapOrElseAsync(Func<Task<T>> elseFunc)
+        public async ValueTask<T> UnwrapOrElseAsync(Func<Task<T>> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -36,7 +36,7 @@ public static class UnwrapOrElseExtensions
 
     extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
     {
-        public async Task<T> UnwrapOrElseAsync(Func<T> elseFunc)
+        public async ValueTask<T> UnwrapOrElseAsync(Func<T> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -45,7 +45,7 @@ public static class UnwrapOrElseExtensions
                 : elseFunc.Invoke();
         }
 
-        public async Task<T> UnwrapOrElseAsync(Func<Task<T>> elseFunc)
+        public async ValueTask<T> UnwrapOrElseAsync(Func<Task<T>> elseFunc)
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/UnwrapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnwrapOrNullExtensions.cs
@@ -30,11 +30,11 @@ public static class UnwrapOrNullExtensions
         /// the option is a <see cref="Some{T}" />, otherwise <see langword="null" />.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the contained value if the
+        /// A <see cref="ValueTask{TResult}" /> containing the contained value if the
         /// awaited option was a <see cref="Some{T}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<T?> UnwrapOrNullAsync()
+        public async ValueTask<T?> UnwrapOrNullAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 
@@ -50,11 +50,11 @@ public static class UnwrapOrNullExtensions
         /// <see langword="null" />.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the contained value if the
+        /// A <see cref="ValueTask{TResult}" /> containing the contained value if the
         /// awaited option was a <see cref="Some{T}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<T?> UnwrapOrNullAsync()
+        public async ValueTask<T?> UnwrapOrNullAsync()
         {
             Option<T> option = await optionTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Options/Extensions/UnzipExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnzipExtensions.cs
@@ -12,11 +12,11 @@ public static class UnzipExtensions
         /// tuple into a tuple of two options.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing a pair of <see cref="Some{T}" />
+        /// A <see cref="ValueTask{TResult}" /> containing a pair of <see cref="Some{T}" />
         /// options carrying the two halves of the tuple if the awaited option was a
         /// <see cref="Some{T}" />, otherwise a pair of <see cref="None{T}" />.
         /// </returns>
-        public async Task<(Option<T1>, Option<T2>)> UnzipAsync()
+        public async ValueTask<(Option<T1>, Option<T2>)> UnzipAsync()
         {
             Option<(T1, T2)> option =
                 await optionTask.ConfigureAwait(false);
@@ -33,11 +33,11 @@ public static class UnzipExtensions
         /// a tuple into a tuple of two options.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing a pair of <see cref="Some{T}" />
+        /// A <see cref="ValueTask{TResult}" /> containing a pair of <see cref="Some{T}" />
         /// options carrying the two halves of the tuple if the awaited option was a
         /// <see cref="Some{T}" />, otherwise a pair of <see cref="None{T}" />.
         /// </returns>
-        public async Task<(Option<T1>, Option<T2>)> UnzipAsync()
+        public async ValueTask<(Option<T1>, Option<T2>)> UnzipAsync()
         {
             Option<(T1, T2)> option =
                 await optionTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Options/Extensions/ZipWithExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/ZipWithExtensions.cs
@@ -26,7 +26,7 @@ public static class ZipWithExtensions
 
     extension<TSelf>(Task<Option<TSelf>> optionTask) where TSelf : notnull
     {
-        public async Task<Option<TOut>> ZipWithAsync<TOther, TOut>(
+        public async ValueTask<Option<TOut>> ZipWithAsync<TOther, TOut>(
             Option<TOther> otherOption,
             Func<TSelf, TOther, Task<TOut>> zip)
             where TOther : notnull
@@ -44,7 +44,7 @@ public static class ZipWithExtensions
             return Option.Some(result);
         }
 
-        public async Task<Option<TOut>> ZipWithAsync<TOther, TOut>(
+        public async ValueTask<Option<TOut>> ZipWithAsync<TOther, TOut>(
             Task<Option<TOther>> otherOptionTask,
             Func<TSelf, TOther, Task<TOut>> zip)
             where TOther : notnull
@@ -68,7 +68,7 @@ public static class ZipWithExtensions
 
     extension<TSelf>(ValueTask<Option<TSelf>> optionTask) where TSelf : notnull
     {
-        public async Task<Option<TOut>> ZipWithAsync<TOther, TOut>(
+        public async ValueTask<Option<TOut>> ZipWithAsync<TOther, TOut>(
             Option<TOther> otherOption,
             Func<TSelf, TOther, Task<TOut>> zip)
             where TOther : notnull
@@ -86,7 +86,7 @@ public static class ZipWithExtensions
             return Option.Some(result);
         }
 
-        public async Task<Option<TOut>> ZipWithAsync<TOther, TOut>(
+        public async ValueTask<Option<TOut>> ZipWithAsync<TOther, TOut>(
             ValueTask<Option<TOther>> otherOptionTask,
             Func<TSelf, TOther, Task<TOut>> zip)
             where TOther : notnull

--- a/src/Waystone.Monads/Results/Extensions/AndThenExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/AndThenExtensions.cs
@@ -76,7 +76,7 @@ public static class AndThenExtensions
         /// If the original result is <see cref="Result{TOk, TErr}.IsErr" />, the error is
         /// propagated.
         /// </returns>
-        public async Task<Result<TOut, TErr>> AndThenAsync<TOut>(
+        public async ValueTask<Result<TOut, TErr>> AndThenAsync<TOut>(
             Func<TOk, Task<Result<TOut, TErr>>> factory) where TOut : notnull
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -103,12 +103,12 @@ public static class AndThenExtensions
         /// <see cref="Result{TOut, TErr}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> that completes with a
+        /// A <see cref="ValueTask{TResult}" /> that completes with a
         /// <see cref="Result{TOut, TErr}" />.
         /// If the original result is <see cref="Result{TOk, TErr}.IsErr" />, the error is
         /// propagated.
         /// </returns>
-        public async Task<Result<TOut, TErr>> AndThenAsync<TOut>(
+        public async ValueTask<Result<TOut, TErr>> AndThenAsync<TOut>(
             Func<TOk, Result<TOut, TErr>> factory) where TOut : notnull
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -138,12 +138,12 @@ public static class AndThenExtensions
         /// <see cref="Result{TOut, TErr}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> that completes with a
+        /// A <see cref="ValueTask{TResult}" /> that completes with a
         /// <see cref="Result{TOut, TErr}" />.
         /// If the original result is <see cref="Result{TOk, TErr}.IsErr" />, the error is
         /// propagated.
         /// </returns>
-        public async Task<Result<TOut, TErr>> AndThenAsync<TOut>(
+        public async ValueTask<Result<TOut, TErr>> AndThenAsync<TOut>(
             Func<TOk, Task<Result<TOut, TErr>>> factory) where TOut : notnull
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -168,11 +168,11 @@ public static class AndThenExtensions
         /// <see cref="Result{TOut, TErr}" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> that completes with a
+        /// A <see cref="ValueTask{TResult}" /> that completes with a
         /// <see cref="Result{TOut, TErr}" />. If the original result is
         /// <see cref="Result{TOk, TErr}.IsErr" />, the error is propagated.
         /// </returns>
-        public async Task<Result<TOut, TErr>> AndThenAsync<TOut>(
+        public async ValueTask<Result<TOut, TErr>> AndThenAsync<TOut>(
             Func<TOk, Result<TOut, TErr>> factory) where TOut : notnull
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Results/Extensions/AsEnumerableExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/AsEnumerableExtensions.cs
@@ -13,11 +13,11 @@ public static class AsEnumerableExtensions
         /// possibly contained <see cref="Ok{TOk,TErr}" /> value.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// A <see cref="ValueTask{TResult}" /> containing a sequence that yields the
         /// contained value once if the awaited result was an
         /// <see cref="Ok{TOk,TErr}" />, otherwise an empty sequence.
         /// </returns>
-        public async Task<IEnumerable<TOk>> AsEnumerableAsync()
+        public async ValueTask<IEnumerable<TOk>> AsEnumerableAsync()
         {
             Result<TOk, TErr> result =
                 await resultTask.ConfigureAwait(false);
@@ -34,11 +34,11 @@ public static class AsEnumerableExtensions
         /// possibly contained <see cref="Ok{TOk,TErr}" /> value.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing a sequence that yields the
+        /// A <see cref="ValueTask{TResult}" /> containing a sequence that yields the
         /// contained value once if the awaited result was an
         /// <see cref="Ok{TOk,TErr}" />, otherwise an empty sequence.
         /// </returns>
-        public async Task<IEnumerable<TOk>> AsEnumerableAsync()
+        public async ValueTask<IEnumerable<TOk>> AsEnumerableAsync()
         {
             Result<TOk, TErr> result =
                 await resultTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Results/Extensions/ExpectExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/ExpectExtensions.cs
@@ -21,7 +21,7 @@ public static class ExpectExtensions
         /// Thrown when the awaited
         /// result is an <see cref="Err{TOk,TErr}" />
         /// </exception>
-        public async Task<TOk> ExpectAsync(string message)
+        public async ValueTask<TOk> ExpectAsync(string message)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -40,7 +40,7 @@ public static class ExpectExtensions
         /// Thrown when the awaited
         /// result is an <see cref="Ok{TOk,TErr}" />
         /// </exception>
-        public async Task<TErr> ExpectErrAsync(string message)
+        public async ValueTask<TErr> ExpectErrAsync(string message)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -64,7 +64,7 @@ public static class ExpectExtensions
         /// Thrown when the awaited
         /// result is an <see cref="Err{TOk,TErr}" />
         /// </exception>
-        public async Task<TOk> ExpectAsync(string message)
+        public async ValueTask<TOk> ExpectAsync(string message)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -83,7 +83,7 @@ public static class ExpectExtensions
         /// Thrown when the awaited
         /// result is an <see cref="Ok{TOk,TErr}" />
         /// </exception>
-        public async Task<TErr> ExpectErrAsync(string message)
+        public async ValueTask<TErr> ExpectErrAsync(string message)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Results/Extensions/FlattenExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/FlattenExtensions.cs
@@ -36,12 +36,12 @@ public static class FlattenExtensions
         /// asynchronously.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task" /> representing the asynchronous operation. The task result
+        /// A <see cref="ValueTask" /> representing the asynchronous operation. The task result
         /// contains a flattened <see cref="Result{TOk, TErr}" />.
         /// If the outer result is <c>Ok</c>, its inner value is returned. If the outer
         /// result is <c>Err</c>, its error value is propagated.
         /// </returns>
-        public async Task<Result<TOk, TErr>> FlattenAsync()
+        public async ValueTask<Result<TOk, TErr>> FlattenAsync()
         {
             Result<Result<TOk, TErr>, TErr> result =
                 await resultTask.ConfigureAwait(false);
@@ -63,13 +63,13 @@ public static class FlattenExtensions
         /// <see cref="Result{TOk, TErr}" />.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task" /> that represents the asynchronous operation. The task
+        /// A <see cref="ValueTask" /> that represents the asynchronous operation. The task
         /// result
         /// contains a flattened <see cref="Result{TOk, TErr}" />.
         /// If the outer result is <c>Ok</c>, its inner value is returned.
         /// If the outer result is <c>Err</c>, its error value is propagated.
         /// </returns>
-        public async Task<Result<TOk, TErr>> FlattenAsync()
+        public async ValueTask<Result<TOk, TErr>> FlattenAsync()
         {
             Result<Result<TOk, TErr>, TErr> result =
                 await resultTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Results/Extensions/InspectErrExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/InspectErrExtensions.cs
@@ -47,11 +47,11 @@ public static class InspectErrExtensions
         /// <see cref="Err{TOk, TErr}" /> value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> that represents the asynchronous operation.
+        /// A <see cref="ValueTask{TResult}" /> that represents the asynchronous operation.
         /// The result of the task is the original <see cref="Result{TOk, TErr}" />
         /// instance, unmodified.
         /// </returns>
-        public async Task<Result<TOk, TErr>> InspectErrAsync(
+        public async ValueTask<Result<TOk, TErr>> InspectErrAsync(
             Func<TErr, Task> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -76,7 +76,7 @@ public static class InspectErrExtensions
         /// <see cref="Err{TOk, TErr}" /> value.
         /// </param>
         /// <returns>The original <see cref="Result{TOk, TErr}" /> instance, unmodified.</returns>
-        public async Task<Result<TOk, TErr>> InspectErrAsync(
+        public async ValueTask<Result<TOk, TErr>> InspectErrAsync(
             Action<TErr> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -109,7 +109,7 @@ public static class InspectErrExtensions
         /// A task that represents the asynchronous operation, returning the
         /// original <see cref="Result{TOk, TErr}" /> instance, unmodified.
         /// </returns>
-        public async Task<Result<TOk, TErr>> InspectErrAsync(
+        public async ValueTask<Result<TOk, TErr>> InspectErrAsync(
             Func<TErr, Task> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -135,7 +135,7 @@ public static class InspectErrExtensions
         /// <returns>
         /// The original <see cref="Result{TOk, TErr}" /> instance, unmodified.
         /// </returns>
-        public async Task<Result<TOk, TErr>> InspectErrAsync(
+        public async ValueTask<Result<TOk, TErr>> InspectErrAsync(
             Action<TErr> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Results/Extensions/InspectExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/InspectExtensions.cs
@@ -53,7 +53,7 @@ public static class InspectExtensions
         /// The original <see cref="Result{TOk, TErr}" /> after executing the specified
         /// <paramref name="action" />, regardless of its state.
         /// </returns>
-        public async Task<Result<TOk, TErr>> InspectAsync(
+        public async ValueTask<Result<TOk, TErr>> InspectAsync(
             Func<TOk, Task> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -73,12 +73,12 @@ public static class InspectExtensions
         /// <see cref="Result{TOk, TErr}.IsOk" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> representing the asynchronous operation.
+        /// A <see cref="ValueTask{TResult}" /> representing the asynchronous operation.
         /// The task's result is the original <see cref="Result{TOk, TErr}" /> after
         /// executing the specified <paramref name="action" />,
         /// regardless of its state.
         /// </returns>
-        public async Task<Result<TOk, TErr>> InspectAsync(Action<TOk> action)
+        public async ValueTask<Result<TOk, TErr>> InspectAsync(Action<TOk> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -103,7 +103,7 @@ public static class InspectExtensions
         /// The original <see cref="Result{TOk, TErr}" /> after executing the specified
         /// <paramref name="action" />, regardless of its state.
         /// </returns>
-        public async Task<Result<TOk, TErr>> InspectAsync(
+        public async ValueTask<Result<TOk, TErr>> InspectAsync(
             Func<TOk, Task> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -123,12 +123,12 @@ public static class InspectExtensions
         /// <see cref="Result{TOk, TErr}.IsOk" />.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> representing the asynchronous operation.
+        /// A <see cref="ValueTask{TResult}" /> representing the asynchronous operation.
         /// The task's result is the original <see cref="Result{TOk, TErr}" /> after
         /// executing the specified <paramref name="action" />,
         /// regardless of its state.
         /// </returns>
-        public async Task<Result<TOk, TErr>> InspectAsync(Action<TOk> action)
+        public async ValueTask<Result<TOk, TErr>> InspectAsync(Action<TOk> action)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Results/Extensions/IsErrAndExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/IsErrAndExtensions.cs
@@ -46,13 +46,13 @@ public static class IsErrAndExtensions
         /// value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> representing the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}" /> representing the asynchronous operation,
         /// containing
         /// <see langword="true" /> if the result is an Err value and satisfies the
         /// specified predicate;
         /// otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsErrAndAsync(Func<TErr, Task<bool>> predicate)
+        public async ValueTask<bool> IsErrAndAsync(Func<TErr, Task<bool>> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -72,12 +72,12 @@ public static class IsErrAndExtensions
         /// value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> representing the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}" /> representing the asynchronous operation,
         /// containing <see langword="true" /> if the result is an Err value and satisfies
         /// the
         /// specified predicate; otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsErrAndAsync(Func<TErr, bool> predicate)
+        public async ValueTask<bool> IsErrAndAsync(Func<TErr, bool> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -101,13 +101,13 @@ public static class IsErrAndExtensions
         /// asynchronously.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> that represents the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}" /> that represents the asynchronous operation,
         /// containing
         /// <see langword="true" /> if the result is an Err value and satisfies the
         /// specified predicate;
         /// otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsErrAndAsync(Func<TErr, Task<bool>> predicate)
+        public async ValueTask<bool> IsErrAndAsync(Func<TErr, Task<bool>> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -127,12 +127,12 @@ public static class IsErrAndExtensions
         /// asynchronously.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> that represents the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}" /> that represents the asynchronous operation,
         /// containing <see langword="true" /> if the result is an Err value and satisfies
         /// the
         /// specified predicate; otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsErrAndAsync(Func<TErr, bool> predicate)
+        public async ValueTask<bool> IsErrAndAsync(Func<TErr, bool> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Results/Extensions/IsOkAndExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/IsOkAndExtensions.cs
@@ -18,7 +18,7 @@ public static class IsOkAndExtensions
         /// to evaluate the <c>Ok</c> value against.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <c>true</c> if the current result is
+        /// A <see cref="ValueTask{TResult}" /> containing <c>true</c> if the current result is
         /// an
         /// <c>Ok</c> value and the <paramref name="predicate" /> returns <c>true</c>;
         /// otherwise, <c>false</c>.
@@ -47,12 +47,12 @@ public static class IsOkAndExtensions
         /// to evaluate the <c>Ok</c> value against.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <c>true</c> if the resolved result is
+        /// A <see cref="ValueTask{TResult}" /> containing <c>true</c> if the resolved result is
         /// an
         /// <c>Ok</c> value and the <paramref name="predicate" /> returns <c>true</c>;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public async Task<bool> IsOkAndAsync(Func<TOk, Task<bool>> predicate)
+        public async ValueTask<bool> IsOkAndAsync(Func<TOk, Task<bool>> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -73,12 +73,12 @@ public static class IsOkAndExtensions
         /// to evaluate the <c>Ok</c> value against.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <c>true</c> if the current result is
+        /// A <see cref="ValueTask{TResult}" /> containing <c>true</c> if the current result is
         /// an
         /// <c>Ok</c> value and the <paramref name="predicate" /> returns <c>true</c>;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public async Task<bool> IsOkAndAsync(Func<TOk, bool> predicate)
+        public async ValueTask<bool> IsOkAndAsync(Func<TOk, bool> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -103,12 +103,12 @@ public static class IsOkAndExtensions
         /// to evaluate the <c>Ok</c> value against.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <c>true</c> if the resolved result is
+        /// A <see cref="ValueTask{TResult}" /> containing <c>true</c> if the resolved result is
         /// an
         /// <c>Ok</c> value and the <paramref name="predicate" /> returns <c>true</c>;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public async Task<bool> IsOkAndAsync(Func<TOk, Task<bool>> predicate)
+        public async ValueTask<bool> IsOkAndAsync(Func<TOk, Task<bool>> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -128,13 +128,13 @@ public static class IsOkAndExtensions
         /// to evaluate the <c>Ok</c> value against.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing <see langword="true" /> if the
+        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
         /// current result
         /// is an <c>Ok</c> value and the <paramref name="predicate" /> returns
         /// <see langword="true" />;
         /// otherwise, <see langword="false" />.
         /// </returns>
-        public async Task<bool> IsOkAndAsync(Func<TOk, bool> predicate)
+        public async ValueTask<bool> IsOkAndAsync(Func<TOk, bool> predicate)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Results/Extensions/MapErrExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapErrExtensions.cs
@@ -31,7 +31,7 @@ public static class MapErrExtensions
         where TOk : notnull
         where TErr : notnull
     {
-        public async Task<Result<TOk, TOut>> MapErrAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> MapErrAsync<TOut>(
             Func<TErr, Task<TOut>> map)
             where TOut : notnull
         {
@@ -40,7 +40,7 @@ public static class MapErrExtensions
             return await result.MapErrAsync(map).ConfigureAwait(false);
         }
 
-        public async Task<Result<TOk, TOut>> MapErrAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> MapErrAsync<TOut>(
             Func<TErr, TOut> map)
             where TOut : notnull
         {
@@ -54,7 +54,7 @@ public static class MapErrExtensions
         where TOk : notnull
         where TErr : notnull
     {
-        public async Task<Result<TOk, TOut>> MapErrAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> MapErrAsync<TOut>(
             Func<TErr, Task<TOut>> map)
             where TOut : notnull
         {
@@ -63,7 +63,7 @@ public static class MapErrExtensions
             return await result.MapErrAsync(map).ConfigureAwait(false);
         }
 
-        public async Task<Result<TOk, TOut>> MapErrAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> MapErrAsync<TOut>(
             Func<TErr, TOut> map)
             where TOut : notnull
         {

--- a/src/Waystone.Monads/Results/Extensions/MapExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapExtensions.cs
@@ -29,7 +29,7 @@ public static class MapExtensions
     extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
         where TOk : notnull where TErr : notnull
     {
-        public async Task<Result<TOut, TErr>> MapAsync<TOut>(
+        public async ValueTask<Result<TOut, TErr>> MapAsync<TOut>(
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
         {
@@ -38,7 +38,7 @@ public static class MapExtensions
             return await result.MapAsync(map);
         }
 
-        public async Task<Result<TOut, TErr>> MapAsync<TOut>(
+        public async ValueTask<Result<TOut, TErr>> MapAsync<TOut>(
             Func<TOk, TOut> map)
             where TOut : notnull
         {

--- a/src/Waystone.Monads/Results/Extensions/MapOrDefaultExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapOrDefaultExtensions.cs
@@ -49,11 +49,11 @@ public static class MapOrDefaultExtensions
         /// value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<TOk, TOut> map)
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(Func<TOk, TOut> map)
             where TOut : notnull
         {
             Result<TOk, TErr> result =
@@ -74,11 +74,11 @@ public static class MapOrDefaultExtensions
         /// <see cref="Ok{TOk,TErr}" /> value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
         {
@@ -105,11 +105,11 @@ public static class MapOrDefaultExtensions
         /// value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(Func<TOk, TOut> map)
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(Func<TOk, TOut> map)
             where TOut : notnull
         {
             Result<TOk, TErr> result =
@@ -130,11 +130,11 @@ public static class MapOrDefaultExtensions
         /// <see cref="Ok{TOk,TErr}" /> value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, or the <see langword="default" /> of
         /// <typeparamref name="TOut" /> otherwise.
         /// </returns>
-        public async Task<TOut?> MapOrDefaultAsync<TOut>(
+        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
         {

--- a/src/Waystone.Monads/Results/Extensions/MapOrElseExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapOrElseExtensions.cs
@@ -66,7 +66,7 @@ public static class MapOrElseExtensions
     extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
         where TOk : notnull where TErr : notnull
     {
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, Task<TOut>> factory,
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
@@ -77,7 +77,7 @@ public static class MapOrElseExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, TOut> factory,
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
@@ -88,7 +88,7 @@ public static class MapOrElseExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, Task<TOut>> factory,
             Func<TOk, TOut> map)
             where TOut : notnull
@@ -99,7 +99,7 @@ public static class MapOrElseExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, TOut> factory,
             Func<TOk, TOut> map)
             where TOut : notnull
@@ -113,7 +113,7 @@ public static class MapOrElseExtensions
     extension<TOk, TErr>(ValueTask<Result<TOk, TErr>> resultTask)
         where TOk : notnull where TErr : notnull
     {
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, Task<TOut>> factory,
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
@@ -124,7 +124,7 @@ public static class MapOrElseExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, TOut> factory,
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
@@ -135,7 +135,7 @@ public static class MapOrElseExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, Task<TOut>> factory,
             Func<TOk, TOut> map)
             where TOut : notnull
@@ -146,7 +146,7 @@ public static class MapOrElseExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrElseAsync<TOut>(
+        public async ValueTask<TOut> MapOrElseAsync<TOut>(
             Func<TErr, TOut> factory,
             Func<TOk, TOut> map)
             where TOut : notnull

--- a/src/Waystone.Monads/Results/Extensions/MapOrExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapOrExtensions.cs
@@ -25,7 +25,7 @@ public static class MapOrExtensions
     extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
         where TOk : notnull where TErr : notnull
     {
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
@@ -36,7 +36,7 @@ public static class MapOrExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<TOk, TOut> map)
             where TOut : notnull
@@ -50,7 +50,7 @@ public static class MapOrExtensions
     extension<TOk, TErr>(ValueTask<Result<TOk, TErr>> resultTask)
         where TOk : notnull where TErr : notnull
     {
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<TOk, Task<TOut>> map)
             where TOut : notnull
@@ -61,7 +61,7 @@ public static class MapOrExtensions
                .ConfigureAwait(false);
         }
 
-        public async Task<TOut> MapOrAsync<TOut>(
+        public async ValueTask<TOut> MapOrAsync<TOut>(
             TOut defaultValue,
             Func<TOk, TOut> map)
             where TOut : notnull

--- a/src/Waystone.Monads/Results/Extensions/MapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MapOrNullExtensions.cs
@@ -70,11 +70,11 @@ public static class MapOrNullExtensions
         /// value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, TOut> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<TOk, TOut> map)
             where TOut : struct
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -93,11 +93,11 @@ public static class MapOrNullExtensions
         /// <see cref="Ok{TOk,TErr}" /> value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, Task<TOut>> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<TOk, Task<TOut>> map)
             where TOut : struct
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -124,11 +124,11 @@ public static class MapOrNullExtensions
         /// value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, TOut> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<TOk, TOut> map)
             where TOut : struct
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
@@ -147,11 +147,11 @@ public static class MapOrNullExtensions
         /// <see cref="Ok{TOk,TErr}" /> value.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the transformed value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<TOut?> MapOrNullAsync<TOut>(Func<TOk, Task<TOut>> map)
+        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<TOk, Task<TOut>> map)
             where TOut : struct
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);

--- a/src/Waystone.Monads/Results/Extensions/MatchExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/MatchExtensions.cs
@@ -8,7 +8,7 @@ public static class MatchExtensions
     extension<TOk, TErr>(Result<TOk, TErr> result)
         where TOk : notnull where TErr : notnull
     {
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Func<TOk, Task> onOk,
             Func<TErr, Task> onErr)
         {
@@ -26,7 +26,7 @@ public static class MatchExtensions
             await onErr.Invoke(err).ConfigureAwait(false);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Func<TOk, Task> onOk,
             Action<TErr> onErr)
         {
@@ -44,7 +44,7 @@ public static class MatchExtensions
             onErr.Invoke(err);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Action<TOk> onOk,
             Func<TErr, Task> onErr)
         {
@@ -62,7 +62,7 @@ public static class MatchExtensions
             await onErr.Invoke(err).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<TOk, Task<TOut>> onOk,
             Func<TErr, Task<TOut>> onErr)
         {
@@ -82,7 +82,7 @@ public static class MatchExtensions
     extension<TOk, TErr>(Task<Result<TOk, TErr>> resultTask)
         where TOk : notnull where TErr : notnull
     {
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Func<TOk, Task> onOk,
             Func<TErr, Task> onErr)
         {
@@ -91,7 +91,7 @@ public static class MatchExtensions
             await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Func<TOk, Task> onOk,
             Action<TErr> onErr)
         {
@@ -100,7 +100,7 @@ public static class MatchExtensions
             await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Action<TOk> onOk,
             Func<TErr, Task> onErr)
         {
@@ -109,7 +109,7 @@ public static class MatchExtensions
             await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<TOk, Task<TOut>> onOk,
             Func<TErr, Task<TOut>> onErr)
         {
@@ -118,7 +118,7 @@ public static class MatchExtensions
             return await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Action<TOk> onOk,
             Action<TErr> onErr)
         {
@@ -142,7 +142,7 @@ public static class MatchExtensions
     extension<TOk, TErr>(ValueTask<Result<TOk, TErr>> resultTask)
         where TOk : notnull where TErr : notnull
     {
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Func<TOk, Task> onOk,
             Func<TErr, Task> onErr)
         {
@@ -151,7 +151,7 @@ public static class MatchExtensions
             await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Func<TOk, Task> onOk,
             Action<TErr> onErr)
         {
@@ -160,7 +160,7 @@ public static class MatchExtensions
             await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Action<TOk> onOk,
             Func<TErr, Task> onErr)
         {
@@ -169,7 +169,7 @@ public static class MatchExtensions
             await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task<TOut> MatchAsync<TOut>(
+        public async ValueTask<TOut> MatchAsync<TOut>(
             Func<TOk, Task<TOut>> onOk,
             Func<TErr, Task<TOut>> onErr)
         {
@@ -178,7 +178,7 @@ public static class MatchExtensions
             return await result.MatchAsync(onOk, onErr).ConfigureAwait(false);
         }
 
-        public async Task MatchAsync(
+        public async ValueTask MatchAsync(
             Action<TOk> onOk,
             Action<TErr> onErr)
         {

--- a/src/Waystone.Monads/Results/Extensions/OrElseExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/OrElseExtensions.cs
@@ -33,7 +33,7 @@ public static class OrElseExtensions
         where TOk : notnull
         where TErr : notnull
     {
-        public async Task<Result<TOk, TOut>> OrElseAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> OrElseAsync<TOut>(
             Func<TErr, Result<TOk, TOut>> factory)
             where TOut : notnull
         {
@@ -42,7 +42,7 @@ public static class OrElseExtensions
             return result.OrElse(factory);
         }
 
-        public async Task<Result<TOk, TOut>> OrElseAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> OrElseAsync<TOut>(
             Func<TErr, Task<Result<TOk, TOut>>> factory)
             where TOut : notnull
         {
@@ -56,7 +56,7 @@ public static class OrElseExtensions
         where TOk : notnull
         where TErr : notnull
     {
-        public async Task<Result<TOk, TOut>> OrElseAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> OrElseAsync<TOut>(
             Func<TErr, Result<TOk, TOut>> factory)
             where TOut : notnull
         {
@@ -65,7 +65,7 @@ public static class OrElseExtensions
             return result.OrElse(factory);
         }
 
-        public async Task<Result<TOk, TOut>> OrElseAsync<TOut>(
+        public async ValueTask<Result<TOk, TOut>> OrElseAsync<TOut>(
             Func<TErr, Task<Result<TOk, TOut>>> factory)
             where TOut : notnull
         {

--- a/src/Waystone.Monads/Results/Extensions/UnwrapExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/UnwrapExtensions.cs
@@ -17,7 +17,7 @@ public static class UnwrapExtensions
         /// Thrown when the awaited result is an
         /// <see cref="Err{TOk,TErr}" />
         /// </exception>
-        public async Task<TOk> UnwrapAsync()
+        public async ValueTask<TOk> UnwrapAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -32,7 +32,7 @@ public static class UnwrapExtensions
         /// Thrown when the awaited result is an
         /// <see cref="Ok{TOk,TErr}" />
         /// </exception>
-        public async Task<TErr> UnwrapErrAsync()
+        public async ValueTask<TErr> UnwrapErrAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -45,7 +45,7 @@ public static class UnwrapExtensions
         /// when it is an <see cref="Err{TOk,TErr}" />.
         /// </summary>
         /// <param name="default">The value to return when the result is an error.</param>
-        public async Task<TOk> UnwrapOrAsync(TOk @default)
+        public async ValueTask<TOk> UnwrapOrAsync(TOk @default)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -57,7 +57,7 @@ public static class UnwrapExtensions
         /// the contained <see cref="Ok{TOk,TErr}" /> value, or the default value of
         /// <typeparamref name="TOk" /> when it is an <see cref="Err{TOk,TErr}" />.
         /// </summary>
-        public async Task<TOk?> UnwrapOrDefaultAsync()
+        public async ValueTask<TOk?> UnwrapOrDefaultAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -77,7 +77,7 @@ public static class UnwrapExtensions
         /// Thrown when the awaited result is an
         /// <see cref="Err{TOk,TErr}" />
         /// </exception>
-        public async Task<TOk> UnwrapAsync()
+        public async ValueTask<TOk> UnwrapAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -92,7 +92,7 @@ public static class UnwrapExtensions
         /// Thrown when the awaited result is an
         /// <see cref="Ok{TOk,TErr}" />
         /// </exception>
-        public async Task<TErr> UnwrapErrAsync()
+        public async ValueTask<TErr> UnwrapErrAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -105,7 +105,7 @@ public static class UnwrapExtensions
         /// when it is an <see cref="Err{TOk,TErr}" />.
         /// </summary>
         /// <param name="default">The value to return when the result is an error.</param>
-        public async Task<TOk> UnwrapOrAsync(TOk @default)
+        public async ValueTask<TOk> UnwrapOrAsync(TOk @default)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -117,7 +117,7 @@ public static class UnwrapExtensions
         /// the contained <see cref="Ok{TOk,TErr}" /> value, or the default value of
         /// <typeparamref name="TOk" /> when it is an <see cref="Err{TOk,TErr}" />.
         /// </summary>
-        public async Task<TOk?> UnwrapOrDefaultAsync()
+        public async ValueTask<TOk?> UnwrapOrDefaultAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Results/Extensions/UnwrapOrElseExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/UnwrapOrElseExtensions.cs
@@ -30,14 +30,14 @@ public static class UnwrapOrElseExtensions
         where TOk : notnull
         where TErr : notnull
     {
-        public async Task<TOk> UnwrapOrElseAsync(Func<TErr, TOk> factory)
+        public async ValueTask<TOk> UnwrapOrElseAsync(Func<TErr, TOk> factory)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return result.UnwrapOrElse(factory);
         }
 
-        public async Task<TOk> UnwrapOrElseAsync(Func<TErr, Task<TOk>> factory)
+        public async ValueTask<TOk> UnwrapOrElseAsync(Func<TErr, Task<TOk>> factory)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -50,14 +50,14 @@ public static class UnwrapOrElseExtensions
         where TOk : notnull
         where TErr : notnull
     {
-        public async Task<TOk> UnwrapOrElseAsync(Func<TErr, TOk> factory)
+        public async ValueTask<TOk> UnwrapOrElseAsync(Func<TErr, TOk> factory)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
             return result.UnwrapOrElse(factory);
         }
 
-        public async Task<TOk> UnwrapOrElseAsync(Func<TErr, Task<TOk>> factory)
+        public async ValueTask<TOk> UnwrapOrElseAsync(Func<TErr, Task<TOk>> factory)
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 

--- a/src/Waystone.Monads/Results/Extensions/UnwrapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Results/Extensions/UnwrapOrNullExtensions.cs
@@ -35,11 +35,11 @@ public static class UnwrapOrNullExtensions
         /// <see langword="null" />.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the contained value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the contained value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<TOk?> UnwrapOrNullAsync()
+        public async ValueTask<TOk?> UnwrapOrNullAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 
@@ -56,11 +56,11 @@ public static class UnwrapOrNullExtensions
         /// <see langword="null" />.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{TResult}" /> containing the contained value if the awaited
+        /// A <see cref="ValueTask{TResult}" /> containing the contained value if the awaited
         /// result was an <see cref="Ok{TOk,TErr}" />, otherwise
         /// <see langword="null" />.
         /// </returns>
-        public async Task<TOk?> UnwrapOrNullAsync()
+        public async ValueTask<TOk?> UnwrapOrNullAsync()
         {
             Result<TOk, TErr> result = await resultTask.ConfigureAwait(false);
 

--- a/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
@@ -156,11 +156,11 @@ public class CodeFixTests
     public Task RenamesFlatMapAsyncToAndThenAsync() =>
         Verify.CodeFixAsync<DeprecationAnalyzer, UseAndThenCodeFix>(
             """
-            internal Task<Option<int>> Doubled(Task<Option<int>> option) =>
+            internal ValueTask<Option<int>> Doubled(Task<Option<int>> option) =>
                 option.{|#0:FlatMapAsync|}(value => Option.Some(value * 2));
             """,
             """
-            internal Task<Option<int>> Doubled(Task<Option<int>> option) =>
+            internal ValueTask<Option<int>> Doubled(Task<Option<int>> option) =>
                 option.AndThenAsync(value => Option.Some(value * 2));
             """,
             Verify.Diagnostic(Rules.RenamedToAndThen)

--- a/test/Waystone.Monads.Analyzers.Tests/DeprecationAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/DeprecationAnalyzerTests.cs
@@ -32,7 +32,7 @@ public class DeprecationAnalyzerTests
     public Task FlagsFlatMapAsyncOnAnOptionTask() =>
         Verify.AnalyzerAsync<DeprecationAnalyzer>(
             """
-            internal Task<Option<int>> Doubled(Task<Option<int>> option) =>
+            internal ValueTask<Option<int>> Doubled(Task<Option<int>> option) =>
                 option.{|#0:FlatMapAsync|}(value => Option.Some(value * 2));
             """,
             Verify.Diagnostic(Rules.RenamedToAndThen)
@@ -43,7 +43,7 @@ public class DeprecationAnalyzerTests
     public Task FlagsFlatMapAsyncOnAnOptionValueTask() =>
         Verify.AnalyzerAsync<DeprecationAnalyzer>(
             """
-            internal Task<Option<int>> Doubled(ValueTask<Option<int>> option) =>
+            internal ValueTask<Option<int>> Doubled(ValueTask<Option<int>> option) =>
                 option.{|#0:FlatMapAsync|}(value => Option.Some(value * 2));
             """,
             Verify.Diagnostic(Rules.RenamedToAndThen)

--- a/test/Waystone.Monads.Analyzers.Tests/PanickingCallAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/PanickingCallAnalyzerTests.cs
@@ -32,7 +32,7 @@ public class PanickingCallAnalyzerTests
     [Fact]
     public Task FlagsTheAsyncExtensionOverload() =>
         Verify.AnalyzerAsync<PanickingCallAnalyzer>(
-            "internal Task<int> Value(Task<Option<int>> option) => option.{|#0:UnwrapAsync|}();",
+            "internal ValueTask<int> Value(Task<Option<int>> option) => option.{|#0:UnwrapAsync|}();",
             Verify.Diagnostic(Rules.UnwrapUsed)
                .WithLocation(0)
                .WithArguments("UnwrapAsync"));

--- a/test/Waystone.Monads.Tests/Extensions/AsyncReturnTypeTests.cs
+++ b/test/Waystone.Monads.Tests/Extensions/AsyncReturnTypeTests.cs
@@ -1,0 +1,140 @@
+namespace Waystone.Monads.Extensions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Options;
+using Options.Extensions;
+using Results;
+using Results.Extensions;
+using Shouldly;
+using Xunit;
+
+public sealed class AsyncReturnTypeTests
+{
+    private static readonly string[] ExtensionNamespaces =
+    [
+        "Waystone.Monads.Options.Extensions",
+        "Waystone.Monads.Results.Extensions",
+    ];
+
+    [Fact]
+    public void GivenAnAsyncExtension_ThenItShouldNotReturnTask()
+    {
+        List<string> offenders =
+            typeof(Option<>).Assembly.GetTypes()
+                            .Where(
+                                 type => type.Namespace is not null
+                                      && ExtensionNamespaces.Contains(
+                                             type.Namespace))
+                            .SelectMany(
+                                 type => type.GetMethods(
+                                     BindingFlags.Public
+                                   | BindingFlags.Static))
+                            .Where(
+                                 method => method.Name.EndsWith(
+                                     "Async",
+                                     StringComparison.Ordinal))
+                            .Where(method => ReturnsTask(method.ReturnType))
+                            .Select(
+                                 method =>
+                                     $"{method.DeclaringType!.Name}.{method.Name}")
+                            .Distinct()
+                            .OrderBy(name => name, StringComparer.Ordinal)
+                            .ToList();
+
+        offenders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenAnAsyncExtension_ThenTheAssemblyShouldDeclareSome()
+    {
+        int count = typeof(Option<>).Assembly.GetTypes()
+                                    .Where(
+                                         type => type.Namespace is not null
+                                          && ExtensionNamespaces.Contains(
+                                                 type.Namespace))
+                                    .SelectMany(
+                                         type => type.GetMethods(
+                                             BindingFlags.Public
+                                           | BindingFlags.Static))
+                                    .Count(
+                                         method => method.Name.EndsWith(
+                                             "Async",
+                                             StringComparison.Ordinal));
+
+        count.ShouldBeGreaterThan(100);
+    }
+
+    [Fact]
+    public async Task GivenEachOptionReceiverShape_ThenMapAsyncShouldReturnValueTask()
+    {
+        Option<int> option = Option.Some(1);
+        Task<Option<int>> optionTask = Task.FromResult(option);
+        ValueTask<Option<int>> optionValueTask = new(option);
+
+        ValueTask<Option<int>> fromSync =
+            option.MapAsync(value => Task.FromResult(value + 1));
+        ValueTask<Option<int>> fromTask =
+            optionTask.MapAsync(value => Task.FromResult(value + 1));
+        ValueTask<Option<int>> fromValueTask =
+            optionValueTask.MapAsync(value => Task.FromResult(value + 1));
+
+        (await fromSync).ShouldBe(Option.Some(2));
+        (await fromTask).ShouldBe(Option.Some(2));
+        (await fromValueTask).ShouldBe(Option.Some(2));
+    }
+
+    [Fact]
+    public async Task GivenEachResultReceiverShape_ThenMapAsyncShouldReturnValueTask()
+    {
+        Result<int, string> result = Result.Ok<int, string>(1);
+        Task<Result<int, string>> resultTask = Task.FromResult(result);
+        ValueTask<Result<int, string>> resultValueTask = new(result);
+
+        ValueTask<Result<int, string>> fromSync =
+            result.MapAsync(value => Task.FromResult(value + 1));
+        ValueTask<Result<int, string>> fromTask =
+            resultTask.MapAsync(value => Task.FromResult(value + 1));
+        ValueTask<Result<int, string>> fromValueTask =
+            resultValueTask.MapAsync(value => Task.FromResult(value + 1));
+
+        (await fromSync).ShouldBe(Result.Ok<int, string>(2));
+        (await fromTask).ShouldBe(Result.Ok<int, string>(2));
+        (await fromValueTask).ShouldBe(Result.Ok<int, string>(2));
+    }
+
+    [Fact]
+    public async Task GivenASyncReceiver_ThenAThreeLinkChainShouldStayValueTask()
+    {
+        Option<int> option = Option.Some(1);
+
+        ValueTask<Option<int>> chain =
+            option.MapAsync(value => Task.FromResult(value + 1))
+                  .AndThenAsync(value => Task.FromResult(Option.Some(value + 1)))
+                  .FilterAsync(value => Task.FromResult(value > 0));
+
+        (await chain).ShouldBe(Option.Some(3));
+    }
+
+    [Fact]
+    public async Task GivenATaskReceiverPartway_ThenTheChainShouldStayValueTask()
+    {
+        Task<Option<int>> optionTask = Task.FromResult(Option.Some(1));
+
+        ValueTask<Option<int>> chain =
+            optionTask.MapAsync(value => Task.FromResult(value + 1))
+                      .AndThenAsync(
+                           value => Task.FromResult(Option.Some(value + 1)))
+                      .FilterAsync(value => Task.FromResult(value > 0));
+
+        (await chain).ShouldBe(Option.Some(3));
+    }
+
+    private static bool ReturnsTask(Type returnType) =>
+        returnType == typeof(Task)
+     || (returnType.IsGenericType
+      && returnType.GetGenericTypeDefinition() == typeof(Task<>));
+}

--- a/test/Waystone.Monads.Tests/Specs/Options/Steps/FlattenExtensionsSteps.cs
+++ b/test/Waystone.Monads.Tests/Specs/Options/Steps/FlattenExtensionsSteps.cs
@@ -25,7 +25,7 @@ public class FlattenExtensionsSteps(SpecContext context)
         var nestedOptionTask =
             context.Subject<ValueTask<Option<Option<int>>>>();
 
-        Task<Option<int>> flattenTask = nestedOptionTask.FlattenAsync();
+        ValueTask<Option<int>> flattenTask = nestedOptionTask.FlattenAsync();
 
         Option<int> result = flattenTask.GetAwaiter().GetResult();
 

--- a/test/Waystone.Monads.Tests/Specs/SpecContext.cs
+++ b/test/Waystone.Monads.Tests/Specs/SpecContext.cs
@@ -51,7 +51,7 @@ public sealed class SpecContext
 
     public void SetSlot<T>(T value, string slot) => slots[slot] = value;
 
-    public async Task CaptureAsync<T>(Func<Task<T>> operation)
+    public async Task CaptureAsync<T>(Func<ValueTask<T>> operation)
     {
         try
         {


### PR DESCRIPTION
Every async extension across Options and Results now returns ValueTask
regardless of receiver shape, so a chain that starts synchronously stays
allocation-free for its whole length rather than degrading to Task after
one hop.

A three-link chain off a sync Some drops from 432 B to 288 B, off a sync
None from 216 B to 72 B, and off an already-completed Task from 576 B to
360 B. A chain off a pending Task rises from 782 B to 866 B: the links
attach before the head completes, so the whole chain suspends and the
larger AsyncValueTaskMethodBuilder box wins nothing. That trade is
documented in the benchmark README.

C# does not allow overloading on return type, so the usual obsolete-then-
remove path cannot apply and this is a hard break. Consumers assigning to
a Task local, passing to a Task parameter, or calling Task.WhenAll get a
compile error and fix it with .AsTask().

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>