### PR TITLE
chore(analyzers)!: retire the rules that encoded the default-value invariant

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
+++ b/sample/Waystone.Monads.Analyzers.Sample/Misuse.cs
@@ -1,6 +1,5 @@
 namespace Waystone.Monads.Analyzers.Sample;
 
-using System;
 using System.Threading.Tasks;
 using Waystone.Monads.Options;
 using Waystone.Monads.Results;
@@ -8,27 +7,16 @@ using Waystone.Monads.Results.Errors;
 
 internal class Misuse
 {
-    internal Option<int> SomeOfADefault() => Option.Some(0);
-
     internal Option<string> SomeOfANull() => Option.Some(default(string)!);
-
-    internal Option<Guid> SomeOfAnEmptyGuid() => Option.Some(Guid.Empty);
 
     internal Option<int> NullInsteadOfNone() => null;
 
     internal Result<int, string> DefaultInsteadOfErr() =>
         default(Result<int, string>);
 
-    internal Option<int> ZeroThatBecomesNone() => 0;
-
     internal void NullPassedToAnOptionParameter() => Accept(null!);
 
     internal void DiscardedResult() => Save();
-
-    internal Option<bool> OptionOfBool() => Option.None<bool>();
-
-    internal Option<Colour> OptionOfAnEnumWithAZeroMember() =>
-        Option.None<Colour>();
 
 #nullable enable
     internal Option<int>? NullableOption() => null;
@@ -43,10 +31,4 @@ internal class Misuse
 
     private Task<Result<int, Error>> SaveAsync() =>
         Task.FromResult(Result.Ok<int, Error>(1));
-}
-
-internal enum Colour
-{
-    Red = 0,
-    Green = 1,
 }

--- a/src/Waystone.Monads.Analyzers.CodeFixes/UseNoneCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/UseNoneCodeFix.cs
@@ -11,12 +11,7 @@ using System.Composition;
 public sealed class UseNoneCodeFix : MonadCodeFix
 {
     public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create(
-            "WM1001",
-            "WM1002",
-            "WM1003",
-            "WM1004",
-            "WM1010");
+        ImmutableArray.Create("WM1001", "WM1002", "WM1003");
 
     protected override void Register(
         CodeFixContext context,
@@ -30,7 +25,7 @@ public sealed class UseNoneCodeFix : MonadCodeFix
             return;
         }
 
-        var target = diagnostic.Id is "WM1001" or "WM1010"
+        var target = diagnostic.Id is "WM1001"
             ? expression.FirstAncestorOrSelf<InvocationExpressionSyntax>()
             : expression;
 
@@ -41,9 +36,7 @@ public sealed class UseNoneCodeFix : MonadCodeFix
 
         var info = model.GetTypeInfo(target, context.CancellationToken);
 
-        var option = diagnostic.Id == "WM1004"
-            ? info.ConvertedType
-            : info.Type ?? info.ConvertedType;
+        var option = info.Type ?? info.ConvertedType;
 
         var arguments = symbols.TypeArgumentsOf(option);
 

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -55,5 +55,8 @@ WM1010 | Reliability | Warning | The default of a value type is used as an Optio
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+WM1004 | Reliability | Warning | A default value converts to None
 WM1007 | Reliability | Warning | A type derives from Option or Result
+WM1009 | Reliability | Warning | Option of bool or of an enum with a zero member
+WM1010 | Reliability | Warning | The default of a value type is used as an Option value
 WM2014 | Usage | Info | FlatMap has been renamed to AndThen

--- a/src/Waystone.Monads.Analyzers/DeclaredTypeAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/DeclaredTypeAnalyzer.cs
@@ -13,7 +13,6 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             Rules.NullableMonadDeclared,
-            Rules.OptionOfZeroValuedType,
             Rules.NestedOption,
             Rules.ResultWithIdenticalTypeArguments,
             Rules.DerivedMonadTypeDeclared);
@@ -68,19 +67,6 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
                     symbols.IsOption(type) ? "None" : "Err"));
         }
 
