### PR TITLE
feat: add closure-avoiding state overloads for Try and TryAsync

### DIFF
--- a/artifacts/dra-104/results/Waystone.Monads.Benchmarks.StateOverloadBenchmarks-report-github.md
+++ b/artifacts/dra-104/results/Waystone.Monads.Benchmarks.StateOverloadBenchmarks-report-github.md
@@ -1,0 +1,24 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]     : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  DefaultJob : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+
+```
+| Method               | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------------------- |---------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| MapWithClosure       | 8.712 ns | 0.1211 ns | 0.1133 ns |  1.00 |    0.02 | 0.0022 |     112 B |        1.00 |
+| MapWithState         | 5.044 ns | 0.0705 ns | 0.0660 ns |  0.58 |    0.01 | 0.0005 |      24 B |        0.21 |
+| MapOrWithClosure     | 5.891 ns | 0.0951 ns | 0.0890 ns |  0.68 |    0.01 | 0.0018 |      88 B |        0.79 |
+| MapOrWithState       | 2.906 ns | 0.0220 ns | 0.0205 ns |  0.33 |    0.00 |      - |         - |        0.00 |
+| FilterWithClosure    | 3.906 ns | 0.0645 ns | 0.0603 ns |  0.45 |    0.01 | 0.0018 |      88 B |        0.79 |
+| FilterWithState      | 3.087 ns | 0.0396 ns | 0.0370 ns |  0.35 |    0.01 |      - |         - |        0.00 |
+| ResultMapWithClosure | 9.499 ns | 0.1259 ns | 0.1178 ns |  1.09 |    0.02 | 0.0022 |     112 B |        1.00 |
+| ResultMapWithState   | 6.139 ns | 0.0771 ns | 0.0644 ns |  0.70 |    0.01 | 0.0005 |      24 B |        0.21 |
+| TryWithClosure       | 7.377 ns | 0.1183 ns | 0.1107 ns |  0.85 |    0.02 | 0.0022 |     112 B |        1.00 |
+| TryWithState         | 4.231 ns | 0.0709 ns | 0.0629 ns |  0.49 |    0.01 | 0.0005 |      24 B |        0.21 |
+| ResultTryWithClosure | 7.806 ns | 0.0736 ns | 0.0688 ns |  0.90 |    0.01 | 0.0022 |     112 B |        1.00 |
+| ResultTryWithState   | 3.880 ns | 0.0746 ns | 0.0623 ns |  0.45 |    0.01 | 0.0005 |      24 B |        0.21 |

--- a/bench/Waystone.Monads.Benchmarks/README.md
+++ b/bench/Waystone.Monads.Benchmarks/README.md
@@ -53,7 +53,7 @@ the escape hatch for a throwaway run you do not want in the tree.
 | `OptionBenchmarks` | `Some`/`None` construction, the implicit conversion, `FromNullable`, `Match`, `Map`, `Filter`, `UnwrapOr`, each on both cases |
 | `ResultBenchmarks` | `Ok`/`Err` construction, `Match`, `Map`, `MapErr`, `UnwrapOr`, each on both cases |
 | `AsyncChainBenchmarks` | A single async link and a three-link chain off a synchronous receiver, on both cases |
-| `StateOverloadBenchmarks` | `Map`, `MapOr` and `Filter` on `Option`, and `Map` on `Result`, each run twice — once with a capturing lambda and once with the state overload |
+| `StateOverloadBenchmarks` | `Map`, `MapOr` and `Filter` on `Option`, `Map` on `Result`, and `Try` on both, each run twice — once with a capturing lambda and once with the state overload |
 
 `AsyncChainBenchmarks` is the one to watch across the v6 stack. A chain today
 starts as `ValueTask` off an `Option<T>` receiver and degrades to `Task` at the
@@ -139,7 +139,8 @@ that configuration is byte-identical to 5.5.0 for these two rows only.
 
 ## The closure-avoiding state overloads
 
-`artifacts/dra-84/` holds the run for DRA-84, same machine and settings. Each
+`artifacts/dra-84/` holds the run for the transform methods and
+`artifacts/dra-104/` the run for the factories, same machine and settings. Each
 pair calls the same method twice: once with a lambda closing over a local, and
 once passing that local as state to a `static` lambda.
 
@@ -149,12 +150,18 @@ once passing that local as state to a `static` lambda.
 | `Option.MapOr` | 88 B | 0 B | −88 B |
 | `Option.Filter` | 88 B | 0 B | −88 B |
 | `Result.Map` | 112 B | 24 B | −88 B |
+| `Option.Try` | 112 B | 24 B | −88 B |
+| `Result.Try` | 112 B | 24 B | −88 B |
 
 The closure costs exactly 88 B in every row — 24 B for the display class and
 64 B for the delegate built over it — and the state overload removes all of it.
-The 24 B the two `Map` rows keep is the returned `Some<int>` or
+The 24 B the four `Map` and `Try` rows keep is the returned `Some<int>` or
 `Ok<int, string>`, which no overload can avoid; `MapOr` and `Filter` return a
 value or the receiver and so reach zero.
+
+The two `Try` rows are the ones worth reaching for. A `Try` factory almost
+always needs an argument — that is why it is a factory — so the closure is
+harder to avoid by accident there than on a `Map`.
 
 Read the allocation column, not the timings. The means do move the same way
 (`MapOr` runs at 0.35× the closure version) but short-run error bars here are

--- a/bench/Waystone.Monads.Benchmarks/StateOverloadBenchmarks.cs
+++ b/bench/Waystone.Monads.Benchmarks/StateOverloadBenchmarks.cs
@@ -70,4 +70,31 @@ public class StateOverloadBenchmarks
     [Benchmark]
     public Result<int, string> ResultMapWithState() =>
         _ok.Map(_addend, static (value, addend) => value + addend);
+
+    [Benchmark]
+    public Option<int> TryWithClosure()
+    {
+        int addend = _addend;
+
+        return Option.Try(() => 42 + addend);
+    }
+
+    [Benchmark]
+    public Option<int> TryWithState() =>
+        Option.Try(_addend, static addend => 42 + addend);
+
+    [Benchmark]
+    public Result<int, string> ResultTryWithClosure()
+    {
+        int addend = _addend;
+
+        return Result.Try(() => 42 + addend, static ex => ex.Message);
+    }
+
+    [Benchmark]
+    public Result<int, string> ResultTryWithState() =>
+        Result.Try(
+            _addend,
+            static addend => 42 + addend,
+            static ex => ex.Message);
 }

--- a/src/Waystone.Monads.Analyzers/TryFactoryAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/TryFactoryAnalyzer.cs
@@ -26,13 +26,20 @@ public sealed class TryFactoryAnalyzer : MonadAnalyzer
         var method = invocation.TargetMethod;
 
         if (method.Name != "Try"
-         || method.TypeArguments.Length == 0
          || !IsFactory(method.ContainingType, symbols))
         {
             return;
         }
 
-        var valueType = method.TypeArguments[0];
+        ImmutableArray<ITypeSymbol> produced =
+            symbols.TypeArgumentsOf(invocation.Type);
+
+        if (produced.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var valueType = produced[0];
 
         if (!IsAwaitable(valueType, symbols))
         {

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -133,6 +133,146 @@ public static class Option
         }
     }
 
+    /// <summary>
+    /// Tries to store the result of a <paramref name="factory" /> into an
+    /// <see cref="Option{T}" />, handing it the provided
+    /// <paramref name="state" />.
+    /// </summary>
+    /// <param name="state">The value handed to the <paramref name="factory" />.</param>
+    /// <param name="factory">
+    /// A method which when executed will produce the value of
+    /// the <see cref="Option{T}" />
+    /// </param>
+    /// <param name="callerMemberName">The method name of the caller.</param>
+    /// <param name="callerLineNumber">The line number of the caller.</param>
+    /// <param name="callerArgumentExpression">
+    /// The argument expression used as the
+    /// factory.
+    /// </param>
+    /// <typeparam name="TState">The state's type.</typeparam>
+    /// <typeparam name="T">The factory return value's type</typeparam>
+    /// <returns>
+    /// A <see cref="Some{T}" /> if the factory produces a value that a
+    /// <see cref="Some{T}" /> can hold, otherwise a <see cref="None{T}" />.
+    /// </returns>
+    /// <remarks>
+    /// The <paramref name="state" /> is handed to the factory rather than
+    /// captured by it, so the factory can be <c>static</c> and the call
+    /// allocates no closure.
+    /// </remarks>
+    /// <remarks>
+    /// A <see cref="None{T}" /> is returned both when the factory throws and
+    /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
+    /// thrown case is reported to the exception logger configured on
+    /// <see cref="MonadOptions" />, because the implicit conversion to
+    /// <see cref="Option{T}" /> decides which values a <see cref="Some{T}" />
+    /// can hold and returns <see cref="None{T}" /> rather than throwing. That
+    /// conversion is applied inside the try, so the two cannot disagree and
+    /// nothing it throws escapes.
+    /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor turned into a
+    /// <see cref="None{T}" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
+    public static Option<T> Try<TState, T>(
+        TState state,
+        Func<TState, T> factory,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerLineNumber] int callerLineNumber = 0,
+        [CallerArgumentExpression(nameof(factory))]
+        string callerArgumentExpression = "")
+        where T : notnull
+    {
+        try
+        {
+            return factory(state);
+        }
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
+        {
+            var caller = new CallerInfo(
+                callerMemberName,
+                callerArgumentExpression,
+                callerLineNumber);
+            MonadOptions.Current.Log(ex, caller);
+            return None<T>();
+        }
+    }
+
+    /// <summary>
+    /// Tries to store the result of an <paramref name="asyncFactory" /> into
+    /// an <see cref="Option{T}" />, handing it the provided
+    /// <paramref name="state" />.
+    /// </summary>
+    /// <param name="state">
+    /// The value handed to the <paramref name="asyncFactory" />.
+    /// </param>
+    /// <param name="asyncFactory">
+    /// An asynchronous method which when awaited will
+    /// produce the value for the <see cref="Option{T}" />
+    /// </param>
+    /// <param name="callerMemberName">The method name of the caller.</param>
+    /// <param name="callerLineNumber">The line number of the caller.</param>
+    /// <param name="callerArgumentExpression">
+    /// The argument expression used as the
+    /// factory.
+    /// </param>
+    /// <typeparam name="TState">The state's type.</typeparam>
+    /// <typeparam name="T">The async factory return type</typeparam>
+    /// <returns>
+    /// A <see cref="Some{T}" /> if the factory produces a value that a
+    /// <see cref="Some{T}" /> can hold, otherwise a <see cref="None{T}" />.
+    /// </returns>
+    /// <remarks>
+    /// The <paramref name="state" /> is handed to the factory rather than
+    /// captured by it, so the factory can be <c>static</c> and the call
+    /// allocates no closure. A <see cref="System.Threading.CancellationToken" />
+    /// is the state this exists for.
+    /// </remarks>
+    /// <remarks>
+    /// A <see cref="None{T}" /> is returned both when the factory throws and
+    /// when it returns a value a <see cref="Some{T}" /> cannot hold. Only the
+    /// thrown case is reported to the exception logger configured on
+    /// <see cref="MonadOptions" />, because the implicit conversion to
+    /// <see cref="Option{T}" /> decides which values a <see cref="Some{T}" />
+    /// can hold and returns <see cref="None{T}" /> rather than throwing. That
+    /// conversion is applied inside the try, so the two cannot disagree and
+    /// nothing it throws escapes.
+    /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor turned into a
+    /// <see cref="None{T}" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
+    public static async Task<Option<T>> TryAsync<TState, T>(
+        TState state,
+        Func<TState, Task<T>> asyncFactory,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerLineNumber] int callerLineNumber = 0,
+        [CallerArgumentExpression(nameof(asyncFactory))]
+        string callerArgumentExpression = "") where T : notnull
+    {
+        try
+        {
+            return await asyncFactory(state);
+        }
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
+        {
+            var caller = new CallerInfo(
+                callerMemberName,
+                callerArgumentExpression,
+                callerLineNumber);
+            MonadOptions.Current.Log(ex, caller);
+            return None<T>();
+        }
+    }
+
     /// <summary>Creates a <see cref="Some{T}" /></summary>
     /// <param name="value">The value of the <see cref="Some{T}" /></param>
     /// <typeparam name="T">The option value's type.</typeparam>

--- a/src/Waystone.Monads/Results/Result.cs
+++ b/src/Waystone.Monads/Results/Result.cs
@@ -178,6 +178,156 @@ public static class Result
             : Ok<TOk, TErr>(value);
     }
 
+    /// <summary>
+    /// Tries to store the result of a <paramref name="factory" /> into a
+    /// <see cref="Result{TOk,TErr}" />, handing it the provided
+    /// <paramref name="state" /> and invoking <paramref name="onError" /> if the
+    /// factory throws an exception.
+    /// </summary>
+    /// <param name="state">The value handed to the <paramref name="factory" />.</param>
+    /// <param name="factory">
+    /// A method which when executed will return the value
+    /// contained in the <see cref="Result{TOk,TErr}" />
+    /// </param>
+    /// <param name="onError">
+    /// A callback method that will be invoked for any exceptions
+    /// thrown by the <paramref name="factory" />
+    /// </param>
+    /// <param name="callerMemberName">The method name of the caller.</param>
+    /// <param name="callerLineNumber">The line number of the caller.</param>
+    /// <param name="callerArgumentExpression">
+    /// The argument expression used as the
+    /// factory.
+    /// </param>
+    /// <typeparam name="TState">The state's type.</typeparam>
+    /// <typeparam name="TOk">The factory method return value's type</typeparam>
+    /// <typeparam name="TErr">The error handler return value's type</typeparam>
+    /// <returns>
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
+    /// </returns>
+    /// <remarks>
+    /// The <paramref name="state" /> is handed to the factory rather than
+    /// captured by it, so the factory can be <c>static</c> and the call
+    /// allocates no closure. The <paramref name="onError" /> callback is not
+    /// handed the state, because it receives the exception and a handler that
+    /// needs more than that is not on the hot path this exists for.
+    /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor passed to
+    /// <paramref name="onError" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
+    public static Result<TOk, TErr> Try<TState, TOk, TErr>(
+        TState state,
+        Func<TState, TOk> factory,
+        Func<Exception, TErr> onError,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerLineNumber] int callerLineNumber = 0,
+        [CallerArgumentExpression(nameof(factory))]
+        string callerArgumentExpression = "")
+        where TOk : notnull where TErr : notnull
+    {
+        TOk value;
+
+        try
+        {
+            value = factory(state);
+        }
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
+        {
+            var caller = new CallerInfo(
+                callerMemberName,
+                callerArgumentExpression,
+                callerLineNumber);
+            MonadOptions.Current.Log(ex, caller);
+            return Err<TOk, TErr>(onError(ex));
+        }
+
+        return value is null
+            ? Err<TOk, TErr>(onError(FactoryReturnedNull(nameof(factory))))
+            : Ok<TOk, TErr>(value);
+    }
+
+    /// <summary>
+    /// Tries to store the result of an <paramref name="asyncFactory" /> into
+    /// a <see cref="Result{TOk, TErr}" />, handing it the provided
+    /// <paramref name="state" /> and invoking <paramref name="onError" /> if the
+    /// factory throws an exception.
+    /// </summary>
+    /// <param name="state">
+    /// The value handed to the <paramref name="asyncFactory" />.
+    /// </param>
+    /// <param name="asyncFactory">
+    /// An asynchronous method which when executed will
+    /// produce the value of the <see cref="Result{TOk,TErr}" />
+    /// </param>
+    /// <param name="onError">
+    /// A callback method that will be invoked for any exceptions
+    /// thrown by the <paramref name="asyncFactory" />
+    /// </param>
+    /// <param name="callerMemberName">The method name of the caller.</param>
+    /// <param name="callerLineNumber">The line number of the caller.</param>
+    /// <param name="callerArgumentExpression">
+    /// The argument expression used as the
+    /// factory.
+    /// </param>
+    /// <typeparam name="TState">The state's type.</typeparam>
+    /// <typeparam name="TOk">The factory method return value's type</typeparam>
+    /// <typeparam name="TErr">The error handler return value's type</typeparam>
+    /// <returns>
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
+    /// </returns>
+    /// <remarks>
+    /// The <paramref name="state" /> is handed to the factory rather than
+    /// captured by it, so the factory can be <c>static</c> and the call
+    /// allocates no closure. A <see cref="System.Threading.CancellationToken" />
+    /// is the state this exists for.
+    /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. It leaves
+    /// this method untouched, so it is neither logged nor passed to
+    /// <paramref name="onError" />, and the caller observes the cancellation it
+    /// asked for. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
+    public static async Task<Result<TOk, TErr>> TryAsync<TState, TOk, TErr>(
+        TState state,
+        Func<TState, Task<TOk>> asyncFactory,
+        Func<Exception, TErr> onError,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerLineNumber] int callerLineNumber = 0,
+        [CallerArgumentExpression(nameof(asyncFactory))]
+        string callerArgumentExpression = "")
+        where TOk : notnull where TErr : notnull
+    {
+        TOk value;
+
+        try
+        {
+            value = await asyncFactory(state);
+        }
+        catch (Exception ex) when (MonadOptions.Current.Catches(ex))
+        {
+            var caller = new CallerInfo(
+                callerMemberName,
+                callerArgumentExpression,
+                callerLineNumber);
+            MonadOptions.Current.Log(ex, caller);
+            return Err<TOk, TErr>(onError(ex));
+        }
+
+        return value is null
+            ? Err<TOk, TErr>(
+                onError(FactoryReturnedNull(nameof(asyncFactory))))
+            : Ok<TOk, TErr>(value);
+    }
+
     private static ArgumentNullException FactoryReturnedNull(
         string parameterName) =>
         new(parameterName, "The factory returned null.");
@@ -286,6 +436,107 @@ public static class Result
         string callerArgumentExpression = "")
         where TOk : notnull =>
         TryAsync(
+            asyncFactory,
+            Error.FromException,
+            callerMemberName,
+            callerLineNumber,
+            callerArgumentExpression);
+
+    /// <summary>
+    /// Tries to store the result of a <paramref name="factory" /> into a
+    /// <see cref="Result{TOk,TErr}" /> which uses <see cref="Error" /> as its error
+    /// type, handing the factory the provided <paramref name="state" /> and
+    /// converting any thrown exception using <see cref="Error.FromException" />.
+    /// </summary>
+    /// <param name="state">The value handed to the <paramref name="factory" />.</param>
+    /// <param name="factory">
+    /// A method which when executed will return the value
+    /// contained in the <see cref="Result{TOk,TErr}" />
+    /// </param>
+    /// <param name="callerMemberName">The method name of the caller.</param>
+    /// <param name="callerLineNumber">The line number of the caller.</param>
+    /// <param name="callerArgumentExpression">
+    /// The argument expression used as the
+    /// factory.
+    /// </param>
+    /// <typeparam name="TState">The state's type.</typeparam>
+    /// <typeparam name="TOk">The factory method return value's type</typeparam>
+    /// <returns>
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
+    /// </returns>
+    /// <remarks>
+    /// The <paramref name="state" /> is handed to the factory rather than
+    /// captured by it, so the factory can be <c>static</c> and the call
+    /// allocates no closure.
+    /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
+    public static Result<TOk, Error> Try<TState, TOk>(
+        TState state,
+        Func<TState, TOk> factory,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerLineNumber] int callerLineNumber = 0,
+        [CallerArgumentExpression(nameof(factory))]
+        string callerArgumentExpression = "")
+        where TOk : notnull =>
+        Try(
+            state,
+            factory,
+            Error.FromException,
+            callerMemberName,
+            callerLineNumber,
+            callerArgumentExpression);
+
+    /// <summary>
+    /// Tries to store the result of an <paramref name="asyncFactory" /> into
+    /// a <see cref="Result{TOk,TErr}" /> which uses <see cref="Error" /> as its error
+    /// type, handing the factory the provided <paramref name="state" /> and
+    /// converting any thrown exception using <see cref="Error.FromException" />.
+    /// </summary>
+    /// <param name="state">
+    /// The value handed to the <paramref name="asyncFactory" />.
+    /// </param>
+    /// <param name="asyncFactory">
+    /// An asynchronous method which when executed will
+    /// produce the value of the <see cref="Result{TOk,TErr}" />
+    /// </param>
+    /// <param name="callerMemberName">The method name of the caller.</param>
+    /// <param name="callerLineNumber">The line number of the caller.</param>
+    /// <param name="callerArgumentExpression">
+    /// The argument expression used as the
+    /// factory.
+    /// </param>
+    /// <typeparam name="TState">The state's type.</typeparam>
+    /// <typeparam name="TOk">The factory method return value's type</typeparam>
+    /// <returns>
+    /// An <see cref="Ok{TOk,TErr}" /> if the factory produces a non-null
+    /// value, otherwise an <see cref="Err{TOk,TErr}" />.
+    /// </returns>
+    /// <remarks>
+    /// The <paramref name="state" /> is handed to the factory rather than
+    /// captured by it, so the factory can be <c>static</c> and the call
+    /// allocates no closure. A <see cref="System.Threading.CancellationToken" />
+    /// is the state this exists for.
+    /// </remarks>
+    /// <remarks>
+    /// An <see cref="OperationCanceledException" /> is not caught. Call
+    /// <see cref="MonadOptions.UseCancellationAsFailure" /> to catch it like
+    /// any other exception, as versions before 6.0.0 did.
+    /// </remarks>
+    public static Task<Result<TOk, Error>> TryAsync<TState, TOk>(
+        TState state,
+        Func<TState, Task<TOk>> asyncFactory,
+        [CallerMemberName] string callerMemberName = "",
+        [CallerLineNumber] int callerLineNumber = 0,
+        [CallerArgumentExpression(nameof(asyncFactory))]
+        string callerArgumentExpression = "")
+        where TOk : notnull =>
+        TryAsync(
+            state,
             asyncFactory,
             Error.FromException,
             callerMemberName,

--- a/test/Waystone.Monads.Analyzers.Tests/TryFactoryAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/TryFactoryAnalyzerTests.cs
@@ -101,4 +101,30 @@ public class TryFactoryAnalyzerTests
                     Attempt.Try(() => Task.FromResult(42));
             }
             """);
+
+    /// <remarks>
+    /// The state overloads put <c>TState</c> at type argument zero, so a rule
+    /// that read the method's first type argument would test the state rather
+    /// than the value. These two pin both halves of that: a state that happens
+    /// to be a task is not the hazard, and a state factory that returns one
+    /// still is.
+    /// </remarks>
+    [Fact]
+    public Task IgnoresATaskPassedAsState() =>
+        Verify.NoDiagnosticAsync<TryFactoryAnalyzer>(
+            """
+            internal Option<int> Make(Task<int> pending) =>
+                Option.Try(pending, static task => task.Result);
+            """);
+
+    [Fact]
+    public Task FlagsAStateFactoryThatReturnsATask() =>
+        Verify.AnalyzerAsync<TryFactoryAnalyzer>(
+            """
+            internal Option<Task<int>> Make(int seed) =>
+                Option.{|#0:Try|}(seed, static value => Task.FromResult(value));
+            """,
+            Verify.Diagnostic(Rules.AsyncFactoryPassedToTry)
+               .WithLocation(0)
+               .WithArguments("Task<int>"));
 }

--- a/test/Waystone.Monads.Tests/Configs/TryStateOverloadTests.cs
+++ b/test/Waystone.Monads.Tests/Configs/TryStateOverloadTests.cs
@@ -1,0 +1,243 @@
+﻿namespace Waystone.Monads.Configs;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using NSubstitute;
+using Options;
+using Results;
+using Results.Errors;
+using Shouldly;
+using Xunit;
+
+[TestSubject(typeof(Option))]
+public sealed class TryStateOverloadTests
+{
+    private readonly Action<Exception, CallerInfo> _logger;
+
+    public TryStateOverloadTests()
+    {
+        _logger = Substitute.For<Action<Exception, CallerInfo>>();
+    }
+
+    private MonadOptionsScope LoggerScope() =>
+        MonadOptions.BeginScope(options => options.UseExceptionLogger(_logger));
+
+    private static int Double(int state) => state * 2;
+
+    private static Task<int> DoubleAsync(int state) =>
+        Task.FromResult(state * 2);
+
+    private static int Throw(int state) =>
+        throw new InvalidOperationException(state.ToString());
+
+    private static Task<int> ThrowAsync(int state) =>
+        throw new InvalidOperationException(state.ToString());
+
+    [Fact]
+    public void GivenState_WhenOptionTrySucceeds_ThenReturnSome()
+    {
+        using (LoggerScope())
+        {
+            Option.Try(21, Double).ShouldBe(Option.Some(42));
+
+            _logger.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenState_WhenOptionTryThrows_ThenReturnNone()
+    {
+        using (LoggerScope())
+        {
+            Option.Try(21, Throw).ShouldBe(Option.None<int>());
+
+            _logger.Received(1)
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenState_WhenOptionTryReturnsNull_ThenReturnNone()
+    {
+        using (LoggerScope())
+        {
+            Option.Try("x", static _ => default(string)!)
+               .ShouldBe(Option.None<string>());
+
+            _logger.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public async Task GivenState_WhenOptionTryAsyncSucceeds_ThenReturnSome()
+    {
+        using (LoggerScope())
+        {
+            Option<int> option = await Option.TryAsync(21, DoubleAsync);
+
+            option.ShouldBe(Option.Some(42));
+        }
+    }
+
+    [Fact]
+    public async Task GivenState_WhenOptionTryAsyncThrows_ThenReturnNone()
+    {
+        using (LoggerScope())
+        {
+            Option<int> option = await Option.TryAsync(21, ThrowAsync);
+
+            option.ShouldBe(Option.None<int>());
+
+            _logger.Received(1)
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenState_WhenResultTrySucceeds_ThenReturnOk()
+    {
+        var onError = Substitute.For<Func<Exception, string>>();
+
+        Result.Try(21, Double, onError)
+           .ShouldBe(Result.Ok<int, string>(42));
+
+        onError.DidNotReceive().Invoke(Arg.Any<Exception>());
+    }
+
+    [Fact]
+    public void GivenState_WhenResultTryThrows_ThenReturnErr()
+    {
+        using (LoggerScope())
+        {
+            Result.Try(21, Throw, static ex => ex.Message)
+               .ShouldBe(Result.Err<int, string>("21"));
+
+            _logger.Received(1)
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenState_WhenResultTryReturnsNull_ThenReturnErr()
+    {
+        var onError = Substitute.For<Func<Exception, string>>();
+        onError.Invoke(Arg.Any<Exception>()).Returns("null");
+
+        Result.Try("x", static _ => default(string)!, onError)
+           .ShouldBe(Result.Err<string, string>("null"));
+
+        onError.Received(1).Invoke(Arg.Any<ArgumentNullException>());
+    }
+
+    [Fact]
+    public async Task GivenState_WhenResultTryAsyncSucceeds_ThenReturnOk()
+    {
+        Result<int, string> result =
+            await Result.TryAsync(21, DoubleAsync, static ex => ex.Message);
+
+        result.ShouldBe(Result.Ok<int, string>(42));
+    }
+
+    [Fact]
+    public async Task GivenState_WhenResultTryAsyncThrows_ThenReturnErr()
+    {
+        using (LoggerScope())
+        {
+            Result<int, string> result = await Result.TryAsync(
+                21,
+                ThrowAsync,
+                static ex => ex.Message);
+
+            result.ShouldBe(Result.Err<int, string>("21"));
+
+            _logger.Received(1)
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public void GivenState_WhenTheErrorReturningTrySucceeds_ThenReturnOk()
+    {
+        Result<int, Error> result = Result.Try(21, Double);
+
+        result.ShouldBe(Result.Ok<int, Error>(42));
+    }
+
+    [Fact]
+    public void GivenState_WhenTheErrorReturningTryThrows_ThenReturnErr()
+    {
+        using (LoggerScope())
+        {
+            Result<int, Error> result = Result.Try(21, Throw);
+
+            result.IsErr.ShouldBeTrue();
+            result.UnwrapErr().Message.ShouldBe("21");
+        }
+    }
+
+    [Fact]
+    public async Task
+        GivenState_WhenTheErrorReturningTryAsyncSucceeds_ThenReturnOk()
+    {
+        Result<int, Error> result = await Result.TryAsync(21, DoubleAsync);
+
+        result.ShouldBe(Result.Ok<int, Error>(42));
+    }
+
+    [Fact]
+    public async Task
+        GivenState_WhenTheErrorReturningTryAsyncThrows_ThenReturnErr()
+    {
+        using (LoggerScope())
+        {
+            Result<int, Error> result = await Result.TryAsync(21, ThrowAsync);
+
+            result.IsErr.ShouldBeTrue();
+            result.UnwrapErr().Message.ShouldBe("21");
+        }
+    }
+
+    [Fact]
+    public void GivenState_WhenTheFactoryIsCancelled_ThenRethrow()
+    {
+        using (LoggerScope())
+        {
+            using var source = new CancellationTokenSource();
+            source.Cancel();
+
+            Should.Throw<OperationCanceledException>(
+                () => Option.Try(
+                    source.Token,
+                    static token =>
+                    {
+                        token.ThrowIfCancellationRequested();
+
+                        return 1;
+                    }));
+
+            _logger.DidNotReceive()
+               .Invoke(Arg.Any<Exception>(), Arg.Any<CallerInfo>());
+        }
+    }
+
+    [Fact]
+    public async Task GivenAToken_WhenTryAsyncIsHandedIt_ThenItReachesTheFactory()
+    {
+        using var source = new CancellationTokenSource();
+
+        Option<int> option = await Option.TryAsync(
+            source.Token,
+            static async token =>
+            {
+                await Task.Delay(1, token);
+
+                return token.CanBeCanceled ? 1 : 0;
+            });
+
+        option.ShouldBe(Option.Some(1));
+    }
+}

--- a/test/Waystone.Monads.Tests/StateOverloadResolutionTests.cs
+++ b/test/Waystone.Monads.Tests/StateOverloadResolutionTests.cs
@@ -1,9 +1,10 @@
-namespace Waystone.Monads;
+﻿namespace Waystone.Monads;
 
 using Options;
 using Results;
 using Shouldly;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 /// <remarks>
@@ -38,6 +39,13 @@ public sealed class StateOverloadResolutionTests
 
     private static readonly Func<int, int, Option<int>> SomeAdd = (x, state) =>
         Option.Some(x + state);
+
+    private static readonly Func<Exception, int> OnError = _ => -1;
+
+    private static readonly Func<Task<int>> TenAsync = () => Task.FromResult(10);
+
+    private static readonly Func<int, Task<int>> IdentityAsync = state =>
+        Task.FromResult(state);
 
     [Fact]
     public void StoredDelegatesBindToTheIntendedOptionOverload()
@@ -76,5 +84,41 @@ public sealed class StateOverloadResolutionTests
 
         ok.MapErr(Zero).ShouldBe(Result.Ok<int, int>(1));
         ok.MapErr(10, ErrorState).ShouldBe(Result.Ok<int, int>(1));
+    }
+
+    /// <remarks>
+    /// The factory pairs are the one place where arity does not separate the
+    /// overloads on its own: <c>Result.Try(factory, onError)</c> and
+    /// <c>Result.Try(state, factory)</c> both take two required arguments, and
+    /// only inference tells them apart. A stored delegate is the shape that
+    /// would collide.
+    /// </remarks>
+    [Fact]
+    public void StoredDelegatesBindToTheIntendedFactoryOverload()
+    {
+        Option.Try(Ten).ShouldBe(Option.Some(10));
+        Option.Try(10, Identity).ShouldBe(Option.Some(10));
+
+        Result.Try(Ten, OnError).ShouldBe(Result.Ok<int, int>(10));
+        Result.Try(10, Identity, OnError).ShouldBe(Result.Ok<int, int>(10));
+
+        Result.Try(Ten).IsOk.ShouldBeTrue();
+        Result.Try(10, Identity).IsOk.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task StoredDelegatesBindToTheIntendedAsyncFactoryOverload()
+    {
+        (await Option.TryAsync(TenAsync)).ShouldBe(Option.Some(10));
+        (await Option.TryAsync(10, IdentityAsync)).ShouldBe(Option.Some(10));
+
+        (await Result.TryAsync(TenAsync, OnError))
+           .ShouldBe(Result.Ok<int, int>(10));
+
+        (await Result.TryAsync(10, IdentityAsync, OnError))
+           .ShouldBe(Result.Ok<int, int>(10));
+
+        (await Result.TryAsync(TenAsync)).IsOk.ShouldBeTrue();
+        (await Result.TryAsync(10, IdentityAsync)).IsOk.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
DRA-84 gave the nine transform families a state overload but left the
factories out, and a Try factory is the shape that almost always closes over
something — needing an argument is why it is a factory.

Six new overloads take TState first and hand it to the delegate:

    Option.Try / Option.TryAsync
    Result.Try / Result.TryAsync         (explicit error type)
    Result.Try / Result.TryAsync         (Error)

A CancellationToken is just one TState, so this covers the cancellation case
without a dedicated token overload:

    Option.TryAsync(ct, static token => LoadAsync(token))

Six rather than five. The Error-returning Result.Try(state, factory) and the
existing Result.Try(factory, onError) both take two required arguments, so
arity does not separate them the way it did for DRA-84's families. A
standalone probe compiled both signatures against inline lambdas, stored
delegates and method groups: inference separates them, because TState cannot
bind to Func<TOk> and Exception at once. StoredDelegatesBindToTheIntended
FactoryOverload keeps that pinned in the test project.

WM1011 read the method's first type argument to find the produced value, and
the state overloads put TState there. It now reads the invocation's return
type instead, which is the value in every overload. Two tests pin both
halves: a task passed as state is not the hazard, and a state factory that
returns one still is.

Measured in artifacts/dra-104: Option.Try 112 B to 24 B and Result.Try 112 B
to 24 B, the same flat 88 B closure that every DRA-84 row shed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>