### PR TITLE
feat(analyzers): code fix that inserts .AsTask() for the ValueTask break

### DIFF
--- a/src/Waystone.Monads.Analyzers.CodeFixes/AsTaskCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/AsTaskCodeFix.cs
@@ -1,0 +1,206 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class AsTaskCodeFix : CodeFixProvider
+{
+    private const string TaskNamespace = "System.Threading.Tasks";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("CS0029", "CS1503");
+
+    public override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document
+           .GetSyntaxRootAsync(context.CancellationToken)
+           .ConfigureAwait(false);
+
+        var model = await context.Document
+           .GetSemanticModelAsync(context.CancellationToken)
+           .ConfigureAwait(false);
+
+        if (root is null || model is null)
+        {
+            return;
+        }
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(
+                diagnostic.Location.SourceSpan,
+                getInnermostNodeForTie: true);
+
+            Register(context, diagnostic, node, model);
+        }
+    }
+
+    private static void Register(
+        CodeFixContext context,
+        Diagnostic diagnostic,
+        SyntaxNode node,
+        SemanticModel model)
+    {
+        if (ExpressionAt(node) is not { } expression)
+        {
+            return;
+        }
+
+        if (model.GetTypeInfo(expression).Type is not INamedTypeSymbol source
+         || !IsValueTask(source))
+        {
+            return;
+        }
+
+        if (!TargetsTask(expression, source, model))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Convert to Task with AsTask()",
+                token => ReplaceAsync(context.Document, expression, token),
+                nameof(AsTaskCodeFix)),
+            diagnostic);
+    }
+
+    private static ExpressionSyntax? ExpressionAt(SyntaxNode node) =>
+        node switch
+        {
+            ArgumentSyntax argument => argument.Expression,
+            ExpressionSyntax expression => expression,
+            _ => null,
+        };
+
+    private static bool TargetsTask(
+        ExpressionSyntax expression,
+        INamedTypeSymbol source,
+        SemanticModel model) =>
+        TargetTypesOf(expression, model)
+           .Any(target => AsTaskBridges(source, target));
+
+    private static IEnumerable<ITypeSymbol> TargetTypesOf(
+        ExpressionSyntax expression,
+        SemanticModel model)
+    {
+        if (model.GetTypeInfo(expression).ConvertedType is { } converted)
+        {
+            yield return converted;
+        }
+
+        if (expression.Parent is not ArgumentSyntax argument
+         || argument.Parent is not ArgumentListSyntax arguments
+         || arguments.Parent is not ExpressionSyntax call)
+        {
+            yield break;
+        }
+
+        int position = arguments.Arguments.IndexOf(argument);
+
+        foreach (var candidate in model.GetSymbolInfo(call).CandidateSymbols)
+        {
+            if (candidate is not IMethodSymbol method)
+            {
+                continue;
+            }
+
+            if (ParameterTypeAt(method, position, argument) is { } parameter)
+            {
+                yield return parameter;
+            }
+        }
+    }
+
+    private static ITypeSymbol? ParameterTypeAt(
+        IMethodSymbol method,
+        int position,
+        ArgumentSyntax argument)
+    {
+        var named = argument.NameColon?.Name.Identifier.ValueText;
+
+        var parameter = named is null
+            ? position >= 0 && position < method.Parameters.Length
+                ? method.Parameters[position]
+                : method.Parameters.LastOrDefault(p => p.IsParams)
+            : method.Parameters.FirstOrDefault(p => p.Name == named);
+
+        return parameter switch
+        {
+            null => null,
+            { IsParams: true, Type: IArrayTypeSymbol array } =>
+                array.ElementType,
+            _ => parameter.Type,
+        };
+    }
+
+    private static bool AsTaskBridges(
+        INamedTypeSymbol source,
+        ITypeSymbol target) =>
+        target is INamedTypeSymbol named
+     && IsTask(named)
+     && named.Arity == source.Arity
+     && (named.Arity == 0
+      || named.TypeArguments[0] is ITypeParameterSymbol
+      || SymbolEqualityComparer.Default.Equals(
+             named.TypeArguments[0],
+             source.TypeArguments[0]));
+
+    private static bool IsValueTask(INamedTypeSymbol type) =>
+        type is { Name: "ValueTask", Arity: 0 or 1 }
+     && type.ContainingNamespace?.ToDisplayString() == TaskNamespace;
+
+    private static bool IsTask(INamedTypeSymbol type) =>
+        type is { Name: "Task", Arity: 0 or 1 }
+     && type.ContainingNamespace?.ToDisplayString() == TaskNamespace;
+
+    private static async Task<Document> ReplaceAsync(
+        Document document,
+        ExpressionSyntax expression,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken)
+           .ConfigureAwait(false);
+
+        var replacement = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Receiver(expression),
+                    SyntaxFactory.IdentifierName("AsTask")))
+           .WithArgumentList(SyntaxFactory.ArgumentList());
+
+        var updated = root!.ReplaceNode(
+            expression,
+            replacement.WithTriviaFrom(expression)
+               .WithAdditionalAnnotations(
+                    Simplifier.Annotation,
+                    Formatter.Annotation));
+
+        return document.WithSyntaxRoot(updated);
+    }
+
+    private static ExpressionSyntax Receiver(ExpressionSyntax expression) =>
+        expression is InvocationExpressionSyntax
+            or MemberAccessExpressionSyntax
+            or IdentifierNameSyntax
+            or ElementAccessExpressionSyntax
+            or ParenthesizedExpressionSyntax
+            ? expression.WithoutTrivia()
+            : SyntaxFactory.ParenthesizedExpression(
+                expression.WithoutTrivia());
+}