-        if (symbols.IsOption(type)
-         && symbols.TypeArgumentsOf(type) is { Length: 1 } held
-         && AdviceFor(held[0]) is { } advice)
-        {
-            context.ReportDiagnostic(
-                Diagnostic.Create(
-                    Rules.OptionOfZeroValuedType,
-                    location,
-                    Semantics.Display(type),
-                    Semantics.Display(held[0]),
-                    advice));
-        }
-
         if (symbols.IsDerivedCase(type))
         {
             var declared = symbols.BaseCaseOf(type);
@@ -126,24 +112,4 @@ public sealed class DeclaredTypeAnalyzer : MonadAnalyzer
                     Semantics.Display(type)));
         }
     }
-
-    private static string? AdviceFor(ITypeSymbol held)
-    {
-        if (held.SpecialType == SpecialType.System_Boolean)
-        {
-            return
-                "Use a three-state enum whose zero member carries the state you meant None to express";
-        }
-
-        return held.TypeKind == TypeKind.Enum && HasZeroMember(held)
-            ? "Renumber it so no meaningful member is 0, leaving zero to the state None expresses"
-            : null;
-    }
-
-    private static bool HasZeroMember(ITypeSymbol held) =>
-        held.GetMembers()
-           .OfType<IFieldSymbol>()
-           .Any(
-                field => field.HasConstantValue
-                      && Semantics.IsZeroConstant(field.ConstantValue));
 }

--- a/src/Waystone.Monads.Analyzers/NullAndDefaultAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/NullAndDefaultAnalyzer.cs
@@ -13,8 +13,7 @@ public sealed class NullAndDefaultAnalyzer : MonadAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             Rules.NullAssignedToMonad,
-            Rules.DefaultOfMonad,
-            Rules.DefaultValueConvertsToNone);
+            Rules.DefaultOfMonad);
 
     protected override void Register(
         CompilationStartAnalysisContext context,
@@ -28,10 +27,6 @@ public sealed class NullAndDefaultAnalyzer : MonadAnalyzer
             node => AnalyzeDefault(node, symbols),
             SyntaxKind.DefaultLiteralExpression,
             SyntaxKind.DefaultExpression);
-
-        context.RegisterOperationAction(
-            operation => AnalyzeConversion(operation, symbols),
-            OperationKind.Conversion);
     }
 
     private static void AnalyzeNull(
@@ -90,38 +85,6 @@ public sealed class NullAndDefaultAnalyzer : MonadAnalyzer
                 Rules.DefaultOfMonad,
                 expression.GetLocation(),
                 Semantics.Display(type!)));
-    }
-
-    private static void AnalyzeConversion(
-        OperationAnalysisContext context,
-        MonadSymbols symbols)
-    {
-        var conversion = (IConversionOperation)context.Operation;
-
-        if (conversion.OperatorMethod is not { Name: "op_Implicit" } operatorMethod
-         || !SymbolEqualityComparer.Default.Equals(
-                operatorMethod.ContainingType.OriginalDefinition,
-                symbols.Option))
-        {
-            return;
-        }
-
-        var operand = conversion.Operand;
-
-        if (operand.ConstantValue is { HasValue: true, Value: null }
-         || !Semantics.IsDefaultValue(operand))
-        {
-            return;
-        }
-
-        var valueType = operatorMethod.ContainingType.TypeArguments[0];
-
-        context.ReportDiagnostic(
-            Diagnostic.Create(
-                Rules.DefaultValueConvertsToNone,
-                operand.Syntax.GetLocation(),
-                Semantics.Display(valueType),
-                operand.Syntax.ToString()));
     }
 
     private static bool IsNullTest(ExpressionSyntax expression) =>

