### PR TITLE
feat!: remove the obsoleted Try overloads that take an async factory

### DIFF
--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -51,6 +51,12 @@ WM1010 | Reliability | Warning | The default of a value type is used as an Optio
 
 ## Release 6.0.0
 
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+WM1011 | Reliability | Warning | An async factory is passed to Try
+
 ### Removed Rules
 
 Rule ID | Category | Severity | Notes

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -86,6 +86,24 @@ public static class Rules
         "'{0}?' has three states where two are meaningful. Drop the annotation — '{1}' already expresses the case you are reaching for.",
         "Option and Result are records, so the compiler accepts a nullable annotation on one. The annotation adds a third state to a type whose whole purpose is to have exactly two, and the null it admits throws on the next member access rather than being handled as an absence.");
 
+    /// <remarks>
+    /// Exists because the break that produces this code is silent. Until v6 an
+    /// async factory bound to a dedicated <c>Try</c> overload; removing that
+    /// overload does not fail the call, it rebinds it to
+    /// <c>Try&lt;T&gt;(Func&lt;T&gt;)</c> with <c>T</c> inferred as the task,
+    /// which satisfies <c>notnull</c>. Only a call site that assigns to an
+    /// explicitly typed local gets a compiler error, so the rule carries the
+    /// whole migration for every other shape. No code fix: renaming to
+    /// <c>TryAsync</c> alone leaves the caller with an unawaited
+    /// <c>Task&lt;Option&lt;T&gt;&gt;</c>, and where the await belongs is not
+    /// something the fix can decide.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor AsyncFactoryPassedToTry = Bug(
+        "WM1011",
+        "Do not pass an async factory to Try",
+        "'Try' invokes this factory without awaiting it, so it produces '{0}' and catches nothing the asynchronous work throws. Use 'TryAsync'.",
+        "Try catches what its factory throws while invoking it. A factory that returns a task returns before its work has run, so the exception surfaces later on the caller's await with Try's handling already bypassed, and the value is the task rather than its result.");
+
     public static readonly DiagnosticDescriptor UnwrapUsed = Idiom(
         "WM2001",
         "Prefer UnwrapOr or Match over Unwrap",

--- a/src/Waystone.Monads.Analyzers/TryFactoryAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/TryFactoryAnalyzer.cs
@@ -1,0 +1,69 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using System.Collections.Immutable;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class TryFactoryAnalyzer : MonadAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rules.AsyncFactoryPassedToTry);
+
+    protected override void Register(
+        CompilationStartAnalysisContext context,
+        MonadSymbols symbols) =>
+        context.RegisterOperationAction(
+            operation => Analyze(operation, symbols),
+            OperationKind.Invocation);
+
+    private static void Analyze(
+        OperationAnalysisContext context,
+        MonadSymbols symbols)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var method = invocation.TargetMethod;
+
+        if (method.Name != "Try"
+         || method.TypeArguments.Length == 0
+         || !IsFactory(method.ContainingType, symbols))
+        {
+            return;
+        }
+
+        var valueType = method.TypeArguments[0];
+
+        if (!IsAwaitable(valueType, symbols))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Rules.AsyncFactoryPassedToTry,
+                Semantics.NameLocationOf(invocation),
+                Semantics.Display(valueType)));
+    }
+
+    private static bool IsFactory(
+        INamedTypeSymbol? containingType,
+        MonadSymbols symbols) =>
+        SymbolEqualityComparer.Default.Equals(
+            containingType,
+            symbols.OptionFactory)
+     || SymbolEqualityComparer.Default.Equals(
+            containingType,
+            symbols.ResultFactory);
+
+    private static bool IsAwaitable(
+        ITypeSymbol type,
+        MonadSymbols symbols) =>
+        type is INamedTypeSymbol { IsGenericType: true } named
+     && (SymbolEqualityComparer.Default.Equals(
+             named.OriginalDefinition,
+             symbols.Task)
+      || SymbolEqualityComparer.Default.Equals(
+             named.OriginalDefinition,
+             symbols.ValueTask));
+}

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -85,39 +85,6 @@ public static class Option
     /// A <see cref="Some{T}" /> if the factory produces a value that a
     /// <see cref="Some{T}" /> can hold, otherwise a <see cref="None{T}" />.
     /// </returns>
-    [Obsolete(
-        "Use TryAsync instead. This overload will be removed in v6 of Waystone.Monads.")]
-    public static Task<Option<T>> Try<T>(
-        Func<Task<T>> asyncFactory,
-        [CallerMemberName] string callerMemberName = "",
-        [CallerLineNumber] int callerLineNumber = 0,
-        [CallerArgumentExpression(nameof(asyncFactory))]
-        string callerArgumentExpression = "") where T : notnull =>
-        TryAsync(
-            asyncFactory,
-            callerMemberName,
-            callerLineNumber,
-            callerArgumentExpression);
-
-    /// <summary>
-    /// Tries to store the result of an <paramref name="asyncFactory" /> into
-    /// an <see cref="Option{T}" />
-    /// </summary>
-    /// <param name="asyncFactory">
-    /// An asynchronous method which when awaited will
-    /// produce the value for the <see cref="Option{T}" />
-    /// </param>
-    /// <param name="callerMemberName">The method name of the caller.</param>
-    /// <param name="callerLineNumber">The line number of the caller.</param>
-    /// <param name="callerArgumentExpression">
-    /// The argument expression used as the
-    /// factory.
-    /// </param>
-    /// <typeparam name="T">The async factory return type</typeparam>
-    /// <returns>
-    /// A <see cref="Some{T}" /> if the factory produces a value that a
-    /// <see cref="Some{T}" /> can hold, otherwise a <see cref="None{T}" />.
-    /// </returns>
     /// <remarks>
     /// A <see cref="None{T}" /> is returned both when the factory throws and
     /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the

