### PR TITLE
feat(analyzers): add WM2016 nudging eager Or/And/UnwrapOr/MapOr/OkOr toward their lazy siblings

### DIFF
--- a/src/Waystone.Monads.Analyzers.CodeFixes/UseLazyVariantCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/UseLazyVariantCodeFix.cs
@@ -1,0 +1,91 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UseLazyVariantCodeFix : MonadCodeFix
+{
+    private static readonly Dictionary<string, string> LazySiblings =
+        new()
+        {
+            ["And"] = "AndThen",
+            ["AndAsync"] = "AndThenAsync",
+            ["Or"] = "OrElse",
+            ["UnwrapOr"] = "UnwrapOrElse",
+            ["UnwrapOrAsync"] = "UnwrapOrElseAsync",
+            ["MapOr"] = "MapOrElse",
+            ["MapOrAsync"] = "MapOrElseAsync",
+            ["OkOr"] = "OkOrElse",
+            ["OkOrAsync"] = "OkOrElseAsync",
+        };
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("WM2016");
+
+    protected override void Register(
+        CodeFixContext context,
+        Diagnostic diagnostic,
+        SyntaxNode node,
+        SemanticModel model,
+        MonadSymbols symbols)
+    {
+        if (MemberInvocationAt(node) is not var (invocation, access))
+        {
+            return;
+        }
+
+        string name = access.Name.Identifier.ValueText;
+
+        if (!LazySiblings.TryGetValue(name, out var lazy)
+         || invocation.ArgumentList.Arguments.Count == 0)
+        {
+            return;
+        }
+
+        var arguments = invocation.ArgumentList.Arguments;
+        var eager = arguments[0];
+
+        var wrapped = eager.WithExpression(
+            Lambda(name, eager.Expression));
+
+        var replacement = invocation
+           .WithExpression(
+                access.WithName(SyntaxFactory.IdentifierName(lazy)))
+           .WithArgumentList(
+                invocation.ArgumentList.WithArguments(
+                    SyntaxFactory.SeparatedList(
+                        new[] { wrapped }.Concat(arguments.Skip(1)))));
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Use " + lazy + "()",
+                token => ReplaceAsync(
+                    context.Document,
+                    invocation,
+                    replacement,
+                    token),
+                nameof(UseLazyVariantCodeFix)),
+            diagnostic);
+    }
+
+    /// <remarks>
+    /// <c>AndThen</c> is the one that takes the receiver's value, so its
+    /// delegate needs a discarded parameter where the others take none.
+    /// </remarks>
+    private static LambdaExpressionSyntax Lambda(
+        string eagerName,
+        ExpressionSyntax body) =>
+        eagerName is "And" or "AndAsync"
+            ? SyntaxFactory.SimpleLambdaExpression(
+                SyntaxFactory.Parameter(SyntaxFactory.Identifier("_")),
+                body)
+            : SyntaxFactory.ParenthesizedLambdaExpression(body);
+}

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -56,6 +56,7 @@ WM1010 | Reliability | Warning | The default of a value type is used as an Optio
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 WM1011 | Reliability | Warning | An async factory is passed to Try
+WM2016 | Usage | Info | An eager argument is not provably free to evaluate
 
 ### Removed Rules
 

