### PR TITLE
refactor: generate the Option async receiver shapes for eight families

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,32 @@ dropping a family into `WSG0002`.
 for the cases where the source member's own wording does not read well after the await
 prefix.
 
+**A forwarding call must not name the type arguments of a member read from an
+`extension` block.** The generator sees that member as the compatibility static form,
+whose type parameter list is the block's followed by the member's — so
+`MapOrNull<TOut>` arrives as `MapOrNull<T, TOut>`, and writing the member's own
+`<TOut>` onto the reduced call is the wrong arity. The compiler reports that as
+`CS1061`, "no accessible extension method", which reads like a missing `using` and
+sends you looking in the wrong place. `AwaitedReceiverWriter.CallTypeArguments` leaves
+those to inference and writes them out only for a real instance method. The generator
+tests missed this until `MapOrNullExtensions` was converted, because no test double
+had a generic member inside an extension block — a member with no type parameters of
+its own renders identically either way.
+
+**The hand-written extension names drifted from the core members they forward to, and
+that is what limits how much of `Extensions` can be generated.** A generated shape
+takes its parameter and type parameter names from the core member, so a family only
+converts with an untouched baseline when the two already agree. They frequently do
+not: `Option<T>.OkOr(TErr error)` against `OkOrAsync(TErr err)`,
+`OrElse(Func<Option<T>> createElse)` against `OrElseAsync(Func<Option<T>> elseFunc)`,
+`UnwrapOrElse(Func<T> @else)` against `UnwrapOrElseAsync(Func<T> elseFunc)`,
+`ZipWith(Option<TOther> other, …)` against `ZipWithAsync(Option<TOther> otherOption, …)`,
+and `T2` on the core against `TOut` on every extension. Converging a *parameter* name
+is source-breaking through the compat-static form's named arguments and so needs a
+major; converging a *type parameter* name is not breaking but still rewrites baseline
+rows. Check both against `PublicAPI.Shipped.txt` before converting a family — the
+baseline is the instrument, and RS0016/RS0017 name the exact drift.
+
 **A C# 14 extension member's doc comment is an `<inheritdoc>` to an unspeakable type.**
 `GetDocumentationCommentXml()` on the compatibility static form returns
 ``<inheritdoc cref="M:...&lt;G&gt;$3141615614C05E25CF7F3D304921F5B1`1.Foo(...)" />`` — the

--- a/src/Waystone.Monads/Options/Extensions/AsEnumerableExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/AsEnumerableExtensions.cs
@@ -1,45 +1,7 @@
 namespace Waystone.Monads.Options.Extensions;
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class AsEnumerableExtensions
-{
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and returns a sequence over the
-        /// possibly contained value.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing a sequence that yields the
-        /// contained value once if the awaited option was a <see cref="Some{T}" />,
-        /// otherwise an empty sequence.
-        /// </returns>
-        public async ValueTask<IEnumerable<T>> AsEnumerableAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.AsEnumerable();
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and returns a sequence over the
-        /// possibly contained value.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing a sequence that yields the
-        /// contained value once if the awaited option was a <see cref="Some{T}" />,
-        /// otherwise an empty sequence.
-        /// </returns>
-        public async ValueTask<IEnumerable<T>> AsEnumerableAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.AsEnumerable();
-        }
-    }
-}
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.AsEnumerable))]
+public static partial class AsEnumerableExtensions;

--- a/src/Waystone.Monads/Options/Extensions/ExpectExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/ExpectExtensions.cs
@@ -1,51 +1,7 @@
 namespace Waystone.Monads.Options.Extensions;
 
-using System.Threading.Tasks;
-using Exceptions;
+using Waystone.SourceGenerators;
 
