### PR TITLE
test: cover Unzip when a tuple component equals its default

### DIFF
--- a/test/Waystone.Monads.Tests/Options/Extensions/OptionOfTExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/OptionOfTExtensionsTests.cs
@@ -40,6 +40,30 @@
             result.ShouldBe((none, none));
         }
 
+        [Fact]
+        public void GivenSomeWithDefaultFirstComponent_WhenUnzip_ThenReturnSome()
+        {
+            Option<(int, string)> zipped = Option.Some((0, "x"));
+            (Option<int>, Option<string>) result = zipped.Unzip();
+            result.ShouldBe((Option.Some(0), Option.Some("x")));
+        }
+
+        [Fact]
+        public void GivenSomeWithDefaultSecondComponent_WhenUnzip_ThenReturnSome()
+        {
+            Option<(string, int)> zipped = Option.Some(("x", 0));
+            (Option<string>, Option<int>) result = zipped.Unzip();
+            result.ShouldBe((Option.Some("x"), Option.Some(0)));
+        }
+
+        [Fact]
+        public void GivenSomeWithBothComponentsDefault_WhenUnzip_ThenReturnSome()
+        {
+            Option<(int, bool)> zipped = Option.Some((0, false));
+            (Option<int>, Option<bool>) result = zipped.Unzip();
+            result.ShouldBe((Option.Some(0), Option.Some(false)));
+        }
+
         #endregion unzip
 
         #region flatten

--- a/test/Waystone.Monads.Tests/Options/Extensions/UnzipExtensionsTests.cs
+++ b/test/Waystone.Monads.Tests/Options/Extensions/UnzipExtensionsTests.cs
@@ -29,6 +29,17 @@ public sealed class UnzipExtensionsTests
     }
 
     [Fact]
+    public async Task
+        GivenSomeTaskWithDefaultComponents_WhenUnzipAsync_ThenReturnTwoSome()
+    {
+        (Option<int> first, Option<bool> second) =
+            await Task.FromResult(Option.Some((0, false))).UnzipAsync();
+
+        first.ShouldBeSomeValue(0);
+        second.ShouldBeSomeValue(false);
+    }
+
+    [Fact]
     public async Task GivenSomeValueTask_WhenUnzipAsync_ThenReturnTwoSome()
     {
         (Option<int> first, Option<int> second) =
@@ -48,5 +59,17 @@ public sealed class UnzipExtensionsTests
 
         first.ShouldBeNone();
         second.ShouldBeNone();
+    }
+
+    [Fact]
+    public async Task
+        GivenSomeValueTaskWithDefaultComponents_WhenUnzipAsync_ThenReturnTwoSome()
+    {
+        (Option<int> first, Option<bool> second) =
+            await new ValueTask<Option<(int, bool)>>(Option.Some((0, false)))
+               .UnzipAsync();
+
+        first.ShouldBeSomeValue(0);
+        second.ShouldBeSomeValue(false);
     }
 }


### PR DESCRIPTION
Unzip built two Some values from a tuple the caller had already handed
over as valid, so it threw whenever either component happened to equal
the default of its type. The Some relaxation removed the throw; these
are the regression tests that record it, covering each component
defaulting independently, both at once, and the Task and ValueTask
UnzipAsync receivers.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>