--- a/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/OptionCreationAnalyzer.cs
@@ -11,7 +11,6 @@ public sealed class OptionCreationAnalyzer : MonadAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             Rules.SomeFromDefaultValue,
-            Rules.DefaultOfValueTypeInOption,
             Rules.PossiblyNullPassedToSome);
 
     protected override void Register(
@@ -44,19 +43,14 @@ public sealed class OptionCreationAnalyzer : MonadAnalyzer
 
         if (Semantics.IsDefaultValue(argument))
         {
-            string type = Semantics.Display(valueType);
-
-            context.ReportDiagnostic(
-                valueType.IsValueType
-                    ? Diagnostic.Create(
-                        Rules.DefaultOfValueTypeInOption,
-                        argument.Syntax.GetLocation(),
-                        argument.Syntax.ToString(),
-                        type)
-                    : Diagnostic.Create(
+            if (!valueType.IsValueType)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
                         Rules.SomeFromDefaultValue,
                         argument.Syntax.GetLocation(),
-                        type));
+                        Semantics.Display(valueType)));
+            }
 
             return;
         }

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -9,17 +9,17 @@ public static class Rules
     private const string Design = nameof(Design);
 
     /// <remarks>
-    /// Narrowed to the null case. The value-type half moved to WM1010, which
-    /// forecasts the v6 relaxation, because no single messageFormat is true of
-    /// both: in v6 a null still throws and a value-type default becomes an
-    /// ordinary Some. This rule survives v6 with only its exception type
-    /// changing, so keep the message about null rather than about default(T).
+    /// The only survivor of the rules that encoded the pre-v6 default-value
+    /// invariant. It reports the null case alone, which is what Some still
+    /// rejects; the value-type half retired with the relaxation, because a
+    /// default is now an ordinary value. Keep the message about null rather
+    /// than about default(T).
     /// </remarks>
     public static readonly DiagnosticDescriptor SomeFromDefaultValue = Bug(
         "WM1001",
         "Do not pass null to Some",
         "'Option.Some' throws at runtime when the value is null. Use 'Option.None<{0}>()' to express the absence of a value.",
-        "The constructor of Some rejects null, so this call always throws an InvalidOperationException.");
+        "The constructor of Some rejects null, so this call always throws an ArgumentNullException.");
 
     /// <remarks>
     /// Warning survives the false-positive question, examined in DRA-77. The
@@ -61,26 +61,11 @@ public static class Rules
         "'default({0})' is null, not an empty value. Construct the absent or failed case explicitly.",
         "Option and Result are reference types, so their default is null rather than None or Err.");
 
-    /// <remarks>
-    /// Not narrowed alongside WM1001, because it never covered the null case in
-    /// the first place: <see cref="NullAndDefaultAnalyzer" /> returns early on a
-    /// null-constant operand, so this rule only ever fires on the default of a
-    /// value type. That is why the v6 forecast goes in this message rather than
-    /// into WM1010 as a second position — one sentence is true of everything the
-    /// rule reports. It follows that the rule becomes wholly false in v6 and is
-    /// retired there, rather than surviving narrowed as WM1001 does.
-    /// </remarks>
-    public static readonly DiagnosticDescriptor DefaultValueConvertsToNone = Bug(
-        "WM1004",
-        "Do not convert a default value to an Option implicitly",
-        "The implicit conversion maps the default of '{0}' to None, so this produces None rather than a Some holding {1} today. In v6 it produces a Some holding {1}.",
-        "Option<T>'s implicit conversion returns None when the value equals default(T), so a default value silently becomes an absent one. In v6 only null maps onto None, and this expression changes meaning rather than failing to compile.");
-
     public static readonly DiagnosticDescriptor PossiblyNullPassedToSome = Bug(
         "WM1005",
         "Prefer FromNullable over Some for a possibly null value",
         "'Option.Some' throws when this value is null. Use 'Option.FromNullable' to map null onto None.",
-        "Some rejects a value equal to default(T), and the default of a reference type is null.");
+        "Some rejects null, and a value the compiler cannot prove is non-null may be one.");
 
     public static readonly DiagnosticDescriptor ResultDiscarded = Bug(
         "WM1006",
@@ -100,41 +85,6 @@ public static class Rules
         "Do not declare an Option or Result as nullable",
         "'{0}?' has three states where two are meaningful. Drop the annotation — '{1}' already expresses the case you are reaching for.",
         "Option and Result are records, so the compiler accepts a nullable annotation on one. The annotation adds a third state to a type whose whole purpose is to have exactly two, and the null it admits throws on the next member access rather than being handled as an absence.");