-public static class ExpectExtensions
-{
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value.
-        /// </summary>
-        /// <param name="message">
-        /// The message that will be included in the thrown
-        /// exception when the option is none.
-        /// </param>
-        /// <exception cref="UnmetExpectationException">
-        /// Thrown when the awaited
-        /// option is a <see cref="None{T}" />
-        /// </exception>
-        public async ValueTask<T> ExpectAsync(string message)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.Expect(message);
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value.
-        /// </summary>
-        /// <param name="message">
-        /// The message that will be included in the thrown
-        /// exception when the option is none.
-        /// </param>
-        /// <exception cref="UnmetExpectationException">
-        /// Thrown when the awaited
-        /// option is a <see cref="None{T}" />
-        /// </exception>
-        public async ValueTask<T> ExpectAsync(string message)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.Expect(message);
-        }
-    }
-}
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.Expect))]
+public static partial class ExpectExtensions;

--- a/src/Waystone.Monads/Options/Extensions/InspectExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/InspectExtensions.cs
@@ -1,9 +1,12 @@
-﻿namespace Waystone.Monads.Options.Extensions;
+namespace Waystone.Monads.Options.Extensions;
 
 using System;
 using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class InspectExtensions
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.Inspect))]
+public static partial class InspectExtensions
 {
     extension<T>(Option<T> option) where T : notnull
     {
@@ -13,60 +16,6 @@ public static class InspectExtensions
 
             T some = option.Expect("Expected Some but found None.");
             await action.Invoke(some).ConfigureAwait(false);
-
-            return option;
-        }
-    }
-
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        public async ValueTask<Option<T>> InspectAsync(Func<T, Task> action)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            if (option.IsNone) return option;
-
-            T some = option.Expect("Expected Some but found None.");
-            await action.Invoke(some).ConfigureAwait(false);
-
-            return option;
-        }
-
-        public async ValueTask<Option<T>> InspectAsync(Action<T> action)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            if (option.IsNone) return option;
-
-            T some = option.Expect("Expected Some but found None.");
-            action.Invoke(some);
-
-            return option;
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        public async ValueTask<Option<T>> InspectAsync(Func<T, Task> action)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            if (option.IsNone) return option;
-
-            T some = option.Expect("Expected Some but found None.");
-            await action.Invoke(some).ConfigureAwait(false);
-
-            return option;
-        }
-
-        public async ValueTask<Option<T>> InspectAsync(Action<T> action)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            if (option.IsNone) return option;
-
-            T some = option.Expect("Expected Some but found None.");
-            action.Invoke(some);
 
             return option;
         }

