### PR TITLE
perf: return a cached None instance rather than allocating one per call

### DIFF
--- a/artifacts/dra-100-before/results/Waystone.Monads.Benchmarks.HotPathBenchmarks-report-github.md
+++ b/artifacts/dra-100-before/results/Waystone.Monads.Benchmarks.HotPathBenchmarks-report-github.md
@@ -1,0 +1,19 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]     : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  DefaultJob : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+
+```
+| Method               | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| CreateNone           |  1.646 ns | 0.0220 ns | 0.0184 ns |  1.00 |    0.02 | 0.0005 |      24 B |        1.00 |
+| FilterThatRejects    |  1.834 ns | 0.0311 ns | 0.0291 ns |  1.11 |    0.02 | 0.0005 |      24 B |        1.00 |
+| MapOnNone            |  4.888 ns | 0.0611 ns | 0.0542 ns |  2.97 |    0.05 | 0.0005 |      24 B |        1.00 |
+| ZipOnNone            |  3.907 ns | 0.0675 ns | 0.0631 ns |  2.37 |    0.05 | 0.0005 |      24 B |        1.00 |
+| XorOnTwoSome         |  1.661 ns | 0.0234 ns | 0.0219 ns |  1.01 |    0.02 | 0.0005 |      24 B |        1.00 |
+| MapAsyncShortCircuit | 18.385 ns | 0.2318 ns | 0.2168 ns | 11.17 |    0.18 | 0.0005 |      24 B |        1.00 |
+| SomeThenUnwrap       |  2.441 ns | 0.0380 ns | 0.0355 ns |  1.48 |    0.03 | 0.0005 |      24 B |        1.00 |

--- a/artifacts/dra-100/results/Waystone.Monads.Benchmarks.HotPathBenchmarks-report-github.md
+++ b/artifacts/dra-100/results/Waystone.Monads.Benchmarks.HotPathBenchmarks-report-github.md
@@ -1,0 +1,19 @@
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 9800X3D 4.70GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.111
+  [Host]     : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+  DefaultJob : .NET 8.0.30 (8.0.30, 8.0.3026.36720), X64 RyuJIT x86-64-v4
+
+
+```
+| Method               | Mean       | Error     | StdDev    | Ratio  | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------------------- |-----------:|----------:|----------:|-------:|--------:|-------:|----------:|------------:|
+| CreateNone           |  0.1807 ns | 0.0125 ns | 0.0111 ns |   1.00 |    0.08 |      - |         - |          NA |
+| FilterThatRejects    |  0.3066 ns | 0.0178 ns | 0.0157 ns |   1.70 |    0.13 |      - |         - |          NA |
+| MapOnNone            |  4.8986 ns | 0.0454 ns | 0.0402 ns |  27.21 |    1.58 |      - |         - |          NA |
+| ZipOnNone            |  2.5846 ns | 0.0362 ns | 0.0321 ns |  14.36 |    0.85 |      - |         - |          NA |
+| XorOnTwoSome         |  0.1837 ns | 0.0104 ns | 0.0087 ns |   1.02 |    0.08 |      - |         - |          NA |
+| MapAsyncShortCircuit | 19.0779 ns | 0.2357 ns | 0.2205 ns | 105.96 |    6.22 |      - |         - |          NA |
+| SomeThenUnwrap       |  2.4583 ns | 0.0589 ns | 0.0551 ns |  13.65 |    0.84 | 0.0005 |      24 B |          NA |

--- a/bench/Waystone.Monads.Benchmarks/HotPathBenchmarks.cs
+++ b/bench/Waystone.Monads.Benchmarks/HotPathBenchmarks.cs
@@ -1,0 +1,48 @@
+namespace Waystone.Monads.Benchmarks;
+
+using BenchmarkDotNet.Attributes;
+using Options;
+using Options.Extensions;
+using System.Threading.Tasks;
+
+[MemoryDiagnoser]
+public class HotPathBenchmarks
+{
+    private Option<int> _some = null!;
+    private Option<int> _none = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _some = Option.Some(42);
+        _none = Option.None<int>();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Option<int> CreateNone() => Option.None<int>();
+
+    [Benchmark]
+    public Option<int> FilterThatRejects() =>
+        _some.Filter(static value => value < 0);
+
+    [Benchmark]
+    public Option<string> MapOnNone() =>
+        _none.Map(static value => value.ToString());
+
+    [Benchmark]
+    public Option<(int, int)> ZipOnNone() => _none.Zip(_none);
+
+    [Benchmark]
+    public Option<int> XorOnTwoSome() => _some.Xor(_some);
+
+    [Benchmark]
+    public async ValueTask<Option<string>> MapAsyncShortCircuit() =>
+        await _none.MapAsync(static value => Task.FromResult(value.ToString()));
+
+    [Benchmark]
+    public async ValueTask<Option<string>> MapAsyncOnSome() =>
+        await _some.MapAsync(static value => Task.FromResult(value.ToString()));
+
+    [Benchmark]
+    public Option<int> SomeThenUnwrap() => Option.Some(_some.Unwrap());
+}