-
-    /// <remarks>
-    /// Scoped to bool and enums with a zero member deliberately. The hazard is
-    /// general — <c>Option&lt;int&gt;</c> breaks on 0 and
-    /// <c>Option&lt;Guid&gt;</c> on <c>Guid.Empty</c> — but widening a
-    /// declaration rule to every value type would fire across code that works
-    /// today, and a Warning ships enabled to every consumer on upgrade. WM1001
-    /// and WM1004 already cover the call site that provably passes a default;
-    /// this rule covers the declaration.
-    /// </remarks>
-    public static readonly DiagnosticDescriptor OptionOfZeroValuedType = Bug(
-        "WM1009",
-        "Do not use Option over bool or a zero-member enum",
-        "'{0}' cannot hold the default of '{1}', because 'Option.Some' throws on it. {2}.",
-        "Option.Some rejects a value equal to default(T), so an Option over a type whose zero is a meaningful value cannot represent part of its own domain.");
-
-    /// <remarks>
-    /// Exists only to forecast the v6 relaxation, and is retired there rather
-    /// than reworded — see DRA-92. It is a separate id from WM1001 rather than a
-    /// reworded one because a descriptor has exactly one messageFormat and no
-    /// single sentence covers both a null and a value-type default once v6
-    /// treats them differently. It covers the Option.Some argument position
-    /// only: the implicit conversion is WM1004's, which never reported a null
-    /// and so carries its own forecast, and Option.FromNullable is deliberately
-    /// left out because the analyzer would only see a literal nobody writes.
-    /// Warning is earned on the present tense of the message — every span
-    /// reported throws today — and it is the severity these spans already
-    /// reported at under WM1001, so no consumer sees a new count.
-    /// </remarks>
-    public static readonly DiagnosticDescriptor DefaultOfValueTypeInOption =
-        Bug(
-            "WM1010",
-            "Do not use the default of a value type as an Option value",
-            "{0} is the default of '{1}', so 'Option.Some' throws today. In v6 it returns a Some holding {0}. Use 'Option.None<{1}>()' if you mean the absent case.",
-            "Option.Some rejects a value equal to default(T). That changes in v6, where only null is rejected and the default of a value type becomes an ordinary Some, so code relying on the current behaviour changes meaning on upgrade rather than failing to compile.");
 
     public static readonly DiagnosticDescriptor UnwrapUsed = Idiom(
         "WM2001",
@@ -233,7 +183,7 @@ public static class Rules
     public static readonly DiagnosticDescriptor OrDefaultOnAValueType = Idiom(
         "WM2015",
         "Prefer UnwrapOrNull over UnwrapOrDefault on a value type",
-        "'{0}' hands back the default of '{1}' when there is no value, which is indistinguishable from a real one. '{2}' returns null instead.",
+        "'{0}' hands back {3}, the default of '{1}', when there is no value, and nothing distinguishes that from a real {3}. '{2}' returns null instead.",
         "T? on a type parameter constrained only to notnull is an annotation rather than a Nullable<T>, so for a value type UnwrapOrDefault and MapOrDefault return 0, false or default(Guid) for the absent case. That is legitimate where the caller genuinely wants the default.");
 
     public static readonly DiagnosticDescriptor NullableReturnCouldBeOption = Migration(

--- a/src/Waystone.Monads.Analyzers/Semantics.cs
+++ b/src/Waystone.Monads.Analyzers/Semantics.cs
@@ -72,6 +72,54 @@ public static class Semantics
     public static bool IsZeroConstant(object? constant) =>
         constant is not null && IsZero(constant);
 
+    public static string DefaultOf(ITypeSymbol type)
+    {
+        if (WellKnownDefaults.TryGetValue(
+                type.ToDisplayString(),
+                out string? wellKnown))
+        {
+            return Display(type) + "." + wellKnown;
+        }
+
+        if (type.TypeKind == TypeKind.Enum)
+        {
+            var zero = ZeroMemberOf(type);
+
+            return zero is null
+                ? "default(" + Display(type) + ")"
+                : Display(type) + "." + zero.Name;
+        }
+
+        switch (type.SpecialType)
+        {
+            case SpecialType.System_Boolean:
+                return "false";
+            case SpecialType.System_Char:
+                return "'\\0'";
+            case SpecialType.System_SByte:
+            case SpecialType.System_Byte:
+            case SpecialType.System_Int16:
+            case SpecialType.System_UInt16:
+            case SpecialType.System_Int32:
+            case SpecialType.System_UInt32:
+            case SpecialType.System_Int64:
+            case SpecialType.System_UInt64:
+            case SpecialType.System_Single:
+            case SpecialType.System_Double:
+            case SpecialType.System_Decimal:
+                return "0";
+            default:
+                return "default(" + Display(type) + ")";
+        }
+    }
+
+    private static IFieldSymbol? ZeroMemberOf(ITypeSymbol type) =>
+        type.GetMembers()
+           .OfType<IFieldSymbol>()
+           .FirstOrDefault(
+                field => field.HasConstantValue
+                      && IsZeroConstant(field.ConstantValue));
+
     public static bool IsMaybeNull(IOperation operation)
     {
         var value = Unconverted(operation);

--- a/src/Waystone.Monads.Analyzers/SimplificationAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/SimplificationAnalyzer.cs
@@ -84,7 +84,8 @@ public sealed class SimplificationAnalyzer : MonadAnalyzer
                 Semantics.NameLocationOf(invocation),
                 name,
                 Semantics.Display(produced),
-                name.Replace("Default", "Null")));
+                name.Replace("Default", "Null"),
+                Semantics.DefaultOf(produced)));
     }
 
     private static void AnalyzeFlatten(

--- a/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
@@ -6,15 +6,6 @@ using Xunit;
 public class CodeFixTests
 {
     [Fact]
-    public Task ReplacesSomeOfAValueTypeDefaultWithNone() =>
-        Verify.CodeFixAsync<OptionCreationAnalyzer, UseNoneCodeFix>(
-            "internal Option<int> Make() => Option.Some({|#0:0|});",
-            "internal Option<int> Make() => Option.None<int>();",
-            Verify.Diagnostic(Rules.DefaultOfValueTypeInOption)
-               .WithLocation(0)
-               .WithArguments("0", "int"));
-
-    [Fact]
     public Task ReplacesSomeOfANullWithNone() =>
         Verify.CodeFixAsync<OptionCreationAnalyzer, UseNoneCodeFix>(
             "internal Option<string> Make() => Option.Some({|#0:default(string)|}!);",
@@ -40,15 +31,6 @@ public class CodeFixTests
             Verify.Diagnostic(Rules.DefaultOfMonad)
                .WithLocation(0)
                .WithArguments("Option<int>"));
-
-    [Fact]
-    public Task MakesASilentNoneConversionExplicit() =>
-        Verify.CodeFixAsync<NullAndDefaultAnalyzer, UseNoneCodeFix>(
-            "internal Option<int> Make() => {|#0:0|};",
-            "internal Option<int> Make() => Option.None<int>();",
-            Verify.Diagnostic(Rules.DefaultValueConvertsToNone)
-               .WithLocation(0)
-               .WithArguments("int", "0"));
 
     [Fact]
     public Task QualifiesNoneWhenTheNamespaceIsNotImported() =>
@@ -121,7 +103,11 @@ public class CodeFixTests
             [
                 Verify.Diagnostic(Rules.OrDefaultOnAValueType)
                    .WithLocation(1)
-                   .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull"),
+                   .WithArguments(
+                        "UnwrapOrDefault",
+                        "int",
+                        "UnwrapOrNull",
+                        "0"),
             ]);
 
     [Fact]

--- a/test/Waystone.Monads.Analyzers.Tests/DeclaredTypeAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/DeclaredTypeAnalyzerTests.cs
@@ -101,83 +101,22 @@ public class DeclaredTypeAnalyzerTests
             """);
 
     [Fact]
-    public Task FlagsAnOptionOfBool() =>
-        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+    public Task IgnoresAnOptionOfBool() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
             """
-            internal {|#0:Option<bool>|} Flag() => Option.None<bool>();
-            """,
-            Verify.Diagnostic(Rules.OptionOfZeroValuedType)
-               .WithLocation(0)
-               .WithArguments(
-                    "Option<bool>",
-                    "bool",
-                    "Use a three-state enum whose zero member carries the state you meant None to express"));
+            internal Option<bool> Flag() => Option.None<bool>();
+            """);
 
     [Fact]
-    public Task FlagsAnOptionOfAnEnumWithAZeroMember() =>
-        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
+    public Task IgnoresAnOptionOfAnEnumWithAZeroMember() =>
+        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
             """
             internal enum Colour { Red = 0, Green = 1 }
 
             internal class Subject
             {
-                internal {|#0:Option<Colour>|} Chosen() => Option.None<Colour>();
-            }
-            """,
-            Verify.Diagnostic(Rules.OptionOfZeroValuedType)
-               .WithLocation(0)
-               .WithArguments(
-                    "Option<Colour>",
-                    "Colour",
-                    "Renumber it so no meaningful member is 0, leaving zero to the state None expresses"));
-
-    [Fact]
-    public Task FlagsAnOptionOfAnEnumWhoseZeroMemberIsImplicit() =>
-        Verify.AnalyzerAsync<DeclaredTypeAnalyzer>(
-            """
-            internal enum Colour { Red, Green }
-
-            internal class Subject
-            {
-                internal {|#0:Option<Colour>|} Chosen() => Option.None<Colour>();
-            }
-            """,
-            Verify.Diagnostic(Rules.OptionOfZeroValuedType)
-               .WithLocation(0)
-               .WithArguments(
-                    "Option<Colour>",
-                    "Colour",
-                    "Renumber it so no meaningful member is 0, leaving zero to the state None expresses"));
-
-    [Fact]
-    public Task IgnoresAnOptionOfAnEnumWithoutAZeroMember() =>
-        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
-            """
-            internal enum Colour { Red = 1, Green = 2 }
-
-            internal class Subject
-            {
                 internal Option<Colour> Chosen() => Option.None<Colour>();
             }
-            """);
-
-    [Fact]
-    public Task IgnoresAnOptionOfAnEnumWithAnUnsignedUnderlyingType() =>
-        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
-            """
-            internal enum Colour : byte { Red = 1, Green = 2 }
-
-            internal class Subject
-            {
-                internal Option<Colour> Chosen() => Option.None<Colour>();
-            }
-            """);
-
-    [Fact]
-    public Task IgnoresAnOptionOfAnIntEvenThoughZeroIsMeaningful() =>
-        Verify.NoDiagnosticAsync<DeclaredTypeAnalyzer>(
-            """
-            internal Option<int> Count() => Option.None<int>();
             """);
 
     [Fact]

