### PR TITLE
feat(analyzers): add WM2017 nudging a capturing delegate toward the state overload

### DIFF
--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -57,6 +57,7 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 WM1011 | Reliability | Warning | An async factory is passed to Try
 WM2016 | Usage | Info | An eager argument is not provably free to evaluate
+WM2017 | Usage | Info | A delegate captures where a state overload exists
 
 ### Removed Rules
 

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -226,6 +226,27 @@ public static class Rules
         "'{0}' evaluates its argument even when '{1}' discards it. Use '{2}' if computing it is expensive or has a side effect.",
         "And, Or, UnwrapOr, MapOr and OkOr evaluate their argument before checking whether the receiver even needs it, so an expensive computation or a side effect runs unconditionally. Their AndThen, OrElse, UnwrapOrElse, MapOrElse and OkOrElse siblings take a delegate instead and only invoke it when the receiver's other branch is taken.");
 
+    /// <remarks>
+    /// Keyed on the capture rather than on the lambda: a lambda that captures
+    /// nothing is already cached by the compiler into a static field, so the
+    /// state overload would buy it nothing. Only a captured local or parameter
+    /// forces a display class per call, and that is what the rule reports.
+    /// Capturing <c>this</c> alone is excluded — it allocates a delegate rather
+    /// than a display class, a smaller cost that would fire on most ordinary
+    /// instance-method code and drown the signal.
+    /// The overload set is discovered from the containing type rather than
+    /// listed here, because <c>AndThen</c> carries a state overload on Option
+    /// and not on Result, and a hardcoded list would name an overload that does
+    /// not exist. No code fix ships: the natural rewrite reuses the captured
+    /// name as the new delegate parameter, which shadows the enclosing local
+    /// and is CS0136 before C# 8.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor DelegateCapturesInsteadOfState = Idiom(
+        "WM2017",
+        "Prefer the state overload when the delegate captures",
+        "The delegate passed to '{0}' captures '{1}', so a closure is allocated on every call. Pass the value to the '{0}' overload that takes state instead.",
+        "Map, MapErr, MapOr, MapOrElse, Filter, AndThen, Try and TryAsync each have an overload that takes a state argument and hands it to the delegate. A lambda that captures a local or a parameter allocates a display class every time the call site runs; passing the value as state lets the delegate close over nothing, so the compiler caches it. Where more than one value is captured, pass them as a tuple.");
+
     public static readonly DiagnosticDescriptor NullableReturnCouldBeOption = Migration(
         "WM3001",
         "Prefer an Option over a nullable return",

--- a/src/Waystone.Monads.Analyzers/StateOverloadAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/StateOverloadAnalyzer.cs
@@ -1,0 +1,134 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class StateOverloadAnalyzer : MonadAnalyzer
+{
+    private const string StateTypeParameterName = "TState";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rules.DelegateCapturesInsteadOfState);
+
+    protected override void Register(
+        CompilationStartAnalysisContext context,
+        MonadSymbols symbols) =>
+        context.RegisterOperationAction(
+            operation => Analyze(operation, symbols),
+            OperationKind.Invocation);
+
+    private static void Analyze(
+        OperationAnalysisContext context,
+        MonadSymbols symbols)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var method = invocation.TargetMethod;
+
+        if (!IsDeclaredByTheLibrary(method, symbols)
+         || TakesState(method)
+         || !HasAStateOverload(method))
+        {
+            return;
+        }
+
+        List<string> captured = CapturedBy(invocation);
+
+        if (captured.Count == 0)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Rules.DelegateCapturesInsteadOfState,
+                Semantics.NameLocationOf(invocation),
+                method.Name,
+                string.Join("', '", captured)));
+    }
+
+    private static bool IsDeclaredByTheLibrary(
+        IMethodSymbol method,
+        MonadSymbols symbols) =>
+        symbols.IsMonad(method.ContainingType)
+     || symbols.IsDerivedCase(method.ContainingType)
+     || SymbolEqualityComparer.Default.Equals(
+            method.ContainingType,
+            symbols.OptionFactory)
+     || SymbolEqualityComparer.Default.Equals(
+            method.ContainingType,
+            symbols.ResultFactory);
+
+    private static bool TakesState(IMethodSymbol method) =>
+        method.OriginalDefinition.TypeParameters.Any(
+            parameter => parameter.Name == StateTypeParameterName);
+
+    private static bool HasAStateOverload(IMethodSymbol method) =>
+        method.ContainingType.GetMembers(method.Name)
+              .OfType<IMethodSymbol>()
+              .Any(TakesState);
+
+    private static List<string> CapturedBy(IInvocationOperation invocation)
+    {
+        var captured = new List<string>();
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (LambdaIn(argument.Value) is not { } lambda)
+            {
+                continue;
+            }
+
+            foreach (var name in CapturedBy(lambda))
+            {
+                if (!captured.Contains(name))
+                {
+                    captured.Add(name);
+                }
+            }
+        }
+
+        return captured;
+    }
+
+    private static IAnonymousFunctionOperation? LambdaIn(IOperation operation)
+    {
+        var value = Semantics.Unconverted(operation);
+
+        if (value is IDelegateCreationOperation creation)
+        {
+            value = Semantics.Unconverted(creation.Target);
+        }
+
+        return value as IAnonymousFunctionOperation;
+    }
+
+    private static IEnumerable<string> CapturedBy(
+        IAnonymousFunctionOperation lambda)
+    {
+        foreach (var descendant in lambda.Descendants())
+        {
+            ISymbol? referenced = descendant switch
+            {
+                ILocalReferenceOperation local => local.Local,
+                IParameterReferenceOperation parameter => parameter.Parameter,
+                _ => null,
+            };
+
+            if (referenced is not null
+             && !IsDeclaredWithin(referenced, lambda.Syntax))
+            {
+                yield return referenced.Name;
+            }
+        }
+    }
+
+    private static bool IsDeclaredWithin(ISymbol symbol, SyntaxNode lambda) =>
+        symbol.DeclaringSyntaxReferences.Any(
+            reference => reference.SyntaxTree == lambda.SyntaxTree
+                      && lambda.Span.Contains(reference.Span));
+}

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -63,7 +63,7 @@ public class RulesTests
     public void EveryTierIsPopulated()
     {
         MisuseRules().Count.ShouldBe(7);
-        IdiomRules().Count.ShouldBe(15);
+        IdiomRules().Count.ShouldBe(16);
         MigrationRules().Count.ShouldBe(2);
     }
 

