### PR TITLE
feat: add the state overload for Result.AndThen that DRA-84 omitted

### DIFF
--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -242,9 +242,9 @@ public static class Rules
     /// than a display class, a smaller cost that would fire on most ordinary
     /// instance-method code and drown the signal.
     /// The overload set is discovered from the containing type rather than
-    /// listed here, because <c>AndThen</c> carries a state overload on Option
-    /// and not on Result, and a hardcoded list would name an overload that does
-    /// not exist. No code fix ships: the natural rewrite reuses the captured
+    /// listed here, because the two are not the same set — <c>Inspect</c> and
+    /// <c>Match</c> take a delegate and carry no state overload — and a
+    /// hardcoded list would name an overload that does not exist. No code fix ships: the natural rewrite reuses the captured
     /// name as the new delegate parameter, which shadows the enclosing local
     /// and is CS0136 before C# 8.
     /// </remarks>

--- a/src/Waystone.Monads/Results/ResultOfTOkTErr.cs
+++ b/src/Waystone.Monads/Results/ResultOfTOkTErr.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Exceptions;
+using Extensions;
 using Options;
 #if !DEBUG
 using System.Diagnostics;
@@ -139,6 +140,32 @@ public abstract record Result<TOk, TErr>
     /// </typeparam>
     public abstract Result<TOut, TErr> AndThen<TOut>(
         Func<TOk, Result<TOut, TErr>> createOther) where TOut : notnull;
+
+    /// <summary>
+    /// Calls the <paramref name="createOther" /> with <paramref name="state" />
+    /// if the result is <see cref="Ok{TOk,TErr}" />, otherwise returns the
+    /// <see cref="Err{TOk,TErr}" /> value of <see langword="this" /> instance.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="state" /> is handed to the function rather than
+    /// captured by it, so the delegate can be <see langword="static" /> and the
+    /// call allocates no closure.
+    /// </remarks>
+    /// <param name="state">The value passed to the <paramref name="createOther" /> function.</param>
+    /// <param name="createOther">A function that creates the other result.</param>
+    /// <typeparam name="TState">The type of the state passed to the function.</typeparam>
+    /// <typeparam name="TOut">
+    /// The <see cref="Ok{TOk,TErr}" /> value's type of the
+    /// other result.
+    /// </typeparam>
+#if !DEBUG
+    [DebuggerStepThrough]
+#endif
+    public Result<TOut, TErr> AndThen<TState, TOut>(
+        TState state,
+        Func<TOk, TState, Result<TOut, TErr>> createOther)
+        where TOut : notnull =>
+        Map(state, createOther).Flatten();
 
     /// <summary>
     /// Returns <paramref name="other" /> if the result is

--- a/test/Waystone.Monads.Analyzers.Tests/StateOverloadAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/StateOverloadAnalyzerTests.cs
@@ -208,20 +208,36 @@ public class StateOverloadAnalyzerTests
             }
             """);
 
-    /// <remarks>
-    /// AndThen carries a state overload on Option and not on Result, so a rule
-    /// keyed on a list of method names would name an overload that does not
-    /// exist. This pins the containing-type lookup that replaces the list.
-    /// </remarks>
     [Fact]
-    public Task IgnoresResultAndThenWhichHasNoStateOverload() =>
-        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+    public Task FlagsResultAndThenCapturingAParameter() =>
+        Verify.AnalyzerAsync<StateOverloadAnalyzer>(
             """
             internal Result<int, string> Chain(
                 Result<int, string> result,
                 int offset) =>