--- a/src/Waystone.Monads/Options/Extensions/IsNoneOrExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/IsNoneOrExtensions.cs
@@ -1,9 +1,12 @@
-﻿namespace Waystone.Monads.Options.Extensions;
+namespace Waystone.Monads.Options.Extensions;
 
 using System;
 using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class IsNoneOrExtensions
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.IsNoneOr))]
+public static partial class IsNoneOrExtensions
 {
     extension<T>(Option<T> option) where T : notnull
     {
@@ -30,97 +33,6 @@ public static class IsNoneOrExtensions
             T some = option.Expect("Expected Some but found None.");
 
             return await predicate.Invoke(some).ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Evaluates whether the current <see cref="Option{T}" /> instance is in a "None"
-        /// state or does not satisfy the provided predicate when in a "Some" state.
-        /// </summary>
-        /// <param name="predicate">
-        /// A function to test the value contained in the <see cref="Option{T}" />
-        /// if it is in a "Some" state.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
-        /// <see cref="Option{T}" /> is in a "None" state or if in a "Some" state
-        /// and the predicate evaluates to <see langword="false" /> for the contained
-        /// value;
-        /// otherwise, <see langword="false" />.
-        /// </returns>
-        public async ValueTask<bool> IsNoneOrAsync(Func<T, bool> predicate)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.IsNoneOr(predicate);
-        }
-
-        /// <summary>
-        /// Evaluates whether the current <see cref="Option{T}" /> instance is in a "None"
-        /// state or satisfies the provided asynchronous predicate.
-        /// </summary>
-        /// <param name="predicate">
-        /// An asynchronous function to test the value contained in the
-        /// <see cref="Option{T}" /> if it is in a "Some" state.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
-        /// <see cref="Option{T}" /> is in a "None" state or the predicate evaluates to
-        /// <see langword="true" /> for the contained value; otherwise,
-        /// <see langword="false" />.
-        /// </returns>
-        public async ValueTask<bool> IsNoneOrAsync(Func<T, Task<bool>> predicate)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return await option.IsNoneOrAsync(predicate).ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Evaluates whether the current <see cref="Option{T}" /> instance is in a "None"
-        /// state or satisfies the provided asynchronous predicate when in a "Some" state.
-        /// </summary>
-        /// <param name="predicate">
-        /// An asynchronous function to evaluate the value contained in the
-        /// <see cref="Option{T}" /> if it is in a "Some" state.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
-        /// <see cref="Option{T}" /> is in a "None" state, or if it is in a "Some" state
-        /// and the predicate evaluates to <see langword="true" /> for the contained value;
-        /// otherwise, <see langword="false" />.
-        /// </returns>
-        public async ValueTask<bool> IsNoneOrAsync(Func<T, Task<bool>> predicate)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return await option.IsNoneOrAsync(predicate).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Evaluates whether the current <see cref="Option{T}" /> instance is in a "None"
-        /// state or satisfies the provided predicate.
-        /// </summary>
-        /// <param name="predicate">
-        /// A function to test the value contained in the <see cref="Option{T}" />
-        /// if it is in a "Some" state.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing <see langword="true" /> if the
-        /// <see cref="Option{T}" /> is in a "None" state or the predicate evaluates to
-        /// <see langword="true" /> for the contained value; otherwise,
-        /// <see langword="false" />.
-        /// </returns>
-        public async ValueTask<bool> IsNoneOrAsync(Func<T, bool> predicate)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.IsNoneOr(predicate);
         }
     }
 }

--- a/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
@@ -2,8 +2,10 @@ namespace Waystone.Monads.Options.Extensions;
 
 using System;
 using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class MapOrNullExtensions
+[GenerateAwaitedReceivers(typeof(Option<>))]
+public static partial class MapOrNullExtensions
 {
     extension<T>(Option<T> option) where T : notnull
     {
@@ -46,108 +48,6 @@ public static class MapOrNullExtensions
             Func<T, Task<TOut>> map)
             where TOut : struct
         {
-            if (option.IsNone) return null;
-
-            T some = option.Expect("Expected Some but found None.");
-
-            return await map.Invoke(some).ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and applies <paramref name="map" /> to
-        /// the contained value if the option is a <see cref="Some{T}" />, otherwise
-        /// returns <see langword="null" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to transform the value inside the option if it is
-        /// a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
-            where TOut : struct
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.MapOrNull(map);
-        }
-
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and awaits <paramref name="map" />
-        /// against the contained value if the option is a <see cref="Some{T}" />,
-        /// otherwise returns <see langword="null" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to asynchronously transform the value inside the
-        /// option if it is a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
-            where TOut : struct
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            if (option.IsNone) return null;
-
-            T some = option.Expect("Expected Some but found None.");
-
-            return await map.Invoke(some).ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and applies
-        /// <paramref name="map" /> to the contained value if the option is a
-        /// <see cref="Some{T}" />, otherwise returns <see langword="null" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to transform the value inside the option if it is
-        /// a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, TOut> map)
-            where TOut : struct
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.MapOrNull(map);
-        }
-
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and awaits
-        /// <paramref name="map" /> against the contained value if the option is a
-        /// <see cref="Some{T}" />, otherwise returns <see langword="null" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to asynchronously transform the value inside the
-        /// option if it is a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, otherwise <see langword="null" />.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrNullAsync<TOut>(Func<T, Task<TOut>> map)
-            where TOut : struct
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
             if (option.IsNone) return null;
 
             T some = option.Expect("Expected Some but found None.");