--- a/test/Waystone.Monads.Analyzers.Tests/NullAndDefaultAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/NullAndDefaultAnalyzerTests.cs
@@ -108,23 +108,9 @@ public class NullAndDefaultAnalyzerTests
                .WithArguments("Result<int, string>"));
 
     [Fact]
-    public Task FlagsADefaultValueConvertedToAnOption() =>
-        Verify.AnalyzerAsync<NullAndDefaultAnalyzer>(
-            "internal Option<int> Make() => {|#0:0|};",
-            Verify.Diagnostic(Rules.DefaultValueConvertsToNone)
-               .WithLocation(0)
-               .WithArguments("int", "0"));
-
-    [Fact]
-    public Task RendersTheV6ForecastInTheConversionMessage() =>
-        Verify.AnalyzerAsync<NullAndDefaultAnalyzer>(
-            "internal Option<int> Make() => {|#0:0|};",
-            Verify.Diagnostic(Rules.DefaultValueConvertsToNone)
-               .WithLocation(0)
-               .WithMessage(
-                    "The implicit conversion maps the default of 'int' to "
-                  + "None, so this produces None rather than a Some holding 0 "
-                  + "today. In v6 it produces a Some holding 0."));
+    public Task IgnoresADefaultValueConvertedToAnOption() =>
+        Verify.NoDiagnosticAsync<NullAndDefaultAnalyzer>(
+            "internal Option<int> Make() => 0;");
 
     [Fact]
     public Task IgnoresTheDefaultOfAReferenceTypeConvertedToAnOption() =>