--- a/src/Waystone.Monads.Analyzers/LazyVariantAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/LazyVariantAnalyzer.cs
@@ -1,0 +1,108 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class LazyVariantAnalyzer : MonadAnalyzer
+{
+    private static readonly Dictionary<string, string> LazySiblings =
+        new()
+        {
+            ["And"] = "AndThen",
+            ["AndAsync"] = "AndThenAsync",
+            ["Or"] = "OrElse",
+            ["UnwrapOr"] = "UnwrapOrElse",
+            ["UnwrapOrAsync"] = "UnwrapOrElseAsync",
+            ["MapOr"] = "MapOrElse",
+            ["MapOrAsync"] = "MapOrElseAsync",
+            ["OkOr"] = "OkOrElse",
+            ["OkOrAsync"] = "OkOrElseAsync",
+        };
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rules.EagerArgumentNotFree);
+
+    protected override void Register(
+        CompilationStartAnalysisContext context,
+        MonadSymbols symbols) =>
+        context.RegisterOperationAction(
+            operation => Analyze(operation, symbols),
+            OperationKind.Invocation);
+
+    private static void Analyze(
+        OperationAnalysisContext context,
+        MonadSymbols symbols)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var name = invocation.TargetMethod.Name;
+
+        if (!LazySiblings.TryGetValue(name, out var lazy)
+         || !symbols.IsMonadInvocation(invocation))
+        {
+            return;
+        }
+
+        var eager = EagerArgumentOf(invocation);
+
+        if (eager is null || IsFree(eager))
+        {
+            return;
+        }
+
+        var receiver = Semantics.ReceiverOf(invocation);
+
+        if (receiver?.Type is not { } receiverType)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Rules.EagerArgumentNotFree,
+                Semantics.NameLocationOf(invocation),
+                name,
+                Semantics.Display(receiverType),
+                lazy));
+    }
+
+    private static IOperation? EagerArgumentOf(IInvocationOperation invocation)
+    {
+        var receiver = Semantics.ReceiverOf(invocation);
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Value == receiver
+             || argument.IsImplicit
+             || argument.Parameter is null)
+            {
+                continue;
+            }
+
+            if (IsDelegate(argument.Parameter.Type))
+            {
+                continue;
+            }
+
+            return argument.Value;
+        }
+
+        return null;
+    }
+
+    private static bool IsDelegate(ITypeSymbol type) =>
+        type.TypeKind == TypeKind.Delegate;
+
+    private static bool IsFree(IOperation operation) =>
+        operation.ConstantValue.HasValue
+     || Semantics.Unconverted(operation) is ILocalReferenceOperation
+            or IParameterReferenceOperation
+            or IFieldReferenceOperation
+            or IPropertyReferenceOperation
+            or IDefaultValueOperation
+            or IInstanceReferenceOperation
+            or ILiteralOperation;
+}

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -204,6 +204,28 @@ public static class Rules
         "'{0}' hands back {3}, the default of '{1}', when there is no value, and nothing distinguishes that from a real {3}. '{2}' returns null instead.",
         "T? on a type parameter constrained only to notnull is an annotation rather than a Nullable<T>, so for a value type UnwrapOrDefault and MapOrDefault return 0, false or default(Guid) for the absent case. That is legitimate where the caller genuinely wants the default.");
 
+    /// <remarks>
+    /// Fires on what is not provably free rather than on what is provably
+    /// expensive, because only the first is decidable. A constant, a bare
+    /// local, parameter, field or property read and a <c>default</c> cost
+    /// nothing to evaluate twice, so the rule stays silent on all of them; a
+    /// call, a <c>new</c> or an <c>await</c> might be cheap or might not, and
+    /// no static test tells the two apart. The residual imprecision is a fire
+    /// on a call that turns out to be cheap, where the caller pays a delegate
+    /// allocation to avoid nothing. That is documented on the rules page
+    /// rather than tuned away, and Info severity is what makes it affordable.
+    /// A bare property read is skipped whatever the receiver, including one
+    /// whose getter computes: auto-versus-computed is only decidable for a
+    /// symbol declared in the current compilation, and a rule that fired on
+    /// the metadata half would make two identical call sites behave
+    /// differently on nothing but which assembly declared the property.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor EagerArgumentNotFree = Idiom(
+        "WM2016",
+        "Prefer the lazy variant when the argument is not free",
+        "'{0}' evaluates its argument even when '{1}' discards it. Use '{2}' if computing it is expensive or has a side effect.",
+        "And, Or, UnwrapOr, MapOr and OkOr evaluate their argument before checking whether the receiver even needs it, so an expensive computation or a side effect runs unconditionally. Their AndThen, OrElse, UnwrapOrElse, MapOrElse and OkOrElse siblings take a delegate instead and only invoke it when the receiver's other branch is taken.");
+
     public static readonly DiagnosticDescriptor NullableReturnCouldBeOption = Migration(
         "WM3001",
         "Prefer an Option over a nullable return",

--- a/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/CodeFixTests.cs
@@ -165,4 +165,104 @@ public class CodeFixTests
             Verify.Diagnostic(Rules.NullableMonadDeclared)
                .WithLocation(0)
                .WithArguments("Option<int>", "None"));