--- a/src/Waystone.Monads/Options/Extensions/ReduceExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/ReduceExtensions.cs
@@ -2,8 +2,11 @@ namespace Waystone.Monads.Options.Extensions;
 
 using System;
 using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class ReduceExtensions
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.Reduce))]
+public static partial class ReduceExtensions
 {
     extension<T>(Option<T> option) where T : notnull
     {
@@ -33,102 +36,6 @@ public static class ReduceExtensions
             T otherSome = other.Expect("Expected Some but found None.");
 
             return await reduce.Invoke(some, otherSome).ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and merges the option with another
-        /// option.
-        /// </summary>
-        /// <param name="other">The option to merge with.</param>
-        /// <param name="reduce">The function that combines two present values.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
-        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
-        /// one of them is, and <see cref="None{T}" /> when neither is.
-        /// </returns>
-        public async ValueTask<Option<T>> ReduceAsync(
-            Option<T> other,
-            Func<T, T, T> reduce)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.Reduce(other, reduce);
-        }
-
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and merges the option with another
-        /// option, awaiting <paramref name="reduce" /> when both are a
-        /// <see cref="Some{T}" />.
-        /// </summary>
-        /// <param name="other">The option to merge with.</param>
-        /// <param name="reduce">
-        /// A function that asynchronously combines two present
-        /// values.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
-        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
-        /// one of them is, and <see cref="None{T}" /> when neither is.
-        /// </returns>
-        public async ValueTask<Option<T>> ReduceAsync(
-            Option<T> other,
-            Func<T, T, Task<T>> reduce)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return await option.ReduceAsync(other, reduce)
-               .ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and merges the option with
-        /// another option.
-        /// </summary>
-        /// <param name="other">The option to merge with.</param>
-        /// <param name="reduce">The function that combines two present values.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
-        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
-        /// one of them is, and <see cref="None{T}" /> when neither is.
-        /// </returns>
-        public async ValueTask<Option<T>> ReduceAsync(
-            Option<T> other,
-            Func<T, T, T> reduce)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.Reduce(other, reduce);
-        }
-
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and merges the option with
-        /// another option, awaiting <paramref name="reduce" /> when both are a
-        /// <see cref="Some{T}" />.
-        /// </summary>
-        /// <param name="other">The option to merge with.</param>
-        /// <param name="reduce">
-        /// A function that asynchronously combines two present
-        /// values.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the combined option when both are a
-        /// <see cref="Some{T}" />, whichever option is a <see cref="Some{T}" /> when only
-        /// one of them is, and <see cref="None{T}" /> when neither is.
-        /// </returns>
-        public async ValueTask<Option<T>> ReduceAsync(
-            Option<T> other,
-            Func<T, T, Task<T>> reduce)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return await option.ReduceAsync(other, reduce)
-               .ConfigureAwait(false);
         }
     }
 }

--- a/src/Waystone.Monads/Options/Extensions/UnwrapExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnwrapExtensions.cs
@@ -1,93 +1,9 @@
 namespace Waystone.Monads.Options.Extensions;
 
-using System.Threading.Tasks;
-using Exceptions;
+using Waystone.SourceGenerators;
 
-public static class UnwrapExtensions
-{
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value.
-        /// </summary>
-        /// <exception cref="UnwrapException">
-        /// Thrown when the awaited option is a
-        /// <see cref="None{T}" />
-        /// </exception>
-        public async ValueTask<T> UnwrapAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.Unwrap();
-        }
-
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value, or the provided default when it is a
-        /// <see cref="None{T}" />.
-        /// </summary>
-        /// <param name="value">The value to return when the option is none.</param>
-        public async ValueTask<T> UnwrapOrAsync(T value)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.UnwrapOr(value);
-        }
-
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value, or the default value of
-        /// <typeparamref name="T" /> when it is a <see cref="None{T}" />.
-        /// </summary>
-        public async ValueTask<T?> UnwrapOrDefaultAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.UnwrapOrDefault();
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value.
-        /// </summary>
-        /// <exception cref="UnwrapException">
-        /// Thrown when the awaited option is a
-        /// <see cref="None{T}" />
-        /// </exception>
-        public async ValueTask<T> UnwrapAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.Unwrap();
-        }
-
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value, or the provided default when it is a
-        /// <see cref="None{T}" />.
-        /// </summary>
-        /// <param name="value">The value to return when the option is none.</param>
-        public async ValueTask<T> UnwrapOrAsync(T value)
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.UnwrapOr(value);
-        }
-
-        /// <summary>
-        /// Asynchronously awaits the <see cref="Option{T}" /> then returns the
-        /// contained <see cref="Some{T}" /> value, or the default value of
-        /// <typeparamref name="T" /> when it is a <see cref="None{T}" />.
-        /// </summary>
-        public async ValueTask<T?> UnwrapOrDefaultAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.UnwrapOrDefault();
-        }
-    }
-}
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.Unwrap))]
+[GenerateAwaitedMember(nameof(Option<>.UnwrapOr))]
+[GenerateAwaitedMember(nameof(Option<>.UnwrapOrDefault))]
+public static partial class UnwrapExtensions;