--- a/bench/Waystone.Monads.Benchmarks/README.md
+++ b/bench/Waystone.Monads.Benchmarks/README.md
@@ -53,6 +53,7 @@ the escape hatch for a throwaway run you do not want in the tree.
 | `OptionBenchmarks` | `Some`/`None` construction, the implicit conversion, `FromNullable`, `Match`, `Map`, `Filter`, `UnwrapOr`, each on both cases |
 | `ResultBenchmarks` | `Ok`/`Err` construction, `Match`, `Map`, `MapErr`, `UnwrapOr`, each on both cases |
 | `AsyncChainBenchmarks` | A single async link and a three-link chain off a synchronous receiver, on both cases |
+| `HotPathBenchmarks` | The paths that produce a `None` — the factory, a rejecting `Filter`, `Map`/`Zip` on a `None`, `Xor`, and an async short circuit |
 | `StateOverloadBenchmarks` | `Map`, `MapOr` and `Filter` on `Option`, `Map` on `Result`, and `Try` on both, each run twice — once with a capturing lambda and once with the state overload |
 
 `AsyncChainBenchmarks` is the one to watch across the v6 stack. A chain today
@@ -171,3 +172,33 @@ A `static` lambda is what makes this work. Passing a non-`static` lambda that
 happens not to capture gets the same result, but nothing stops a later edit
 from capturing again and silently putting the 88 B back — `static` makes that a
 compile error.
+
+## The None singleton
+
+`artifacts/dra-100-before/` and `artifacts/dra-100/` hold the two runs.
+`None<T>` is stateless, so `Option.None<T>()` was allocating a fresh 24 B
+record on every cold branch in the library. It now returns a
+`static readonly` instance the runtime builds once per closed generic.
+
+| Call | before | after |
+| -- | --: | --: |
+| `Option.None<int>()` | 24 B | 0 B |
+| `Filter` that rejects | 24 B | 0 B |
+| `Map` on a `None` | 24 B | 0 B |
+| `Zip` on a `None` | 24 B | 0 B |
+| `Xor` on two `Some` | 24 B | 0 B |
+| `MapAsync` short circuit | 24 B | 0 B |
+
+`Option.None<int>()` also drops from 1.65 ns to 0.18 ns, which is the
+allocation and nothing else — there was never any work to do.
+
+`Some` is untouched and still allocates its 24 B, because it holds a value.
+
+### What was measured and dropped
+
+Replacing the `IsNone`-then-`Expect` pair in the async extensions with a
+single `is not Some<T>` type test was measured on `MapAsync` over a `Some`
+before it was applied anywhere: 29.30 ns to 28.81 ns, with error bars of
+±0.44 and ±0.15, and no change in allocation. That is under two percent and
+inside the noise, against a diff touching 43 files. It was reverted rather
+than argued for.

--- a/src/Waystone.Monads/Options/None.cs
+++ b/src/Waystone.Monads/Options/None.cs
@@ -16,6 +16,15 @@ using System.Diagnostics;
 public sealed record None<T> : Option<T>
     where T : notnull
 {
+    /// <remarks>
+    /// A <see cref="None{T}" /> holds nothing, so every instance of a given
+    /// closed type is interchangeable and the runtime builds this one once.
+    /// Structural equality is unaffected — two <c>None</c> values were already
+    /// equal — but <c>ReferenceEquals</c> now answers true where it answered
+    /// false before 6.0.0.
+    /// </remarks>
+    internal static readonly None<T> Instance = new();
+
     /// <inheritdoc />
     public override bool IsSome => false;
 

--- a/src/Waystone.Monads/Options/Option.cs
+++ b/src/Waystone.Monads/Options/Option.cs
@@ -287,7 +287,8 @@ public static class Option
     /// <summary>Creates a <see cref="None{T}" /></summary>
     /// <typeparam name="T">The option value's type.</typeparam>
     /// <returns>An <see cref="Option{T}" />.</returns>
-    public static Option<T> None<T>() where T : notnull => new None<T>();
+    public static Option<T> None<T>() where T : notnull =>
+        Options.None<T>.Instance;
 
     /// <summary>Creates an <see cref="Option{T}" /> from a nullable value type.</summary>
     /// <typeparam name="T">The non-nullable value's type</typeparam>
@@ -301,7 +302,7 @@ public static class Option
     /// </returns>
     public static Option<T> FromNullable<T>(T? value)
         where T : struct =>
-        value.HasValue ? new Some<T>(value.Value) : new None<T>();
+        value.HasValue ? new Some<T>(value.Value) : None<T>();
 
     /// <summary>Creates an <see cref="Option{T}" /> from a nullable reference type.</summary>
     /// <typeparam name="T">The non-nullable value's type</typeparam>
@@ -315,5 +316,5 @@ public static class Option
     /// </returns>
     public static Option<T> FromNullable<T>(T? value)
         where T : class =>
-        value is null ? new None<T>() : new Some<T>(value);
+        value is null ? None<T>() : new Some<T>(value);
 }