--- a/test/Waystone.Monads.Analyzers.Tests/OptionCreationAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/OptionCreationAnalyzerTests.cs
@@ -8,29 +8,14 @@ public class OptionCreationAnalyzerTests
     [Theory]
     [InlineData("0", "int")]
     [InlineData("false", "bool")]
-    [InlineData("'\\0'", "char")]
     [InlineData("0m", "decimal")]
     [InlineData("default(int)", "int")]
     [InlineData("Guid.Empty", "Guid")]
     [InlineData("DateTime.MinValue", "DateTime")]
     [InlineData("TimeSpan.Zero", "TimeSpan")]
-    public Task FlagsTheDefaultOfAValueType(string value, string type) =>
-        Verify.AnalyzerAsync<OptionCreationAnalyzer>(
-            $"internal Option<{type}> Make() => Option.Some({{|#0:{value}|}});",
-            Verify.Diagnostic(Rules.DefaultOfValueTypeInOption)
-               .WithLocation(0)
-               .WithArguments(value, type));
-
-    [Fact]
-    public Task RendersEveryPlaceholderInTheValueTypeMessage() =>
-        Verify.AnalyzerAsync<OptionCreationAnalyzer>(
-            "internal Option<int> Make() => Option.Some({|#0:0|});",
-            Verify.Diagnostic(Rules.DefaultOfValueTypeInOption)
-               .WithLocation(0)
-               .WithMessage(
-                    "0 is the default of 'int', so 'Option.Some' throws today. "
-                  + "In v6 it returns a Some holding 0. Use "
-                  + "'Option.None<int>()' if you mean the absent case."));
+    public Task IgnoresTheDefaultOfAValueType(string value, string type) =>
+        Verify.NoDiagnosticAsync<OptionCreationAnalyzer>(
+            $"internal Option<{type}> Make() => Option.Some({value});");
 
     [Theory]
     [InlineData("default(string)", "string")]

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -62,7 +62,7 @@ public class RulesTests
     [Fact]
     public void EveryTierIsPopulated()
     {
-        MisuseRules().Count.ShouldBe(9);
+        MisuseRules().Count.ShouldBe(6);
         IdiomRules().Count.ShouldBe(14);
         MigrationRules().Count.ShouldBe(2);
     }