--- a/src/Waystone.Monads.Analyzers.CodeFixes/AsTaskCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/AsTaskCodeFix.cs
@@ -56,7 +56,7 @@ public sealed class AsTaskCodeFix : CodeFixProvider
         SyntaxNode node,
         SemanticModel model)
     {
-        if (ExpressionAt(node) is not { } expression)
+        if (node is not ExpressionSyntax expression)
         {
             return;
         }
@@ -79,14 +79,6 @@ public sealed class AsTaskCodeFix : CodeFixProvider
                 nameof(AsTaskCodeFix)),
             diagnostic);
     }
-
-    private static ExpressionSyntax? ExpressionAt(SyntaxNode node) =>
-        node switch
-        {
-            ArgumentSyntax argument => argument.Expression,
-            ExpressionSyntax expression => expression,
-            _ => null,
-        };
 
     private static bool TargetsTask(
         ExpressionSyntax expression,

--- a/test/Waystone.Monads.Analyzers.Tests/AsTaskCodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/AsTaskCodeFixTests.cs
@@ -1,6 +1,8 @@
 namespace Waystone.Monads.Analyzers;
 
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Testing;
+using Shouldly;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -121,4 +123,177 @@ public class AsTaskCodeFixTests
             private static Task<string> Accept(Task<string> task) => task;
             """,
             DiagnosticResult.CompilerError("CS1503").WithLocation(0));
+
+    [Fact]
+    public Task FixesAValueTaskHeldInALocal() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<int> FromLocal()
+            {
+                ValueTask<int> pending = new ValueTask<int>(1);
+
+                Task<int> task = {|#0:pending|};
+
+                return task;
+            }
+            """,
+            """
+            internal Task<int> FromLocal()
+            {
+                ValueTask<int> pending = new ValueTask<int>(1);
+
+                Task<int> task = pending.AsTask();
+
+                return task;
+            }
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    [Fact]
+    public Task FixesAValueTaskReadFromAField() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal sealed class Holder
+            {
+                internal ValueTask<int> Pending;
+            }
+
+            internal class Subject
+            {
+                internal Task<int> FromField(Holder holder) =>
+                    {|#0:holder.Pending|};
+            }
+            """,
+            """
+            internal sealed class Holder
+            {
+                internal ValueTask<int> Pending;
+            }
+
+            internal class Subject
+            {
+                internal Task<int> FromField(Holder holder) =>
+                    holder.Pending.AsTask();
+            }
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    [Fact]
+    public Task FixesAValueTaskReadFromAnArray() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<int> FromArray(ValueTask<int>[] pending) =>
+                {|#0:pending[0]|};
+            """,
+            """
+            internal Task<int> FromArray(ValueTask<int>[] pending) =>
+                pending[0].AsTask();
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    /// <remarks>
+    /// The receiver is parenthesised only where appending <c>.AsTask()</c>
+    /// would otherwise bind to part of the expression. A conditional binds
+    /// looser than member access, so it needs the parentheses that an
+    /// identifier or an element access does not.
+    /// </remarks>
+    [Fact]
+    public Task WrapsAConditionalValueTaskInParentheses() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<int> Either(
+                bool flag,
+                ValueTask<int> first,
+                ValueTask<int> second) =>
+                {|#0:flag ? first : second|};
+            """,
+            """
+            internal Task<int> Either(
+                bool flag,
+                ValueTask<int> first,
+                ValueTask<int> second) =>
+                (flag ? first : second).AsTask();
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    /// <remarks>
+    /// A named argument reaches the parameter by name rather than by position,
+    /// so the target type cannot be read from the index. Reordering the call
+    /// puts the ValueTask at an index whose parameter is not a Task, which
+    /// fails the fix if the name is ignored.
+    /// </remarks>
+    [Fact]
+    public Task FixesAValueTaskPassedByName() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<int> ByName(ValueTask<int> pending) =>
+                Accept(task: {|#0:pending|}, label: "x");
+
+            private static Task<int> Accept(string label, Task<int> task) =>
+                task;
+            """,
+            """
+            internal Task<int> ByName(ValueTask<int> pending) =>
+                Accept(task: pending.AsTask(), label: "x");
+
+            private static Task<int> Accept(string label, Task<int> task) =>
+                task;
+            """,
+            DiagnosticResult.CompilerError("CS1503").WithLocation(0));
+
+    /// <remarks>
+    /// The name alone is not the test. A type called ValueTask outside
+    /// System.Threading.Tasks has no AsTask, so a fix keyed on the name would
+    /// produce code that does not compile.
+    /// </remarks>
+    [Fact]
+    public Task LeavesAForeignValueTaskAlone() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal struct ValueTask<T>
+            {
+            }
+
+            internal class Subject
+            {
+                internal Task<int> Foreign(ValueTask<int> pending) =>
+                    {|#0:pending|};
+            }
+            """,
+            """
+            internal struct ValueTask<T>
+            {
+            }
+
+            internal class Subject
+            {
+                internal Task<int> Foreign(ValueTask<int> pending) =>
+                    {|#0:pending|};
+            }
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    [Fact]
+    public void OffersTheBatchFixAllProvider() =>
+        new AsTaskCodeFix().GetFixAllProvider()
+                          .ShouldBe(WellKnownFixAllProviders.BatchFixer);
+
+    /// <remarks>
+    /// The mismatch case reached through an assignment rather than an
+    /// argument. The converted type is present and does not bridge, so the
+    /// fixer falls through to the overload-candidate path and finds no call to
+    /// read a parameter from.
+    /// </remarks>
+    [Fact]
+    public Task LeavesAMismatchedAssignmentAlone() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<string> Mismatched(ValueTask<int> pending) =>
+                {|#0:pending|};
+            """,
+            """
+            internal Task<string> Mismatched(ValueTask<int> pending) =>
+                {|#0:pending|};
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
 }

--- a/test/Waystone.Monads.Analyzers.Tests/AsTaskCodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/AsTaskCodeFixTests.cs
@@ -1,0 +1,124 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+public class AsTaskCodeFixTests
+{
+    [Fact]
+    public Task FixesAValueTaskAssignedToATaskLocal() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<Option<int>> Assign(Option<int> option)
+            {
+                Task<Option<int>> mapped =
+                    {|#0:option.MapAsync(value => Task.FromResult(value + 1))|};
+
+                return mapped;
+            }
+            """,
+            """
+            internal Task<Option<int>> Assign(Option<int> option)
+            {
+                Task<Option<int>> mapped =
+                    option.MapAsync(value => Task.FromResult(value + 1)).AsTask();
+
+                return mapped;
+            }
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    [Fact]
+    public Task FixesAValueTaskPassedToATaskParameter() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<Option<int>> Pass(Option<int> option) =>
+                Accept({|#0:option.MapAsync(value => Task.FromResult(value + 1))|});
+
+            private static Task<Option<int>> Accept(Task<Option<int>> task) =>
+                task;
+            """,
+            """
+            internal Task<Option<int>> Pass(Option<int> option) =>
+                Accept(option.MapAsync(value => Task.FromResult(value + 1)).AsTask());
+
+            private static Task<Option<int>> Accept(Task<Option<int>> task) =>
+                task;
+            """,
+            DiagnosticResult.CompilerError("CS1503").WithLocation(0));
+
+    [Fact]
+    public Task FixesAValueTaskInsideTaskWhenAll() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task FanOut(Option<int> first, Option<int> second) =>
+                Task.WhenAll(
+                    {|#0:first.MapAsync(value => Task.FromResult(value + 1))|},
+                    {|#1:second.MapAsync(value => Task.FromResult(value + 1))|});
+            """,
+            """
+            internal Task FanOut(Option<int> first, Option<int> second) =>
+                Task.WhenAll(
+                    first.MapAsync(value => Task.FromResult(value + 1)).AsTask(),
+                    second.MapAsync(value => Task.FromResult(value + 1)).AsTask());
+            """,
+            DiagnosticResult.CompilerError("CS1503").WithLocation(0),
+            DiagnosticResult.CompilerError("CS1503").WithLocation(1));
+
+    [Fact]
+    public Task FixesANonGenericValueTaskAssignedToATask() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task Run(Result<int, string> result)
+            {
+                Task matched = {|#0:result.MatchAsync(
+                    ok => Task.CompletedTask,
+                    err => Task.CompletedTask)|};
+
+                return matched;
+            }
+            """,
+            """
+            internal Task Run(Result<int, string> result)
+            {
+                Task matched = result.MatchAsync(
+                    ok => Task.CompletedTask,
+                    err => Task.CompletedTask).AsTask();
+
+                return matched;
+            }
+            """,
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    [Fact]
+    public Task LeavesAnUnrelatedConversionErrorAlone() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            "internal string Wrong() => {|#0:1|};",
+            "internal string Wrong() => {|#0:1|};",
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    [Fact]
+    public Task LeavesANonValueTaskSourceAlone() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            "internal Task<int> NotATask(Option<int> option) => {|#0:option|};",
+            "internal Task<int> NotATask(Option<int> option) => {|#0:option|};",
+            DiagnosticResult.CompilerError("CS0029").WithLocation(0));
+
+    [Fact]
+    public Task LeavesAMismatchedTypeArgumentAlone() =>
+        Verify.CompilerCodeFixAsync<AsTaskCodeFix>(
+            """
+            internal Task<string> Mismatched(Option<int> option) =>
+                Accept({|#0:option.MapAsync(value => Task.FromResult(value + 1))|});
+
+            private static Task<string> Accept(Task<string> task) => task;
+            """,
+            """
+            internal Task<string> Mismatched(Option<int> option) =>
+                Accept({|#0:option.MapAsync(value => Task.FromResult(value + 1))|});
+
+            private static Task<string> Accept(Task<string> task) => task;
+            """,
+            DiagnosticResult.CompilerError("CS1503").WithLocation(0));
+}

--- a/test/Waystone.Monads.Analyzers.Tests/Verify.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/Verify.cs
@@ -1,4 +1,4 @@
-namespace Waystone.Monads.Analyzers;
+﻿namespace Waystone.Monads.Analyzers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -65,6 +65,23 @@ internal static class Verify
 
         test.ExpectedDiagnostics.AddRange(expected);
         test.FixedState.ExpectedDiagnostics.AddRange(remaining);
+
+        return test.RunAsync();
+    }
+
+    public static Task CompilerCodeFixAsync<TCodeFix>(
+        string source,
+        string fixedSource,
+        params DiagnosticResult[] expected)
+        where TCodeFix : CodeFixProvider, new()
+    {
+        var test = new CodeFixTest<EmptyDiagnosticAnalyzer, TCodeFix>
+        {
+            TestCode = Wrap(source),
+            FixedCode = Wrap(fixedSource),
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
 
         return test.RunAsync();
     }


### PR DESCRIPTION
Every async Option/Result extension now returns ValueTask, so a caller
that assigns to a Task local, passes one to a Task parameter, or fans out
through Task.WhenAll gets CS0029 or CS1503. The repair is the same at every
site: append .AsTask().

AsTaskCodeFix registers against the compiler's own diagnostic ids rather
than a new WMxxxx rule. The break is not legal code that misbehaves at
runtime — it does not compile — so an analyzer diagnostic would report a
second time on a span the compiler already owns. No Rules.cs descriptor and
no AnalyzerReleases entry follow, because there is no new diagnostic; RS2008
only speaks for descriptors this analyzer declares.

The fixer confirms both ends before offering: the source must be
System.Threading.Tasks.ValueTask or ValueTask<T>, and the target must be
Task or Task<T> of the same T. CS0029 supplies the target through
ConvertedType; CS1503 has no converted type, so the target comes from the
parameter at that position on each overload-resolution candidate, unwrapping
the params array so Task.WhenAll's Task<TResult>[] matches. An unbound type
parameter counts as a match, since inference succeeds once .AsTask() is
applied. A genuinely different T is a real type error and gets no fix.

Task.WhenAll turned out to need no special handling: the compiler reports
CS1503 once per mismatched argument rather than failing overload resolution
across the array, so the fixer repairs each one independently. That was an
open question on the issue and is now covered by a test.

Not derived from MonadCodeFix — its RegisterCodeFixesAsync is sealed and
resolves MonadSymbols, which this fixer never needs. The mismatch is
between ValueTask and Task, not between Option/Result and anything.

Verified: 240 analyzer tests, 574 Monads tests on all five frameworks.
Both guards carry a negative test that fails when the guard is removed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>