--- a/test/Waystone.Monads.Analyzers.Tests/StateOverloadAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/StateOverloadAnalyzerTests.cs
@@ -1,0 +1,247 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Threading.Tasks;
+using Xunit;
+
+public class StateOverloadAnalyzerTests
+{
+    [Fact]
+    public Task FlagsMapCapturingAParameter() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Shift(Option<int> option, int offset) =>
+                option.{|#0:Map|}(value => value + offset);
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Map", "offset"));
+
+    [Fact]
+    public Task FlagsMapCapturingALocal() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Shift(Option<int> option)
+            {
+                var offset = 5;
+
+                return option.{|#0:Map|}(value => value + offset);
+            }
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Map", "offset"));
+
+    [Fact]
+    public Task FlagsFilterCapturingAParameter() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Big(Option<int> option, int limit) =>
+                option.{|#0:Filter|}(value => value > limit);
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Filter", "limit"));
+
+    [Fact]
+    public Task FlagsAndThenCapturingAParameter() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Chain(Option<int> option, int offset) =>
+                option.{|#0:AndThen|}(value => Option.Some(value + offset));
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("AndThen", "offset"));
+
+    [Fact]
+    public Task FlagsMapErrCapturingAParameter() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Result<int, string> Tag(
+                Result<int, string> result,
+                string prefix) =>
+                result.{|#0:MapErr|}(error => prefix + error);
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("MapErr", "prefix"));
+
+    /// <remarks>
+    /// MapOrElse takes two delegates and the state overload hands one state to
+    /// both, so a capture in either is enough to report.
+    /// </remarks>
+    [Fact]
+    public Task FlagsMapOrElseWhenOnlyTheDefaultCaptures() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal int Read(Option<int> option, int fallback) =>
+                option.{|#0:MapOrElse|}(() => fallback, value => value);
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("MapOrElse", "fallback"));
+
+    [Fact]
+    public Task FlagsOptionTryCapturingAParameter() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Parse(string text) =>
+                Option.{|#0:Try|}(() => int.Parse(text));
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Try", "text"));
+
+    [Fact]
+    public Task FlagsResultTryCapturingAParameter() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Result<int, Error> Parse(string text) =>
+                Result.{|#0:Try|}(() => int.Parse(text));
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Try", "text"));
+
+    [Fact]
+    public Task ListsEveryCapturedName() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Shift(
+                Option<int> option,
+                int first,
+                int second) =>
+                option.{|#0:Map|}(value => value + first + second);
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Map", "first', 'second"));
+
+    [Fact]
+    public Task ReportsACapturedNameOnce() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Shift(Option<int> option, int offset) =>
+                option.{|#0:Map|}(value => value + offset + offset);
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Map", "offset"));
+
+    [Fact]
+    public Task FlagsAnAnonymousMethodThatCaptures() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Shift(Option<int> option, int offset) =>
+                option.{|#0:Map|}(
+                    delegate(int value) { return value + offset; });
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("Map", "offset"));
+
+    [Fact]
+    public Task IgnoresALambdaThatCapturesNothing() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Doubled(Option<int> option) =>
+                option.Map(value => value * 2);
+            """);
+
+    [Fact]
+    public Task IgnoresAStaticLambda() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Doubled(Option<int> option) =>
+                option.Map(static value => value * 2);
+            """);
+
+    [Fact]
+    public Task IgnoresALocalDeclaredInsideTheLambda() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Doubled(Option<int> option) =>
+                option.Map(value =>
+                {
+                    var twice = value * 2;
+
+                    return twice;
+                });
+            """);
+
+    [Fact]
+    public Task IgnoresACallAlreadyOnTheStateOverload() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Shift(Option<int> option, int offset) =>
+                option.Map(offset, (value, state) => value + state);
+            """);
+
+    /// <remarks>
+    /// Capturing <c>this</c> allocates a delegate rather than a display class,
+    /// and firing on it would hit most ordinary instance-method code. Both the
+    /// field read and the instance call reach <c>this</c> the same way.
+    /// </remarks>
+    [Fact]
+    public Task IgnoresALambdaThatOnlyReadsAField() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal class Subject
+            {
+                private readonly int _offset = 5;
+
+                internal Option<int> Shift(Option<int> option) =>
+                    option.Map(value => value + _offset);
+            }
+            """);
+
+    [Fact]
+    public Task IgnoresALambdaThatOnlyCallsAnInstanceMethod() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal class Subject
+            {
+                private int Compute(int value) => value * 2;
+
+                internal Option<int> Doubled(Option<int> option) =>
+                    option.Map(value => Compute(value));
+            }
+            """);
+
+    /// <remarks>
+    /// AndThen carries a state overload on Option and not on Result, so a rule
+    /// keyed on a list of method names would name an overload that does not
+    /// exist. This pins the containing-type lookup that replaces the list.
+    /// </remarks>
+    [Fact]
+    public Task IgnoresResultAndThenWhichHasNoStateOverload() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal Result<int, string> Chain(
+                Result<int, string> result,
+                int offset) =>
+                result.AndThen(
+                    value => Result.Ok<int, string>(value + offset));
+            """);
+
+    [Fact]
+    public Task IgnoresAStateOverloadOnATypeOutsideTheLibrary() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal class Mine
+            {
+                internal int Map(Func<int, int> map) => map(1);
+
+                internal int Map<TState>(
+                    TState state,
+                    Func<int, TState, int> map) =>
+                    map(1, state);
+            }
+
+            internal class Subject
+            {
+                internal int Use(Mine mine, int offset) =>
+                    mine.Map(value => value + offset);
+            }
+            """);
+}


### PR DESCRIPTION
DRA-84 and DRA-104 added state overloads but nothing pointed callers at
them. WM2017 fires where a delegate argument captures a local or a
parameter, which is the call site the overload actually helps.

The overload set is discovered from the target's containing type rather
than from a list of names: AndThen carries a state overload on Option
and not on Result, so a name list would name an overload that does not
exist.

No code fix ships. The natural rewrite reuses the captured name as the
new delegate parameter, which shadows the enclosing local — legal from
C# 8, CS0136 on C# 7.3, verified both ways. The analyzer reaches every
consumer including netstandard2.0 targets.

Closes DRA-105

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>