--- a/src/Waystone.Monads/Results/Result.cs
+++ b/src/Waystone.Monads/Results/Result.cs
@@ -113,48 +113,6 @@ public static class Result
     /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
     /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
-    [Obsolete(
-        "Use TryAsync instead. This overload will be removed in v6 of Waystone.Monads.")]
-    public static Task<Result<TOk, TErr>> Try<TOk, TErr>(
-        Func<Task<TOk>> asyncFactory,
-        Func<Exception, TErr> onError,
-        [CallerMemberName] string callerMemberName = "",
-        [CallerLineNumber] int callerLineNumber = 0,
-        [CallerArgumentExpression(nameof(asyncFactory))]
-        string callerArgumentExpression = "")
-        where TOk : notnull where TErr : notnull =>
-        TryAsync(
-            asyncFactory,
-            onError,
-            callerMemberName,
-            callerLineNumber,
-            callerArgumentExpression);
-
-    /// <summary>
-    /// Tries to store the result of an <paramref name="asyncFactory" /> into
-    /// a <see cref="Result{TOk, TErr}" />, invoking <paramref name="onError" /> if the
-    /// factory throws an exception.
-    /// </summary>
-    /// <param name="asyncFactory">
-    /// An asynchronous method which when executed will
-    /// produce the value of the <see cref="Result{TOk,TErr}" />
-    /// </param>
-    /// <param name="onError">
-    /// A callback method that will be invoked for any exceptions
-    /// thrown by the <paramref name="asyncFactory" />
-    /// </param>
-    /// <param name="callerMemberName">The method name of the caller.</param>
-    /// <param name="callerLineNumber">The line number of the caller.</param>
-    /// <param name="callerArgumentExpression">
-    /// The argument expression used as the
-    /// factory.
-    /// </param>
-    /// <typeparam name="TOk">The factory method return value's type</typeparam>
-    /// <typeparam name="TErr">The error handler return value's type</typeparam>
-    /// <returns>
-    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
-    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
-    /// </returns>
     /// <remarks>
     /// An <see cref="Err{TOk,TErr}" /> is returned both when the factory throws
     /// and when it returns null, and <paramref name="onError" /> is invoked in

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -62,7 +62,7 @@ public class RulesTests
     [Fact]
     public void EveryTierIsPopulated()
     {
-        MisuseRules().Count.ShouldBe(6);
+        MisuseRules().Count.ShouldBe(7);
         IdiomRules().Count.ShouldBe(14);
         MigrationRules().Count.ShouldBe(2);
     }

