### PR TITLE
feat!: the implicit conversion to Option only maps null to None

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,14 @@ complains. When a step is not found, the folder is never the reason.
 Without one, an unmatched value runs no assertion and the scenario passes. This
 hid three no-op assertions in the Result specs.
 
+**A char literal written as a raw control character turns the file binary to
+git.** `SomeTests.cs` picked up two actual NUL bytes where the source meant the
+two-character escape, and git then refused to diff the file: the PR that
+introduced it showed `Bin 16307 -> 16743` instead of the change, and every later
+diff of that file would have shown the same. It compiles and the tests pass, so
+nothing else complains. Write the escape, and check `git diff --stat` for `Bin`
+on a file that is plainly text.
+
 **The library's extensions are C# 14 `extension` blocks, so `IsExtensionMethod`
 is not a reliable test in an analyzer.** The compiler emits a compatibility static
 method that older Roslyn sees as a classic extension, so a rule keyed on

--- a/src/Waystone.Monads/Options/OptionOfT.cs
+++ b/src/Waystone.Monads/Options/OptionOfT.cs
@@ -358,12 +358,12 @@ public abstract record Option<T> where T : notnull
     /// </summary>
     /// <param name="value">The value of the option</param>
     /// <returns>
-    /// A <see cref="Some{T}" /> when the value is not the default of its
-    /// type, otherwise a <see cref="None{T}" />
+    /// A <see cref="Some{T}" /> when the value is not null, otherwise a
+    /// <see cref="None{T}" />
     /// </returns>
 #if !DEBUG
     [DebuggerStepThrough]
 #endif
     public static implicit operator Option<T>(T value) =>
-        Equals(value, default(T)) ? new None<T>() : new Some<T>(value);
+        value is null ? new None<T>() : new Some<T>(value);
 }

--- a/test/Waystone.Monads.Tests/Options/OptionTests.cs
+++ b/test/Waystone.Monads.Tests/Options/OptionTests.cs
@@ -82,13 +82,13 @@ public sealed class OptionTests
     }
 
     [Fact]
-    public void GivenFactoryReturningDefault_WhenBinding_ThenReturnNone()
+    public void GivenFactoryReturningDefault_WhenBinding_ThenReturnSome()
     {
         using (LoggerScope())
         {
-            Option.Try(() => 0).ShouldBe(Option.None<int>());
-            Option.Try(() => false).ShouldBe(Option.None<bool>());
-            Option.Try(() => default(Guid)).ShouldBe(Option.None<Guid>());
+            Option.Try(() => 0).ShouldBe(Option.Some(0));
+            Option.Try(() => false).ShouldBe(Option.Some(false));
+            Option.Try(() => default(Guid)).ShouldBe(Option.Some(Guid.Empty));
 
             _callback.DidNotReceive()
                .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
@@ -126,14 +126,14 @@ public sealed class OptionTests
 
     [Fact]
     public async Task
-        GivenAsyncFactoryReturningDefault_WhenBinding_ThenReturnNone()
+        GivenAsyncFactoryReturningDefault_WhenBinding_ThenReturnSome()
     {
         using (LoggerScope())
         {
             Option<int> option =
                 await Option.TryAsync(() => Task.FromResult(0));
 
-            option.ShouldBe(Option.None<int>());
+            option.ShouldBe(Option.Some(0));
 
             _callback.DidNotReceive()
                .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
@@ -172,11 +172,11 @@ public sealed class OptionTests
 #pragma warning restore CS8604 // Possible null reference argument.
         Option<Guid> option6 = Guid.NewGuid();
 
-        option1.IsSome.ShouldBeFalse();
+        option1.IsSome.ShouldBeTrue();
         option2.IsSome.ShouldBeTrue();
         option3.IsSome.ShouldBeTrue();
         option4.IsSome.ShouldBeFalse();
-        option5.IsSome.ShouldBeFalse();
+        option5.IsSome.ShouldBeTrue();
         option6.IsSome.ShouldBeTrue();
     }
 

--- a/test/Waystone.Monads.Tests/Options/SomeTests.cs
+++ b/test/Waystone.Monads.Tests/Options/SomeTests.cs
@@ -161,6 +161,16 @@ public sealed class SomeTests
     }
 
     [Fact]
+    public void WhenMapProducesADefault_ThenReturnSome()
+    {
+        Option<int> some = Option.Some(1);
+
+        Option<int> result = some.Map(x => x - x);
+
+        result.ShouldBeSomeValue(0);
+    }
+
+    [Fact]
     public void WhenMapOr_ThenReturnMappedValue()
     {
         Option<int> some = Option.Some(1);
@@ -579,6 +589,14 @@ public sealed class SomeTests
 
         some.Reduce(Option.None<int>(), (x, y) => x + y)
            .ShouldBeSomeValue(1);
+    }
+
+    [Fact]
+    public void WhenReduceProducesADefault_ThenReturnSome()
+    {
+        Option<int> some = Option.Some(1);
+
+        some.Reduce(Option.Some(-1), (x, y) => x + y).ShouldBeSomeValue(0);
     }
 
     [Fact]


### PR DESCRIPTION
The second of the three sites encoding the old default-rejecting invariant,
and the single largest behaviour change in v6. With Some(0) legal as of the
previous PR, a conversion that still mapped 0 to None gave the library two
contradictory answers for the same value, and Map and Reduce kept handing back
None for a value the author had just computed.

Option<int> x = 0 is now Some(0). So is Option.Try(() => 0), which ends in
`return value;` and defers to this conversion rather than testing anything of
its own, and so is option.Map(x => x - x). None of it fails to compile and none
of it throws — a consumer's .IsNone branch simply stops being taken. That is
the whole risk of this PR and the reason it is reviewable on its own.

Some.Map and Some.Reduce both return a bare T through the conversion, so both
gain a test that produces a default deliberately. OptionTests inverts the two
implicit-conversion cases and the two Try-returning-default cases; the existing
GivenAnyFactory_WhenBinding_ThenAgreeWithTheConversion asserts agreement rather
than a particular result and keeps passing, which is what pins Try to the
conversion instead of to a second copy of the rule.

WM1004 and WM1010 now describe behaviour that no longer exists. They are
retired in the next PR rather than here, which keeps the analyzer churn out of
the one PR whose behaviour change needs reading closely.

Verified on all five frameworks: 589 Monads tests, 224 analyzer tests, Release
build 0 errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>