-                result.AndThen(
+                result.{|#0:AndThen|}(
                     value => Result.Ok<int, string>(value + offset));
+            """,
+            Verify.Diagnostic(Rules.DelegateCapturesInsteadOfState)
+               .WithLocation(0)
+               .WithArguments("AndThen", "offset"));
+
+    /// <remarks>
+    /// Inspect takes a delegate on a type that carries state overloads on other
+    /// methods, and has none of its own. This pins the containing-type lookup:
+    /// a rule that fired because the receiver has state overloads somewhere
+    /// would name an overload that does not exist.
+    /// </remarks>
+    [Fact]
+    public Task IgnoresInspectWhichHasNoStateOverload() =>
+        Verify.NoDiagnosticAsync<StateOverloadAnalyzer>(
+            """
+            internal Option<int> Log(Option<int> option, int offset) =>
+                option.Inspect(value => Record(value + offset));
+
+            private static void Record(int value)
+            {
+            }
             """);
 
     [Fact]

--- a/test/Waystone.Monads.Tests/Results/ErrTests.cs
+++ b/test/Waystone.Monads.Tests/Results/ErrTests.cs
@@ -95,6 +95,18 @@ public class ErrTests
     }
 
     [Fact]
+    public void GivenState_WhenAndThen_ThenReturnError()
+    {
+        Result<int, string> err = Result.Err<int, string>("error");
+
+        err.AndThen(10, static (x, state) => Result.Ok<int, string>(x + state))
+           .ShouldBe(Result.Err<int, string>("error"));
+
+        err.AndThen(10, static (_, state) => Result.Err<int, string>($"e{state}"))
+           .ShouldBe(Result.Err<int, string>("error"));
+    }
+
+    [Fact]
     public void WhenOr_ThenReturnOther()
     {
         Result<int, string> result = Result.Err<int, string>("error");

--- a/test/Waystone.Monads.Tests/Results/OkTests.cs
+++ b/test/Waystone.Monads.Tests/Results/OkTests.cs
@@ -96,6 +96,18 @@ public class OkTests
     }
 
     [Fact]
+    public void GivenState_WhenAndThen_ThenReturnOther()
+    {
+        Result<int, string> ok = Result.Ok<int, string>(1);
+
+        Result<int, string> result = ok.AndThen(
+            10,
+            static (x, state) => Result.Ok<int, string>(x + state));
+
+        result.ShouldBe(Result.Ok<int, string>(11));
+    }
+
+    [Fact]
     public void WhenOr_ThenReturnOk()
     {
         Result<int, string> ok = Result.Ok<int, string>(1);

--- a/test/Waystone.Monads.Tests/StateOverloadResolutionTests.cs
+++ b/test/Waystone.Monads.Tests/StateOverloadResolutionTests.cs
@@ -40,6 +40,12 @@ public sealed class StateOverloadResolutionTests
     private static readonly Func<int, int, Option<int>> SomeAdd = (x, state) =>
         Option.Some(x + state);
 
+    private static readonly Func<int, Result<int, string>> OkIncrement = x =>
+        Result.Ok<int, string>(x + 1);
+
+    private static readonly Func<int, int, Result<int, string>> OkAdd =
+        (x, state) => Result.Ok<int, string>(x + state);
+
     private static readonly Func<Exception, int> OnError = _ => -1;
 
     private static readonly Func<Task<int>> TenAsync = () => Task.FromResult(10);
@@ -84,6 +90,9 @@ public sealed class StateOverloadResolutionTests
 
         ok.MapErr(Zero).ShouldBe(Result.Ok<int, int>(1));
         ok.MapErr(10, ErrorState).ShouldBe(Result.Ok<int, int>(1));
+
+        ok.AndThen(OkIncrement).ShouldBe(Result.Ok<int, string>(2));
+        ok.AndThen(10, OkAdd).ShouldBe(Result.Ok<int, string>(11));
     }
 
     /// <remarks>


### PR DESCRIPTION
DRA-84 shipped nine families of closure-avoiding state overloads and gave one
to Option.AndThen but not to Result.AndThen. That was an omission rather than a
decision: its recommended-subset table lists AndThen under Option only, and its
explicitly-excluded section does not mention Result.AndThen at all. The row was
never carried across when the table was written per type.

The two types are meant to be the same shape, and_then is one operation in the
Rust semantics this milestone aligns to, and nothing at a call site explains
why one takes state and the other does not.

Concrete on the base and delegating to the state Map, exactly as Option's does,
so there are no Ok/Err overrides and ClosedHierarchyTests does not grow. Both
pieces it needs already shipped in DRA-84: Result.Map<TState, TOut> and the
Flatten extension on Result<Result<TOk, TErr>, TErr>. Arity separates it from
the one-argument AndThen, satisfying DRA-84's constraint that a state overload
adds the state parameter rather than reusing a slot, and
StateOverloadResolutionTests calls both shapes with stored delegates because a
lambda would let the compiler disambiguate on inferred arity and hide it.

WM2017 needed no analyzer change — it discovers the overload set from the
containing type, so it picked the new overload up on its own. Its test for that
lookup used Result.AndThen as the method with no state overload, which is no
longer true; it now flags that call, and Inspect takes over as the pin. The
reasoning in the descriptor's remark survives, only the example changes.

AndThenAsync is out of scope. DRA-84 excluded every async variant.

Verified: 655 Monads tests on all five frameworks, 288 analyzer tests,
solution builds with no errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>