--- a/src/Waystone.Monads/Options/Extensions/UnwrapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/UnwrapOrNullExtensions.cs
@@ -1,8 +1,10 @@
 namespace Waystone.Monads.Options.Extensions;
 
 using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class UnwrapOrNullExtensions
+[GenerateAwaitedReceivers(typeof(Option<>))]
+public static partial class UnwrapOrNullExtensions
 {
     extension<T>(Option<T> option) where T : struct
     {
@@ -21,44 +23,5 @@ public static class UnwrapOrNullExtensions
         /// otherwise <see langword="null" />.
         /// </returns>
         public T? UnwrapOrNull() => option.Match<T?>(value => value, () => null);
-    }
-
-    extension<T>(Task<Option<T>> optionTask) where T : struct
-    {
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and returns the contained value if
-        /// the option is a <see cref="Some{T}" />, otherwise <see langword="null" />.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the contained value if the
-        /// awaited option was a <see cref="Some{T}" />, otherwise
-        /// <see langword="null" />.
-        /// </returns>
-        public async ValueTask<T?> UnwrapOrNullAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.UnwrapOrNull();
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : struct
-    {
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and returns the contained value
-        /// if the option is a <see cref="Some{T}" />, otherwise
-        /// <see langword="null" />.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the contained value if the
-        /// awaited option was a <see cref="Some{T}" />, otherwise
-        /// <see langword="null" />.
-        /// </returns>
-        public async ValueTask<T?> UnwrapOrNullAsync()
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.UnwrapOrNull();
-        }
     }
 }

--- a/src/Waystone.SourceGenerators/AwaitedReceivers/AwaitedReceiverWriter.cs
+++ b/src/Waystone.SourceGenerators/AwaitedReceivers/AwaitedReceiverWriter.cs
@@ -126,7 +126,7 @@ internal static class AwaitedReceiverWriter
     private static (string ReturnType, string Statement) Invocation(AwaitedMember member)
     {
         var call =
-            $"{Identifiers.Escape(member.ReceiverParameterName)}.{member.Source.Name}{TypeParameters.Render(member.MemberTypeParameters)}({RenderArguments(member.Parameters)})";
+            $"{Identifiers.Escape(member.ReceiverParameterName)}.{member.Source.Name}{CallTypeArguments(member)}({RenderArguments(member.Parameters)})";
 
         ITypeSymbol returns = member.Source.ReturnType;
 
@@ -145,6 +145,18 @@ internal static class AwaitedReceiverWriter
         return ($"{ValueTask}<{returns.ToDisplayString(Display.Format)}>",
             $"return {call};");
     }
+
+    /// <summary>
+    /// The type arguments to write on the forwarding call. A member read from an
+    /// <c>extension</c> block is seen as the compiler's compatibility static form,
+    /// whose type parameter list also carries the block's, so naming only the
+    /// member's own would be the wrong arity for the reduced call. Those are left to
+    /// inference; an instance method's are written out.
+    /// </summary>
+    private static string CallTypeArguments(AwaitedMember member) =>
+        member.Source.TypeParameters.Length == member.MemberTypeParameters.Length
+            ? TypeParameters.Render(member.MemberTypeParameters)
+            : string.Empty;
 
     private static string RenderParameters(ImmutableArray<IParameterSymbol> parameters) =>
         string.Join(", ", parameters.Select(RenderParameter));

