### PR TITLE
feat!: rethrow OperationCanceledException from Try by default, with an opt-in on MonadOptions

### DIFF
--- a/src/Waystone.Monads/Configs/MonadOptions.cs
+++ b/src/Waystone.Monads/Configs/MonadOptions.cs
@@ -29,6 +29,7 @@ public sealed class MonadOptions
         ErrorCodeFactory = new ErrorCodeFactory();
         FallbackErrorCode = "Unspecified";
         FallbackErrorMessage = "An unexpected error occurred.";
+        CatchesCancellation = false;
     }
 
     private MonadOptions(MonadOptions source)
@@ -37,6 +38,7 @@ public sealed class MonadOptions
         ErrorCodeFactory = source.ErrorCodeFactory;
         FallbackErrorCode = source.FallbackErrorCode;
         FallbackErrorMessage = source.FallbackErrorMessage;
+        CatchesCancellation = source.CatchesCancellation;
 
         ConcurrentDictionary<Type, IMonadOptionsSatellite>? satellites =
             source._satellites;
@@ -65,6 +67,10 @@ public sealed class MonadOptions
     internal ErrorCodeFactory ErrorCodeFactory { get; set; }
     internal string FallbackErrorCode { get; set; }
     internal string FallbackErrorMessage { get; set; }
+    internal bool CatchesCancellation { get; set; }
+
+    internal bool Catches(Exception exception) =>
+        CatchesCancellation || exception is not OperationCanceledException;
 
     internal T Satellite<T>(Func<T> create)
         where T : class, IMonadOptionsSatellite
@@ -184,6 +190,33 @@ public sealed class MonadOptions
     public MonadOptions UseExceptionLogger(Action<Exception, CallerInfo> action)
     {
         ExceptionLogger = Option.Some(action);
+        return this;
+    }
+
+    /// <summary>
+    /// Configures <c>Try</c> and <c>TryAsync</c> to treat a cancellation as a
+    /// failure rather than letting it propagate.
+    /// </summary>
+    /// <remarks>
+    /// By default an <see cref="OperationCanceledException" /> is not caught,
+    /// so it leaves <c>Try</c> and <c>TryAsync</c> untouched and is neither
+    /// logged nor converted. Calling this restores the behaviour of versions
+    /// before 6.0.0, where a cancellation produced a
+    /// <see cref="Options.None{T}" /> or an <see cref="Results.Err{TOk,TErr}" />
+    /// like any other exception. Prefer the default: a cancelled operation
+    /// produced no answer, and reporting that as an absent or failed value
+    /// hides the cancellation from the caller that requested it.
+    /// <see cref="System.Threading.Tasks.TaskCanceledException" /> derives from
+    /// <see cref="OperationCanceledException" /> and is covered by this option
+    /// too.
+    /// </remarks>
+    /// <returns>
+    /// The <see cref="MonadOptions" /> instance for you to chain additional
+    /// configurations.
+    /// </returns>
+    public MonadOptions UseCancellationAsFailure()
+    {
+        CatchesCancellation = true;
         return this;
     }
 

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -43,6 +43,14 @@ public static class Option
     /// conversion is applied inside the try, so the two cannot disagree and
     /// nothing it throws escapes.
     /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor turned into a