--- a/test/Waystone.Monads.Analyzers.Tests/SimplificationAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/SimplificationAnalyzerTests.cs
@@ -50,7 +50,7 @@ public class SimplificationAnalyzerTests
             """,
             Verify.Diagnostic(Rules.OrDefaultOnAValueType)
                .WithLocation(0)
-               .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull"));
+               .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull", "0"));
 
     [Fact]
     public Task FlagsUnwrapOrDefaultOnAResultWhoseOkIsAStruct() =>
@@ -61,7 +61,7 @@ public class SimplificationAnalyzerTests
             """,
             Verify.Diagnostic(Rules.OrDefaultOnAValueType)
                .WithLocation(0)
-               .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull"));
+               .WithArguments("UnwrapOrDefault", "int", "UnwrapOrNull", "0"));
 
     [Fact]
     public Task FlagsMapOrDefaultProducingAStruct() =>
@@ -72,7 +72,7 @@ public class SimplificationAnalyzerTests
             """,
             Verify.Diagnostic(Rules.OrDefaultOnAValueType)
                .WithLocation(0)
-               .WithArguments("MapOrDefault", "int", "MapOrNull"));
+               .WithArguments("MapOrDefault", "int", "MapOrNull", "0"));
 
     [Fact]
     public Task FlagsUnwrapOrDefaultAsyncBehindConfigureAwait() =>
@@ -87,7 +87,48 @@ public class SimplificationAnalyzerTests
                .WithArguments(
                     "UnwrapOrDefaultAsync",
                     "int",
-                    "UnwrapOrNullAsync"));
+                    "UnwrapOrNullAsync",
+                    "0"));
+
+    [Theory]
+    [InlineData("int", "0")]
+    [InlineData("bool", "false")]
+    [InlineData("char", "'\\0'")]
+    [InlineData("Guid", "Guid.Empty")]
+    [InlineData("TimeSpan", "TimeSpan.Zero")]
+    public Task RendersTheDefaultItHandsBack(string type, string @default) =>
+        Verify.AnalyzerAsync<SimplificationAnalyzer>(
+            $$"""
+              internal {{type}} Value(Option<{{type}}> option) =>
+                  option.{|#0:UnwrapOrDefault|}();
+              """,
+            Verify.Diagnostic(Rules.OrDefaultOnAValueType)
+               .WithLocation(0)
+               .WithMessage(
+                    $"'UnwrapOrDefault' hands back {@default}, the default of "
+                  + $"'{type}', when there is no value, and nothing "
+                  + $"distinguishes that from a real {@default}. "
+                  + "'UnwrapOrNull' returns null instead."));
+
+    [Fact]
+    public Task RendersTheZeroMemberOfAnEnumItHandsBack() =>
+        Verify.AnalyzerAsync<SimplificationAnalyzer>(
+            """
+            internal enum Colour { Red = 0, Green = 1 }
+
+            internal class Subject
+            {
+                internal Colour Chosen(Option<Colour> option) =>
+                    option.{|#0:UnwrapOrDefault|}();
+            }
+            """,
+            Verify.Diagnostic(Rules.OrDefaultOnAValueType)
+               .WithLocation(0)
+               .WithMessage(
+                    "'UnwrapOrDefault' hands back Colour.Red, the default of "
+                  + "'Colour', when there is no value, and nothing "
+                  + "distinguishes that from a real Colour.Red. "
+                  + "'UnwrapOrNull' returns null instead."));
 
     [Fact]
     public Task IgnoresUnwrapOrDefaultOnAnOptionOfAReferenceType() =>


### PR DESCRIPTION
Three rules described behaviour that stopped existing two PRs ago. WM1004 says
the implicit conversion maps a default onto None, WM1010 says Option.Some
throws on the default of a value type, and WM1009 says an Option cannot hold
the default of bool or of a zero-member enum. None of the three is true in v6,
so each gets a Removed Rules row and its id is never reused.

WM1004 was written down as surviving v6 narrowed to null. It does not.
AnalyzeConversion returns early on a null-constant operand, so the rule only
ever fired on the default of a value type — it never covered null, so there
was nothing to narrow and it becomes wholly false rather than half-false.
WM1001 is the only one of the pair that survives, and only its exception type
moves, from InvalidOperationException to ArgumentNullException.

WM1005's description said Some rejects a value equal to default(T). It now
says Some rejects null, which is both what the rule reports and what the
constructor does.

WM2015 survives at Info with its message reworded to name the value concretely
rather than calling it "the default of int": a reader who is told the call
hands back 0 can see the ambiguity, where the abstract phrasing left it to be
worked out. That needs a fourth format argument, and Diagnostic.Create takes
arguments positionally with a count mismatch rendering as a literal {3} in a
consumer's IDE and nothing to catch it, so Semantics.DefaultOf and the tests
asserting substituted text go in the same change. It renders the zero member's
name for an enum and the well-known instance for the six types that have one.

The retired rules' sample cases come out of Misuse.cs, since Option.Some(0),
Option<bool> and an Option over a zero-member enum are now ordinary correct
code and a sample of misuse should not teach otherwise. Their tests become
negatives rather than disappearing, so a rule that comes back to life fails
something.

The Misuse tier is 6, read off Rules.cs rather than from any issue's
arithmetic.

Verified: 212 analyzer tests, 589 Monads tests on all five frameworks, Release
build 0 errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>