--- a/test/Waystone.SourceGenerators.Tests/AwaitedReceiversGeneratorTests.cs
+++ b/test/Waystone.SourceGenerators.Tests/AwaitedReceiversGeneratorTests.cs
@@ -214,6 +214,52 @@ public sealed class AwaitedReceiversGeneratorTests
     }
 
     [Fact]
+    public void LeavesAnExtensionBlockMembersOwnTypeArgumentsToInference()
+    {
+        GeneratorRun run = Verify.Run(
+            Box
+          + """
+            [GenerateAwaitedReceivers(typeof(Box<>))]
+            public static partial class BoxExtensions
+            {
+                extension<T>(Box<T> box) where T : notnull
+                {
+                    /// <summary>Reshapes the value.</summary>
+                    /// <param name="shape">The shaper.</param>
+                    /// <typeparam name="TOut">The reshaped type.</typeparam>
+                    public ValueTask<TOut> ReshapeAsync<TOut>(Func<T, TOut> shape)
+                        where TOut : struct =>
+                        new(shape.Invoke(box.Get()));
+                }
+            }
+            """);
+
+        run.CompilationDiagnostics.ShouldBeEmpty();
+
+        run.Source.ShouldContain("public async global::System.Threading.Tasks.ValueTask<TOut> ReshapeAsync<TOut>(");
+        run.Source.ShouldContain("where TOut : struct");
+        run.Source.ShouldContain("return await box.ReshapeAsync(shape).ConfigureAwait(false);");
+    }
+
+    [Fact]
+    public void WritesAnInstanceMembersOwnTypeArgumentsOnTheCall()
+    {
+        GeneratorRun run = Verify.Run(
+            Box
+          + """
+            [GenerateAwaitedReceivers(typeof(Box<>))]
+            [GenerateAwaitedMember(nameof(Box<>.Map))]
+            public static partial class BoxExtensions
+            {
+            }
+            """);
+
+        run.CompilationDiagnostics.ShouldBeEmpty();
+
+        run.Source.ShouldContain("return box.Map<TOut>(map);");
+    }
+
+    [Fact]
     public void DoesNotWrapAnAlreadyAwaitedReceiverBlock()
     {
         GeneratorRun run = Verify.Run(


### PR DESCRIPTION
Deletes the hand-written Task<Option<T>> and ValueTask<Option<T>> blocks in
AsEnumerable, Expect, Inspect, IsNoneOr, MapOrNull, Reduce, Unwrap and
UnwrapOrNull, and derives them instead from [GenerateAwaitedReceivers]. Net
570 lines of duplicated bodies and doc comments removed for 93 added.

PublicAPI.Shipped.txt is untouched, which is the point: RS0016/RS0017 prove the
generated surface is identical to the hand-written one it replaced.

The remaining thirteen Option families do not convert with an untouched
baseline and are left hand-written:

  - Map, MapOr, MapOrElse, AndThen and Filter would newly emit async shapes for
    the TState overloads, which decision 3 on DRA-86 rules out.
  - OkOr, OkOrElse, OrElse, UnwrapOrElse, ZipWith and MapOrElse forward to a
    core member whose parameter names differ from the extension's, and And and
    MapOrDefault to one whose type parameter is T2 rather than TOut.
  - Flatten, Unzip and Match do not forward to an Option<T> instance method at
    all, so there is nothing for the generator to read.

Also fixes a generator bug the conversion exposed. A member read from an
extension block arrives as the compiler's compatibility static form, whose type
parameter list carries the block's as well, so writing the member's own type
arguments onto the forwarding call is the wrong arity and fails as CS1061.
CallTypeArguments leaves those to inference. Two tests cover both directions;
the existing ones missed it because no test double had a generic member inside
an extension block.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>