+    /// <see cref="None{T}" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
     public static Option<T> Try<T>(
         Func<T> factory,
         [CallerMemberName] string callerMemberName = "",
@@ -55,7 +63,7 @@ public static class Option
         {
             return factory();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
         {
             var caller = new CallerInfo(
                 callerMemberName,
@@ -95,6 +103,14 @@ public static class Option
     /// conversion is applied inside the try, so the two cannot disagree and
     /// nothing it throws escapes.
     /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor turned into a
+    /// <see cref="None{T}" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
     public static async Task<Option<T>> TryAsync<T>(
         Func<Task<T>> asyncFactory,
         [CallerMemberName] string callerMemberName = "",
@@ -106,7 +122,7 @@ public static class Option
         {
             return await asyncFactory();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
         {
             var caller = new CallerInfo(
                 callerMemberName,

--- a/src/Waystone.Monads/Results/Result.cs
+++ b/src/Waystone.Monads/Results/Result.cs
@@ -58,6 +58,14 @@ public static class Result
     /// delegates to returns a <see cref="Options.None{T}" /> rather than
     /// throwing.
     /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor passed to
+    /// <paramref name="onError" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
     public static Result<TOk, TErr> Try<TOk, TErr>(
         Func<TOk> factory,
         Func<Exception, TErr> onError,
@@ -73,7 +81,7 @@ public static class Result
         {
             value = factory();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
         {
             var caller = new CallerInfo(
                 callerMemberName,
@@ -131,6 +139,14 @@ public static class Result
     /// delegates to returns a <see cref="Options.None{T}" /> rather than
     /// throwing.
     /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor passed to
+    /// <paramref name="onError" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
     public static async Task<Result<TOk, TErr>> TryAsync<TOk, TErr>(
         Func<Task<TOk>> asyncFactory,
         Func<Exception, TErr> onError,
@@ -146,7 +162,7 @@ public static class Result
         {
             value = await asyncFactory();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
         {
             var caller = new CallerInfo(
                 callerMemberName,
@@ -217,6 +233,11 @@ public static class Result
     /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
     /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
     public static Result<TOk, Error> Try<TOk>(
         Func<TOk> factory,
         [CallerMemberName] string callerMemberName = "",
@@ -252,6 +273,11 @@ public static class Result
     /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
     /// value, otherwise an <see cref="Err{TOk,TErr}" />.
     /// </returns>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
     public static Task<Result<TOk, Error>> TryAsync<TOk>(
         Func<Task<TOk>> asyncFactory,
         [CallerMemberName] string callerMemberName = "",

--- a/test/Waystone.Monads.Tests/Configs/CancellationHandlingTests.cs
+++ b/test/Waystone.Monads.Tests/Configs/CancellationHandlingTests.cs
@@ -1,0 +1,288 @@
+﻿namespace Waystone.Monads.Configs;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using NSubstitute;
+using Options;
+using Results;
+using Results.Errors;
+using Shouldly;
+using Xunit;
+
+[TestSubject(typeof(MonadOptions))]
+public sealed class CancellationHandlingTests
+{
+    private readonly Action<Exception, CallerInfo> _logger;
+
+    public CancellationHandlingTests()
+    {
+        _logger = Substitute.For<Action<Exception, CallerInfo>>();
+    }
+
+    private MonadOptionsScope Default() =>
+        MonadOptions.BeginScope(options => options.UseExceptionLogger(_logger));
+
+    private MonadOptionsScope OptedIn() =>
+        MonadOptions.BeginScope(
+            options => options.UseExceptionLogger(_logger)
+               .UseCancellationAsFailure());
+
+    private static OperationCanceledException Cancelled()
+    {
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+
+        try
+        {
+            source.Token.ThrowIfCancellationRequested();
+        }
+        catch (OperationCanceledException ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException("The token did not cancel.");
+    }
+
+    private void ShouldNotHaveLogged() =>
+        _logger.DidNotReceive()
+           .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+
+    [Fact]
+    public void GivenTheDefault_WhenOptionTryIsCancelled_ThenRethrow()
+    {
+        using (Default())
+        {
+            Should.Throw<OperationCanceledException>(
+                () => Option.Try<int>(() => throw Cancelled()));
+
+            ShouldNotHaveLogged();
+        }
+    }
+
+    [Fact]
+    public async Task GivenTheDefault_WhenOptionTryAsyncIsCancelled_ThenRethrow()
+    {
+        using (Default())
+        {
+            await Should.ThrowAsync<OperationCanceledException>(
+                () => Option.TryAsync<int>(() => throw Cancelled()));
+
+            ShouldNotHaveLogged();
+        }
+    }
+
+    [Fact]
+    public void GivenTheDefault_WhenResultTryIsCancelled_ThenRethrow()
+    {
+        var onError = Substitute.For<Func<Exception, string>>();
+
+        using (Default())
+        {
+            Should.Throw<OperationCanceledException>(
+                () => Result.Try<int, string>(
+                    () => throw Cancelled(),
+                    onError));
+
+            onError.DidNotReceive().Invoke(Arg.Any<Exception>());
+            ShouldNotHaveLogged();
+        }
+    }
+
+    [Fact]
+    public async Task GivenTheDefault_WhenResultTryAsyncIsCancelled_ThenRethrow()
+    {
+        var onError = Substitute.For<Func<Exception, string>>();
+
+        using (Default())
+        {
+            await Should.ThrowAsync<OperationCanceledException>(
+                () => Result.TryAsync<int, string>(
+                    () => throw Cancelled(),
+                    onError));
+
+            onError.DidNotReceive().Invoke(Arg.Any<Exception>());
+            ShouldNotHaveLogged();
+        }
+    }
+
+    [Fact]
+    public void GivenTheDefault_WhenTheErrorReturningTryIsCancelled_ThenRethrow()
+    {
+        using (Default())
+        {
+            Should.Throw<OperationCanceledException>(
+                () => Result.Try<int>(() => throw Cancelled()));
+
+            ShouldNotHaveLogged();
+        }
+    }
+
+    [Fact]
+    public async Task
+        GivenTheDefault_WhenTheErrorReturningTryAsyncIsCancelled_ThenRethrow()
+    {
+        using (Default())
+        {
+            await Should.ThrowAsync<OperationCanceledException>(
+                () => Result.TryAsync<int>(() => throw Cancelled()));
+
+            ShouldNotHaveLogged();
+        }
+    }
+
+    [Fact]
+    public async Task GivenTheDefault_WhenATaskIsCancelled_ThenRethrow()
+    {
+        using (Default())
+        {
+            using var source = new CancellationTokenSource();
+            source.Cancel();
+
+            await Should.ThrowAsync<TaskCanceledException>(
+                () => Option.TryAsync(
+                    () => Task.FromCanceled<int>(source.Token)));
+
+            ShouldNotHaveLogged();
+        }
+    }
+
+    [Fact]
+    public void GivenTheDefault_WhenAnotherExceptionIsThrown_ThenStillCatch()
+    {
+        using (Default())
+        {
+            Option.Try<int>(() => throw new InvalidOperationException())
+               .ShouldBe(Option.None<int>());
+
+            _logger.Received(1)
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenTheOptIn_WhenOptionTryIsCancelled_ThenReturnNone()
+    {
+        using (OptedIn())
+        {
+            Option.Try<int>(() => throw Cancelled())
+               .ShouldBe(Option.None<int>());
+
+            _logger.Received(1)
+               .Invoke(
+                    Arg.Any<OperationCanceledException>(),
+                    Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public async Task
+        GivenTheOptIn_WhenOptionTryAsyncIsCancelled_ThenReturnNone()
+    {
+        using (OptedIn())
+        {
+            Option<int> option =
+                await Option.TryAsync<int>(() => throw Cancelled());
+
+            option.ShouldBe(Option.None<int>());
+
+            _logger.Received(1)
+               .Invoke(
+                    Arg.Any<OperationCanceledException>(),
+                    Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenTheOptIn_WhenResultTryIsCancelled_ThenReturnErr()
+    {
+        using (OptedIn())
+        {
+            Result<int, string> result = Result.Try<int, string>(
+                () => throw Cancelled(),
+                _ => "cancelled");
+
+            result.ShouldBe(Result.Err<int, string>("cancelled"));
+
+            _logger.Received(1)
+               .Invoke(
+                    Arg.Any<OperationCanceledException>(),
+                    Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public async Task GivenTheOptIn_WhenResultTryAsyncIsCancelled_ThenReturnErr()
+    {
+        using (OptedIn())
+        {
+            Result<int, string> result = await Result.TryAsync<int, string>(
+                () => throw Cancelled(),
+                _ => "cancelled");
+
+            result.ShouldBe(Result.Err<int, string>("cancelled"));
+
+            _logger.Received(1)
+               .Invoke(
+                    Arg.Any<OperationCanceledException>(),
+                    Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenTheOptIn_WhenTheErrorReturningTryIsCancelled_ThenReturnErr()
+    {
+        using (OptedIn())
+        {
+            Result<int, Error> result =
+                Result.Try<int>(() => throw Cancelled());
+
+            result.IsErr.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task
+        GivenTheOptIn_WhenTheErrorReturningTryAsyncIsCancelled_ThenReturnErr()
+    {
+        using (OptedIn())
+        {
+            Result<int, Error> result =
+                await Result.TryAsync<int>(() => throw Cancelled());
+
+            result.IsErr.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void GivenTheOptIn_WhenANestedScopeIsOpened_ThenItIsInherited()
+    {
+        using (OptedIn())
+        {
+            using (MonadOptions.BeginScope(
+                       options => options.UseFallbackErrorCode("Nested")))
+            {
+                Option.Try<int>(() => throw Cancelled())
+                   .ShouldBe(Option.None<int>());
+            }
+        }
+    }
+
+    [Fact]
+    public void GivenTheOptIn_WhenTheScopeEnds_ThenTheDefaultReturns()
+    {
+        using (OptedIn())
+        {
+            Option.Try<int>(() => throw Cancelled())
+               .ShouldBe(Option.None<int>());
+        }
+
+        using (Default())
+        {
+            Should.Throw<OperationCanceledException>(
+                () => Option.Try<int>(() => throw Cancelled()));
+        }
+    }
+}


### PR DESCRIPTION
Try and TryAsync caught every exception, so a cancelled operation came back
as a None or an Err. The caller that asked for the cancellation could not
tell it apart from a genuine absence or failure, and the exception logger
reported the cancellation as an exception silently handled.

An OperationCanceledException is now excluded by a filter on the catch
clause rather than caught and rethrown, so it propagates with its frame
intact and never reaches the logger or onError. TaskCanceledException
derives from it and is covered too.

MonadOptions.UseCancellationAsFailure restores the old behaviour for
callers that want it, and it is inherited by BeginScope like every other
option.

The break is silent: code that relied on a cancellation becoming a None or
an Err still compiles and now propagates instead. The one-line restoration
is MonadOptions.Configure(options => options.UseCancellationAsFailure()) at
startup.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>