+
+    [Fact]
+    public Task WrapsAnEagerOrArgumentInALambda() =>
+        Verify.CodeFixAsync<LazyVariantAnalyzer, UseLazyVariantCodeFix>(
+            """
+            internal Option<int> Fallback() => Option.Some(0);
+
+            internal Option<int> Pick(Option<int> option) =>
+                option.{|#0:Or|}(Fallback());
+            """,
+            """
+            internal Option<int> Fallback() => Option.Some(0);
+
+            internal Option<int> Pick(Option<int> option) =>
+                option.OrElse(() => Fallback());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("Or", "Option<int>", "OrElse"));
+
+    /// <remarks>
+    /// <c>AndThen</c> is the only replacement whose delegate takes the
+    /// receiver's value, so the fix has to discard it rather than emit the
+    /// parameterless lambda the other four use.
+    /// </remarks>
+    [Fact]
+    public Task DiscardsTheValueWhenWrappingAnEagerAndArgument() =>
+        Verify.CodeFixAsync<LazyVariantAnalyzer, UseLazyVariantCodeFix>(
+            """
+            internal Option<string> Next() => Option.Some("x");
+
+            internal Option<string> Pick(Option<int> option) =>
+                option.{|#0:And|}(Next());
+            """,
+            """
+            internal Option<string> Next() => Option.Some("x");
+
+            internal Option<string> Pick(Option<int> option) =>
+                option.AndThen(_ => Next());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("And", "Option<int>", "AndThen"));
+
+    [Fact]
+    public Task WrapsAnEagerUnwrapOrArgumentInALambda() =>
+        Verify.CodeFixAsync<LazyVariantAnalyzer, UseLazyVariantCodeFix>(
+            """
+            internal int Expensive() => 42;
+
+            internal int Read(Option<int> option) =>
+                option.{|#0:UnwrapOr|}(Expensive());
+            """,
+            """
+            internal int Expensive() => 42;
+
+            internal int Read(Option<int> option) =>
+                option.UnwrapOrElse(() => Expensive());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("UnwrapOr", "Option<int>", "UnwrapOrElse"));
+
+    [Fact]
+    public Task KeepsTheMapDelegateWhenWrappingMapOr() =>
+        Verify.CodeFixAsync<LazyVariantAnalyzer, UseLazyVariantCodeFix>(
+            """
+            internal int Expensive() => 42;
+
+            internal int Read(Option<int> option) =>
+                option.{|#0:MapOr|}(Expensive(), value => value + 1);
+            """,
+            """
+            internal int Expensive() => 42;
+
+            internal int Read(Option<int> option) =>
+                option.MapOrElse(() => Expensive(), value => value + 1);
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("MapOr", "Option<int>", "MapOrElse"));
+
+    [Fact]
+    public Task WrapsAnEagerOkOrArgumentInALambda() =>
+        Verify.CodeFixAsync<LazyVariantAnalyzer, UseLazyVariantCodeFix>(
+            """
+            internal string Reason() => "missing";
+
+            internal Result<int, string> Convert(Option<int> option) =>
+                option.{|#0:OkOr|}(Reason());
+            """,
+            """
+            internal string Reason() => "missing";
+
+            internal Result<int, string> Convert(Option<int> option) =>
+                option.OkOrElse(() => Reason());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("OkOr", "Option<int>", "OkOrElse"));
 }

--- a/test/Waystone.Monads.Analyzers.Tests/LazyVariantAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/LazyVariantAnalyzerTests.cs
@@ -1,0 +1,194 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Threading.Tasks;
+using Xunit;
+
+public class LazyVariantAnalyzerTests
+{
+    [Fact]
+    public Task FlagsOrWithACall() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal Option<int> Fallback() => Option.Some(0);
+
+            internal Option<int> Pick(Option<int> option) =>
+                option.{|#0:Or|}(Fallback());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("Or", "Option<int>", "OrElse"));
+
+    [Fact]
+    public Task FlagsAndWithACall() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal Option<string> Next() => Option.Some("x");
+
+            internal Option<string> Pick(Option<int> option) =>
+                option.{|#0:And|}(Next());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("And", "Option<int>", "AndThen"));
+
+    [Fact]
+    public Task FlagsUnwrapOrWithACall() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal int Expensive() => 42;
+
+            internal int Read(Option<int> option) =>
+                option.{|#0:UnwrapOr|}(Expensive());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("UnwrapOr", "Option<int>", "UnwrapOrElse"));
+
+    [Fact]
+    public Task FlagsMapOrOnItsFirstArgument() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal int Expensive() => 42;
+
+            internal int Read(Option<int> option) =>
+                option.{|#0:MapOr|}(Expensive(), value => value + 1);
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("MapOr", "Option<int>", "MapOrElse"));
+
+    [Fact]
+    public Task FlagsOkOrWithACall() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal string Reason() => "missing";
+
+            internal Result<int, string> Convert(Option<int> option) =>
+                option.{|#0:OkOr|}(Reason());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("OkOr", "Option<int>", "OkOrElse"));
+
+    [Fact]
+    public Task FlagsAResultReceiver() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal int Expensive() => 42;
+
+            internal int Read(Result<int, string> result) =>
+                result.{|#0:UnwrapOr|}(Expensive());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("UnwrapOr", "Result<int, string>", "UnwrapOrElse"));
+
+    [Fact]
+    public Task FlagsAnObjectCreation() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal Option<string> Pick(Option<string> option) =>
+                option.{|#0:Or|}(Option.Some(new string('x', 3)));
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments("Or", "Option<string>", "OrElse"));
+
+    [Fact]
+    public Task FlagsAnAsyncWrapper() =>
+        Verify.AnalyzerAsync<LazyVariantAnalyzer>(
+            """
+            internal int Expensive() => 42;
+
+            internal ValueTask<int> Read(Task<Option<int>> option) =>
+                option.{|#0:UnwrapOrAsync|}(Expensive());
+            """,
+            Verify.Diagnostic(Rules.EagerArgumentNotFree)
+               .WithLocation(0)
+               .WithArguments(
+                    "UnwrapOrAsync",
+                    "Task<Option<int>>",
+                    "UnwrapOrElseAsync"));
+
+    [Fact]
+    public Task IgnoresALiteral() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            internal int Read(Option<int> option) => option.UnwrapOr(0);
+            """);
+
+    [Fact]
+    public Task IgnoresALocal() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            internal int Read(Option<int> option)
+            {
+                int fallback = 42;
+
+                return option.UnwrapOr(fallback);
+            }
+            """);
+
+    [Fact]
+    public Task IgnoresAParameter() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            internal int Read(Option<int> option, int fallback) =>
+                option.UnwrapOr(fallback);
+            """);
+
+    [Fact]
+    public Task IgnoresAField() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            private readonly int _fallback = 42;
+
+            internal int Read(Option<int> option) =>
+                option.UnwrapOr(_fallback);
+            """);
+
+    [Fact]
+    public Task IgnoresAPropertyRead() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            private int Fallback => 42;
+
+            internal int Read(Option<int> option) =>
+                option.UnwrapOr(Fallback);
+            """);
+
+    [Fact]
+    public Task IgnoresADefault() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            internal Option<int> Pick(Option<int> option) =>
+                option.Or(default(Option<int>));
+            """);
+
+    [Fact]
+    public Task IgnoresTheLazySiblings() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            internal Option<int> Fallback() => Option.Some(0);
+
+            internal Option<int> Pick(Option<int> option) =>
+                option.OrElse(() => Fallback());
+            """);
+
+    [Fact]
+    public Task IgnoresAnUnrelatedOr() =>
+        Verify.NoDiagnosticAsync<LazyVariantAnalyzer>(
+            """
+            internal static class Choice
+            {
+                internal static int Or(this int value, int other) => other;
+            }
+
+            internal class Subject
+            {
+                internal int Expensive() => 42;
+
+                internal int Read(int value) => value.Or(Expensive());
+            }
+            """);
+}

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -63,7 +63,7 @@ public class RulesTests
     public void EveryTierIsPopulated()
     {
         MisuseRules().Count.ShouldBe(7);
-        IdiomRules().Count.ShouldBe(14);
+        IdiomRules().Count.ShouldBe(15);
         MigrationRules().Count.ShouldBe(2);
     }
 