--- a/test/Waystone.Monads.Analyzers.Tests/TryFactoryAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/TryFactoryAnalyzerTests.cs
@@ -1,0 +1,104 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Threading.Tasks;
+using Xunit;
+
+public class TryFactoryAnalyzerTests
+{
+    [Fact]
+    public Task FlagsAnAsyncFactoryPassedToOptionTry() =>
+        Verify.AnalyzerAsync<TryFactoryAnalyzer>(
+            """
+            internal Option<Task<int>> Make() =>
+                Option.{|#0:Try|}(() => Task.FromResult(42));
+            """,
+            Verify.Diagnostic(Rules.AsyncFactoryPassedToTry)
+               .WithLocation(0)
+               .WithArguments("Task<int>"));
+
+    [Fact]
+    public Task FlagsAnAsyncFactoryPassedToResultTry() =>
+        Verify.AnalyzerAsync<TryFactoryAnalyzer>(
+            """
+            internal Result<Task<int>, string> Make() =>
+                Result.{|#0:Try|}(
+                    () => Task.FromResult(42),
+                    error => error.Message);
+            """,
+            Verify.Diagnostic(Rules.AsyncFactoryPassedToTry)
+               .WithLocation(0)
+               .WithArguments("Task<int>"));
+
+    [Fact]
+    public Task FlagsAnAsyncFactoryPassedToTheErrorReturningResultTry() =>
+        Verify.AnalyzerAsync<TryFactoryAnalyzer>(
+            """
+            internal Result<Task<int>, Error> Make() =>
+                Result.{|#0:Try|}(() => Task.FromResult(42));
+            """,
+            Verify.Diagnostic(Rules.AsyncFactoryPassedToTry)
+               .WithLocation(0)
+               .WithArguments("Task<int>"));
+
+    [Fact]
+    public Task FlagsAValueTaskFactory() =>
+        Verify.AnalyzerAsync<TryFactoryAnalyzer>(
+            """
+            internal Option<ValueTask<int>> Make() =>
+                Option.{|#0:Try|}(() => new ValueTask<int>(42));
+            """,
+            Verify.Diagnostic(Rules.AsyncFactoryPassedToTry)
+               .WithLocation(0)
+               .WithArguments("ValueTask<int>"));
+
+    [Fact]
+    public Task FlagsAnAsyncMethodGroup() =>
+        Verify.AnalyzerAsync<TryFactoryAnalyzer>(
+            """
+            internal Task<int> LoadAsync() => Task.FromResult(42);
+
+            internal Option<Task<int>> Make() => Option.{|#0:Try|}(LoadAsync);
+            """,
+            Verify.Diagnostic(Rules.AsyncFactoryPassedToTry)
+               .WithLocation(0)
+               .WithArguments("Task<int>"));
+
+    [Fact]
+    public Task IgnoresASynchronousFactory() =>
+        Verify.NoDiagnosticAsync<TryFactoryAnalyzer>(
+            """
+            internal Option<int> Make() => Option.Try(() => 42);
+
+            internal Result<int, string> Fallible() =>
+                Result.Try(() => 42, error => error.Message);
+            """);
+
+    [Fact]
+    public Task IgnoresTryAsync() =>
+        Verify.NoDiagnosticAsync<TryFactoryAnalyzer>(
+            """
+            internal Task<Option<int>> Make() =>
+                Option.TryAsync(() => Task.FromResult(42));
+
+            internal Task<Result<int, string>> Fallible() =>
+                Result.TryAsync(
+                    () => Task.FromResult(42),
+                    error => error.Message);
+            """);
+
+    [Fact]
+    public Task IgnoresAnUnrelatedTryMethod() =>
+        Verify.NoDiagnosticAsync<TryFactoryAnalyzer>(
+            """
+            internal static class Attempt
+            {
+                internal static T Try<T>(Func<T> factory) => factory();
+            }
+
+            internal class Subject
+            {
+                internal Task<int> Make() =>
+                    Attempt.Try(() => Task.FromResult(42));
+            }
+            """);
+}

--- a/test/Waystone.Monads.Tests/Options/OptionTests.cs
+++ b/test/Waystone.Monads.Tests/Options/OptionTests.cs
@@ -34,19 +34,6 @@ public sealed class OptionTests
     }
 
     [Fact]
-    public async Task GivenObsoleteAsyncTry_WhenBinding_ThenReturnSome()
-    {
-#pragma warning disable CS0618 // Type or member is obsolete
-        Task<Option<int>> optionTask =
-            Option.Try(() => Task.FromResult(42));
-#pragma warning restore CS0618 // Type or member is obsolete
-
-        Option<int> option = await optionTask;
-
-        option.ShouldBe(Option.Some(42));
-    }
-
-    [Fact]
     public async Task
         GivenAsyncFactoryThrows_WhenBinding_ThenReturnNone()
     {

--- a/test/Waystone.Monads.Tests/Results/ResultTests.cs
+++ b/test/Waystone.Monads.Tests/Results/ResultTests.cs
@@ -54,20 +54,6 @@ public sealed class ResultTests
 
     [Fact]
     public async Task
-        GivenObsoleteAsyncTry_WhenBindingFactory_ThenReturnOk()
-    {
-        var callback = Substitute.For<Func<Exception, string>>();
-#pragma warning disable CS0618 // Type or member is obsolete
-        Result<int, string> result = await Result.Try(
-            () => Task.FromResult(1),
-            callback);
-#pragma warning restore CS0618 // Type or member is obsolete
-        result.ShouldBe(Result.Ok<int, string>(1));
-        callback.DidNotReceive().Invoke(Arg.Any<Exception>());
-    }
-
-    [Fact]
-    public async Task
         GivenAsyncFactoryThatFails_WhenBindingFactory_ThenReturnError()
     {
         var callback = Substitute.For<Func<Exception, string>>();


### PR DESCRIPTION
Option.Try(Func<Task<T>>) and Result.Try(Func<Task<TOk>>, Func<Exception, TErr>)
carried an [Obsolete] naming v6 as the removal, so they go here. Both were pure
forwarders to TryAsync, and no behaviour is deleted with them.

Removing them does not fail a call site, it rebinds it: Option.Try(() =>
SomethingAsync()) now binds to Try<T>(Func<T>) with T inferred as Task<int>,
which satisfies notnull. The factory is never awaited, so Try catches nothing
and the exception escapes to the caller instead of becoming a None or an Err.
Only a call site that assigns to an explicitly typed local gets a compiler
error.

WM1011 covers the rest. It reports an Option.Try or Result.Try whose inferred
value type is a Task<T> or ValueTask<T>, at warning severity, because the code
it fires on compiles and runs while doing something other than what it says.
No code fix: renaming to TryAsync alone leaves an unawaited task, and where the
await belongs is not something a fix can decide.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>