### PR TITLE
feat!: a Some may hold the default of its type

### DIFF
--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -154,6 +154,10 @@ public static class Option
     /// <param name="value">The value of the <see cref="Some{T}" /></param>
     /// <typeparam name="T">The option value's type.</typeparam>
     /// <returns>An <see cref="Option{T}" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// The value is null. A <see cref="Some{T}" /> may hold the default of
+    /// its type, but never null.
+    /// </exception>
     public static Option<T> Some<T>(T value) where T : notnull =>
         new Some<T>(value);
 
@@ -169,14 +173,12 @@ public static class Option
     /// <see cref="Option{T}" />
     /// </param>
     /// <returns>
-    /// Returns a <see cref="Some{T}" /> if the value is not null and not
-    /// equal to the default value, otherwise it will return a <see cref="None{T}" />.
+    /// Returns a <see cref="Some{T}" /> if the value is not null, otherwise
+    /// returns a <see cref="None{T}" />.
     /// </returns>
     public static Option<T> FromNullable<T>(T? value)
         where T : struct =>
-        value.HasValue && !value.Value.Equals(default(T))
-            ? new Some<T>(value.Value)
-            : new None<T>();
+        value.HasValue ? new Some<T>(value.Value) : new None<T>();
 
     /// <summary>Creates an <see cref="Option{T}" /> from a nullable reference type.</summary>
     /// <typeparam name="T">The non-nullable value's type</typeparam>

--- a/src/Waystone.Monads/Options/Some.cs
+++ b/src/Waystone.Monads/Options/Some.cs
@@ -20,10 +20,11 @@ public sealed record Some<T> : Option<T>
 {
     internal Some(T value)
     {
-        if (Equals(value, default(T)))
+        if (value is null)
         {
-            throw new InvalidOperationException(
-                $"The value of a `Some` option cannot be it's default value `{default(T)}`");
+            throw new ArgumentNullException(
+                nameof(value),
+                "The value of a `Some` option cannot be null.");
         }
 
         Value = value;

--- a/test/Waystone.Monads.Tests/Options/OptionTests.cs
+++ b/test/Waystone.Monads.Tests/Options/OptionTests.cs
@@ -217,4 +217,17 @@ public sealed class OptionTests
         result.ShouldBeOfType<Some<int>>();
         result.Unwrap().ShouldBe(42);
     }
+
+    [Fact]
+    public void GivenTheDefaultOfAValueType_WhenCreatingOption_ThenReturnSome()
+    {
+        int? zero = 0;
+        Option<int> result = Option.FromNullable(zero);
+        result.IsSome.ShouldBeTrue();
+        result.ShouldBeOfType<Some<int>>();
+        result.Unwrap().ShouldBe(0);
+
+        Guid? empty = Guid.Empty;
+        Option.FromNullable(empty).ShouldBe(Option.Some(Guid.Empty));
+    }
 }

--- a/test/Waystone.Monads.Tests/Options/SomeTests.cs
+++ b/test/Waystone.Monads.Tests/Options/SomeTests.cs
@@ -14,19 +14,35 @@ using Xunit;
 public sealed class SomeTests
 {
     [Fact]
-    public void GivenDefault_WhenCreatingSome_ThenThrow()
+    public void GivenNull_WhenCreatingSome_ThenThrow()
     {
-        Func<Option<int>> someDefaultNumber = () => Option.Some(0);
-
-        Func<Option<string>> someDefaultString =
+        Func<Option<string>> someNullString =
             () => Option.Some(default(string)!);
 
-        Func<Option<object>> someDefaultObject =
+        Func<Option<object>> someNullObject =
             () => Option.Some(default(object)!);
 
-        someDefaultNumber.ShouldThrow<InvalidOperationException>();
-        someDefaultString.ShouldThrow<InvalidOperationException>();
-        someDefaultObject.ShouldThrow<InvalidOperationException>();
+        someNullString.ShouldThrow<ArgumentNullException>();
+        someNullObject.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenTheDefaultOfAValueType_WhenCreatingSome_ThenReturnSome()
+    {
+        Option.Some(0).ShouldBe(Option.Some(0));
+        Option.Some(0).Unwrap().ShouldBe(0);
+        Option.Some(false).Unwrap().ShouldBeFalse();
+        Option.Some('\0').Unwrap().ShouldBe('\0');
+        Option.Some(default(Guid)).Unwrap().ShouldBe(Guid.Empty);
+        Option.Some(TimeSpan.Zero).Unwrap().ShouldBe(TimeSpan.Zero);
+        Option.Some(DateTime.MinValue).Unwrap().ShouldBe(DateTime.MinValue);
+    }
+
+    [Fact]
+    public void GivenTheDefaultOfAValueType_WhenCreatingSome_ThenItIsNotNone()
+    {
+        Option.Some(0).IsSome.ShouldBeTrue();
+        Option.Some(0).ShouldNotBe(Option.None<int>());
     }
 
     [Fact]


### PR DESCRIPTION
The invariant becomes "a Some never holds null" rather than "a Some never
holds default(T)". Rust's Some(0), Some(false) and Some(Duration::ZERO) are
ordinary values; ours threw, so Option<int> could not represent part of its
own domain and Option<bool> was close to useless.

Two of the three sites that encoded the old invariant move here. Some's
constructor guard becomes a null test, and the struct overload of
FromNullable keys on HasValue alone rather than also rejecting the default,
which is what its reference-type sibling already promised. The implicit
conversion is the third site and changes in the next PR, so between the two
Option.Some(0) is a Some while Option<int> x = 0 is still None.

The guard is `value is null`, not `value == null` or Equals: the first binds
to a user-defined operator on T and the second reaches T's overridden Equals.
T : notnull is a compile-time hint a caller defeats with null!, so the runtime
check has to stay. It throws ArgumentNullException as the type the condition
actually is, which is a source break for anyone catching
InvalidOperationException around Option.Some.

Option.Some<T> gains an <exception> tag, since the thrown type is part of the
public contract and was documented nowhere.

Verified on all five frameworks rather than net8.0 alone — Equals(value,
default(T)) to `value is null` is exactly the shape that can differ on net472
and net481. 587 Monads tests, 224 analyzer tests, Release build 0 errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>