### PR DESCRIPTION
C# evaluates an argument before the call, so option.Or(ExpensiveLookup())
pays for the lookup even when the option is Some and the result is thrown
away. Nothing pointed a caller at OrElse.

The rule fires on what is not provably free rather than on what is provably
expensive, because only the first is decidable. A constant, a bare local,
parameter, field or property read and a default are skipped; a call, a new
or an await are not, and no static test says whether they are cheap. The
residual imprecision — a fire on a call that turns out to be cheap, where
the caller pays a delegate allocation to avoid nothing — is recorded on the
descriptor and belongs on the rules page rather than being tuned away.

A bare property read is skipped whatever the receiver. Auto-versus-computed
is only decidable for a symbol declared in the current compilation, so a
rule that fired on the metadata half would make two identical call sites
behave differently on nothing but which assembly declared the property.

The code fix wraps the argument in place. AndThen is the one replacement
whose delegate takes the receiver's value, so it gets a discard where the
other four take no parameter.

Usage/Info, enabled by default, in its own analyzer class rather than
SimplificationAnalyzer, whose checks are unrelated. Keyed on
MonadSymbols.IsMonadInvocation rather than IsExtensionMethod, per the C# 14
extension-block gotcha.

The proposed title ran to 65 characters and RulesTests caps them at 60, so
it ships as "Prefer the lazy variant when the argument is not free".

WM2016 was confirmed free against Rules.cs and both release files. The idiom
tier goes to 15: DRA-96, which the issue expected to add another, was
cancelled.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>