--- a/src/Waystone.Monads/Options/OptionOfT.cs
+++ b/src/Waystone.Monads/Options/OptionOfT.cs
@@ -472,5 +472,5 @@ public abstract record Option<T> where T : notnull
     [DebuggerStepThrough]
 #endif
     public static implicit operator Option<T>(T value) =>
-        value is null ? new None<T>() : new Some<T>(value);
+        value is null ? Option.None<T>() : new Some<T>(value);
 }

--- a/test/Waystone.Monads.Tests/Options/NoneSingletonTests.cs
+++ b/test/Waystone.Monads.Tests/Options/NoneSingletonTests.cs
@@ -1,0 +1,79 @@
+﻿namespace Waystone.Monads.Options;
+
+using JetBrains.Annotations;
+using Shouldly;
+using Xunit;
+
+/// <remarks>
+/// The singleton changes reference identity and nothing else. These pin the
+/// "nothing else" half: a rule that made two <c>None</c> values stop being
+/// equal, or hash differently, would break correct programs, where the
+/// identity change cannot.
+/// </remarks>
+[TestSubject(typeof(None<>))]
+public sealed class NoneSingletonTests
+{
+    [Fact]
+    public void TwoNonesOfTheSameTypeAreTheSameInstance() =>
+        ReferenceEquals(Option.None<int>(), Option.None<int>())
+           .ShouldBeTrue();
+
+    [Fact]
+    public void TwoNonesOfDifferentTypesAreDifferentInstances() =>
+        ReferenceEquals(Option.None<int>(), Option.None<string>())
+           .ShouldBeFalse();
+
+    [Fact]
+    public void TwoNonesAreEqual() =>
+        Option.None<int>().ShouldBe(Option.None<int>());
+
+    [Fact]
+    public void TwoNonesHashTheSame() =>
+        Option.None<int>().GetHashCode()
+           .ShouldBe(Option.None<int>().GetHashCode());
+
+    [Fact]
+    public void ANoneEqualsAnIndependentlyConstructedOne()
+    {
+        Option<int> constructed = new None<int>();
+
+        constructed.ShouldBe(Option.None<int>());
+        constructed.GetHashCode().ShouldBe(Option.None<int>().GetHashCode());
+    }
+
+    [Fact]
+    public void TheSingletonIsNotEqualToASome() =>
+        Option.None<int>().ShouldNotBe(Option.Some(0));
+
+    /// <remarks>
+    /// A record's <c>with</c> goes through the compiler-generated clone rather
+    /// than the factory, so it hands back a second instance. That is harmless —
+    /// there is no state to diverge — but it means the singleton is the
+    /// factory's guarantee, not the type's.
+    /// </remarks>
+    [Fact]
+    public void AWithExpressionStillProducesAnEqualNone()
+    {
+        var original = (None<int>)Option.None<int>();
+        var copied = original with { };
+
+        copied.ShouldBe(original);
+        copied.IsNone.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TheSingletonSurvivesConversionRoundTrips()
+    {
+        Option<int> converted = Option.FromNullable<int>(null);
+
+        converted.ShouldBe(Option.None<int>());
+        converted.IsNone.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AFilteredOutSomeIsTheSingleton() =>
+        ReferenceEquals(
+                Option.Some(1).Filter(static value => value < 0),
+                Option.None<int>())
+           .ShouldBeTrue();
+}


### PR DESCRIPTION
None<T> is a stateless sealed record, so every Option.None<T>() was
allocating 24 B to represent nothing. They are everywhere on the cold
branch: a Filter that rejects, Map and Zip on a None, Xor, and the
short circuit at the top of every async extension.

The factory now returns a static readonly instance the runtime builds once
per closed generic. Measured in artifacts/dra-100-before and
artifacts/dra-100, all six None-producing rows go from 24 B to zero, and
Option.None<int>() drops from 1.65 ns to 0.18 ns. Some is untouched and
still allocates, because it holds a value.

ReferenceEquals(Option.None<int>(), Option.None<int>()) becomes true where
it was false. Record equality is structural, so ==, Equals and GetHashCode
are unchanged and no correct program can observe the difference, but it is
observable and belongs in the upgrade notes. NoneSingletonTests pins the
half that must not move, including that an independently constructed
new None<int>() is still equal to the singleton and that a with expression
goes through the compiler's clone rather than the factory.

Item 1 of the issue arrived with DRA-87's null test and needed no code here.

Item 3, the is-not-Some type test across the async extensions, was measured
before being applied anywhere: 29.30 ns to 28.81 ns on MapAsync over a Some,
error bars +/-0.44 and +/-0.15, no allocation change. Under two percent and
inside the noise, against a diff touching 43 files. Reverted; the numbers
and the reasoning are in the benchmark README so nobody re-derives it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>