### PR TITLE
refactor: name the mapped output type parameter TOut on Option<T>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,13 +237,26 @@ takes its parameter and type parameter names from the core member, so a family o
 converts with an untouched baseline when the two already agree. They frequently do
 not: `Option<T>.OkOr(TErr error)` against `OkOrAsync(TErr err)`,
 `OrElse(Func<Option<T>> createElse)` against `OrElseAsync(Func<Option<T>> elseFunc)`,
-`UnwrapOrElse(Func<T> @else)` against `UnwrapOrElseAsync(Func<T> elseFunc)`,
-`ZipWith(Option<TOther> other, …)` against `ZipWithAsync(Option<TOther> otherOption, …)`,
-and `T2` on the core against `TOut` on every extension. Converging a *parameter* name
-is source-breaking through the compat-static form's named arguments and so needs a
-major; converging a *type parameter* name is not breaking but still rewrites baseline
-rows. Check both against `PublicAPI.Shipped.txt` before converting a family — the
-baseline is the instrument, and RS0016/RS0017 name the exact drift.
+`UnwrapOrElse(Func<T> @else)` against `UnwrapOrElseAsync(Func<T> elseFunc)`, and
+`ZipWith(Option<TOther> other, …)` against `ZipWithAsync(Option<TOther> otherOption, …)`.
+Check against `PublicAPI.Shipped.txt` before converting a family — the baseline is the
+instrument, and RS0016/RS0017 name the exact drift.
+
+The two kinds of drift cost very different amounts, so do not lump them together. A
+**parameter** rename is source-breaking: named arguments work in reduced extension
+syntax, so `option.OkOrAsync(err: e)` compiles today and would stop, and a parameter
+name cannot be obsoleted, so there is no deprecate-then-remove path. Those wait for a
+major. A **type parameter** rename breaks nothing at all, because no call site can name
+one — which is why the `T2`/`TOut` drift that used to sit in this list is gone. The core
+now names the mapped output `TOut` everywhere, matching the extensions and the published
+documentation, and that landed as an ordinary non-breaking `refactor:`. What the baseline
+proves in that case is not that nothing moved but that nothing was *added or removed*:
+every RS0017 paired with an RS0016 differing only in the name.
+
+`Zip` is the exception that shows the rule is about roles, not spelling: it takes
+`TOther`, because its type parameter is the other input element rather than an output —
+the role `ZipWith` already spells that way. `Unzip<T1, T2>` keeps `T1` and `T2`, which
+are tuple positions. Do not sweep those into a `TOut` rename.
 
 **A C# 14 extension member's doc comment is an `<inheritdoc>` to an unspeakable type.**
 `GetDocumentationCommentXml()` on the compatibility static form returns

--- a/src/Waystone.Monads/Options/Extensions/AndExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/AndExtensions.cs
@@ -1,58 +1,7 @@
 namespace Waystone.Monads.Options.Extensions;
 
-using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class AndExtensions
-{
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and returns <see cref="None{T}" /> if
-        /// the option is a <see cref="None{T}" />, otherwise returns
-        /// <paramref name="other" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the value contained in the other option.</typeparam>
-        /// <param name="other">
-        /// The option to return when the awaited option is a
-        /// <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" /> containing
-        /// <paramref name="other" /> if the awaited option was a <see cref="Some{T}" />,
-        /// or <see cref="None{T}" /> otherwise.
-        /// </returns>
-        public async ValueTask<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
-            where TOut : notnull
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.And(other);
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and returns
-        /// <see cref="None{T}" /> if the option is a <see cref="None{T}" />, otherwise
-        /// returns <paramref name="other" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the value contained in the other option.</typeparam>
-        /// <param name="other">
-        /// The option to return when the awaited option is a
-        /// <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> of <see cref="Option{TOut}" /> containing
-        /// <paramref name="other" /> if the awaited option was a <see cref="Some{T}" />,
-        /// or <see cref="None{T}" /> otherwise.
-        /// </returns>
-        public async ValueTask<Option<TOut>> AndAsync<TOut>(Option<TOut> other)
-            where TOut : notnull
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.And(other);
-        }
-    }
-}
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.And))]
+public static partial class AndExtensions;

--- a/src/Waystone.Monads/Options/Extensions/MapOrDefaultExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrDefaultExtensions.cs
@@ -2,8 +2,11 @@ namespace Waystone.Monads.Options.Extensions;
 
 using System;
 using System.Threading.Tasks;
+using Waystone.SourceGenerators;
 
-public static class MapOrDefaultExtensions
+[GenerateAwaitedReceivers(typeof(Option<>))]
+[GenerateAwaitedMember(nameof(Option<>.MapOrDefault))]
+public static partial class MapOrDefaultExtensions
 {
     extension<T>(Option<T> option) where T : notnull
     {
@@ -26,117 +29,6 @@ public static class MapOrDefaultExtensions
             Func<T, Task<TOut>> map)
             where TOut : notnull
         {
-            if (option.IsNone) return default;
-
-            T some = option.Expect("Expected Some but found None.");
-
-            return await map.Invoke(some).ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(Task<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and applies <paramref name="map" /> to
-        /// the contained value if the option is a <see cref="Some{T}" />, otherwise
-        /// returns the <see langword="default" /> of <typeparamref name="TOut" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to transform the value inside the option if it is
-        /// a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
-        /// <typeparamref name="TOut" /> otherwise.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
-            where TOut : notnull
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.MapOrDefault(map);
-        }
-
-        /// <summary>
-        /// Awaits the <see cref="Task{TResult}" /> and awaits <paramref name="map" />
-        /// against the contained value if the option is a <see cref="Some{T}" />,
-        /// otherwise returns the <see langword="default" /> of
-        /// <typeparamref name="TOut" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to asynchronously transform the value inside the
-        /// option if it is a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
-        /// <typeparamref name="TOut" /> otherwise.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
-            Func<T, Task<TOut>> map)
-            where TOut : notnull
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            if (option.IsNone) return default;
-
-            T some = option.Expect("Expected Some but found None.");
-
-            return await map.Invoke(some).ConfigureAwait(false);
-        }
-    }
-
-    extension<T>(ValueTask<Option<T>> optionTask) where T : notnull
-    {
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and applies
-        /// <paramref name="map" /> to the contained value if the option is a
-        /// <see cref="Some{T}" />, otherwise returns the <see langword="default" /> of
-        /// <typeparamref name="TOut" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to transform the value inside the option if it is
-        /// a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
-        /// <typeparamref name="TOut" /> otherwise.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(Func<T, TOut> map)
-            where TOut : notnull
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
-            return option.MapOrDefault(map);
-        }
-
-        /// <summary>
-        /// Awaits the <see cref="ValueTask{TResult}" /> and awaits
-        /// <paramref name="map" /> against the contained value if the option is a
-        /// <see cref="Some{T}" />, otherwise returns the <see langword="default" /> of
-        /// <typeparamref name="TOut" />.
-        /// </summary>
-        /// <typeparam name="TOut">The type of the output value.</typeparam>
-        /// <param name="map">
-        /// A function to asynchronously transform the value inside the
-        /// option if it is a <see cref="Some{T}" />.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}" /> containing the transformed value if the awaited
-        /// option was a <see cref="Some{T}" />, or the <see langword="default" /> of
-        /// <typeparamref name="TOut" /> otherwise.
-        /// </returns>
-        public async ValueTask<TOut?> MapOrDefaultAsync<TOut>(
-            Func<T, Task<TOut>> map)
-            where TOut : notnull
-        {
-            Option<T> option = await optionTask.ConfigureAwait(false);
-
             if (option.IsNone) return default;
 
             T some = option.Expect("Expected Some but found None.");

--- a/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
+++ b/src/Waystone.Monads/Options/Extensions/MapOrNullExtensions.cs
@@ -14,7 +14,7 @@ public static partial class MapOrNullExtensions
         /// <see cref="Some{T}" />, otherwise returns <see langword="null" />.
         /// </summary>
         /// <remarks>
-        /// Prefer this to <see cref="Option{T}.MapOrDefault{T2}" /> when
+        /// Prefer this to <see cref="Option{T}.MapOrDefault{TOut}" /> when
         /// <typeparamref name="TOut" /> is a value type. <c>MapOrDefault</c> returns the
         /// default of <typeparamref name="TOut" /> for a <see cref="None{T}" />, which is
         /// indistinguishable from a legitimate zero.

--- a/src/Waystone.Monads/Options/None.cs
+++ b/src/Waystone.Monads/Options/None.cs
@@ -1,4 +1,4 @@
-﻿namespace Waystone.Monads.Options;
+namespace Waystone.Monads.Options;
 
 using System;
 using System.Collections.Generic;
@@ -71,42 +71,42 @@ public sealed record None<T> : Option<T>
         @else();
 
     /// <inheritdoc />
-    public override Option<T2> And<T2>(Option<T2> other) =>
-        Option.None<T2>();
+    public override Option<TOut> And<TOut>(Option<TOut> other) =>
+        Option.None<TOut>();
 
     /// <inheritdoc />
-    public override Option<T2> Map<T2>(Func<T, T2> map) =>
-        Option.None<T2>();
+    public override Option<TOut> Map<TOut>(Func<T, TOut> map) =>
+        Option.None<TOut>();
 
     /// <inheritdoc />
-    public override Option<T2> Map<TState, T2>(
+    public override Option<TOut> Map<TState, TOut>(
         TState state,
-        Func<T, TState, T2> map) => Option.None<T2>();
+        Func<T, TState, TOut> map) => Option.None<TOut>();
 
     /// <inheritdoc />
-    public override T2 MapOr<T2>(T2 @default, Func<T, T2> map) =>
+    public override TOut MapOr<TOut>(TOut @default, Func<T, TOut> map) =>
         @default;
 
     /// <inheritdoc />
-    public override T2 MapOr<TState, T2>(
+    public override TOut MapOr<TState, TOut>(
         TState state,
-        T2 @default,
-        Func<T, TState, T2> map) => @default;
+        TOut @default,
+        Func<T, TState, TOut> map) => @default;
 
     /// <inheritdoc />
-    public override T2 MapOrDefault<T2>(Func<T, T2> map) =>
+    public override TOut MapOrDefault<TOut>(Func<T, TOut> map) =>
         default!;
 
     /// <inheritdoc />
-    public override T2 MapOrElse<T2>(
-        Func<T2> createDefault,
-        Func<T, T2> map) => createDefault();
+    public override TOut MapOrElse<TOut>(
+        Func<TOut> createDefault,
+        Func<T, TOut> map) => createDefault();
 
     /// <inheritdoc />
-    public override T2 MapOrElse<TState, T2>(
+    public override TOut MapOrElse<TState, TOut>(
         TState state,
-        Func<TState, T2> createDefault,
-        Func<T, TState, T2> map) => createDefault(state);
+        Func<TState, TOut> createDefault,
+        Func<T, TState, TOut> map) => createDefault(state);
 
     /// <inheritdoc />
     public override Option<T> Inspect(Action<T> action) =>
@@ -134,8 +134,8 @@ public sealed record None<T> : Option<T>
         other.IsSome ? other : this;
 
     /// <inheritdoc />
-    public override Option<(T, T2)> Zip<T2>(Option<T2> other) =>
-        Option.None<(T, T2)>();
+    public override Option<(T, TOther)> Zip<TOther>(Option<TOther> other) =>
+        Option.None<(T, TOther)>();
 
     /// <inheritdoc />
     public override Option<TOut> ZipWith<TOther, TOut>(

--- a/src/Waystone.Monads/Options/OptionOfT.cs
+++ b/src/Waystone.Monads/Options/OptionOfT.cs
@@ -1,4 +1,4 @@
-﻿namespace Waystone.Monads.Options;
+namespace Waystone.Monads.Options;
 
 using System;
 using System.Collections.Generic;
@@ -127,16 +127,16 @@ public abstract record Option<T> where T : notnull
     public abstract T UnwrapOrElse(Func<T> @else);
 
     /// <summary>
-    /// Maps an <c>Option&lt;T&gt;</c> to an <c>Option&lt;T2&gt;</c> by
+    /// Maps an <c>Option&lt;T&gt;</c> to an <c>Option&lt;TOut&gt;</c> by
     /// applying a function to a contained value (if <see cref="Some{T}" />) or returns
     /// <see cref="None{T}" /> (if <see cref="None{T}" />).
     /// </summary>
     /// <param name="map">The map function.</param>
-    /// <typeparam name="T2">The return type of the map function.</typeparam>
-    public abstract Option<T2> Map<T2>(Func<T, T2> map) where T2 : notnull;
+    /// <typeparam name="TOut">The return type of the map function.</typeparam>
+    public abstract Option<TOut> Map<TOut>(Func<T, TOut> map) where TOut : notnull;
 
     /// <summary>
-    /// Maps an <c>Option&lt;T&gt;</c> to an <c>Option&lt;T2&gt;</c> by
+    /// Maps an <c>Option&lt;T&gt;</c> to an <c>Option&lt;TOut&gt;</c> by
     /// applying a function to a contained value (if <see cref="Some{T}" />) or returns
     /// <see cref="None{T}" /> (if <see cref="None{T}" />).
     /// </summary>
@@ -148,10 +148,10 @@ public abstract record Option<T> where T : notnull
     /// <param name="state">The value passed to the map function.</param>
     /// <param name="map">The map function.</param>
     /// <typeparam name="TState">The type of the state passed to the map function.</typeparam>
-    /// <typeparam name="T2">The return type of the map function.</typeparam>
-    public abstract Option<T2> Map<TState, T2>(
+    /// <typeparam name="TOut">The return type of the map function.</typeparam>
+    public abstract Option<TOut> Map<TState, TOut>(
         TState state,
-        Func<T, TState, T2> map) where T2 : notnull;
+        Func<T, TState, TOut> map) where TOut : notnull;
 
     /// <summary>
     /// Returns <see cref="None{T}" /> if the option is a <see cref="None{T}" />,
@@ -159,12 +159,12 @@ public abstract record Option<T> where T : notnull
     /// </summary>
     /// <remarks>
     /// <paramref name="other" /> is eagerly evaluated. If you are passing the
-    /// result of a function call, prefer <see cref="AndThen{T2}" />, which is
+    /// result of a function call, prefer <see cref="AndThen{TOut}" />, which is
     /// lazily evaluated.
     /// </remarks>
     /// <param name="other">The option to return when this one is a <see cref="Some{T}" />.</param>
-    /// <typeparam name="T2">The type of the value contained in the other option.</typeparam>
-    public abstract Option<T2> And<T2>(Option<T2> other) where T2 : notnull;
+    /// <typeparam name="TOut">The type of the value contained in the other option.</typeparam>
+    public abstract Option<TOut> And<TOut>(Option<TOut> other) where TOut : notnull;
 
     /// <summary>
     /// Returns <see cref="None{T}" /> if the option is a <see cref="None{T}" />,
@@ -179,15 +179,15 @@ public abstract record Option<T> where T : notnull
     /// A transform function to apply to the inner value if the
     /// option is a <see cref="Some{T}" />.
     /// </param>
-    /// <typeparam name="T2">The type of the value contained in the resulting option.</typeparam>
+    /// <typeparam name="TOut">The type of the value contained in the resulting option.</typeparam>
     /// <returns>
-    /// A flattened <see cref="Option{T2}" /> resulting from applying the
+    /// A flattened <see cref="Option{TOut}" /> resulting from applying the
     /// transform function and flattening the nested option.
     /// </returns>
 #if !DEBUG
     [DebuggerStepThrough]
 #endif
-    public Option<T2> AndThen<T2>(Func<T, Option<T2>> map) where T2 : notnull =>
+    public Option<TOut> AndThen<TOut>(Func<T, Option<TOut>> map) where TOut : notnull =>
         Map(map).Flatten();
 
     /// <summary>
@@ -206,17 +206,17 @@ public abstract record Option<T> where T : notnull
     /// option is a <see cref="Some{T}" />.
     /// </param>
     /// <typeparam name="TState">The type of the state passed to the map function.</typeparam>
-    /// <typeparam name="T2">The type of the value contained in the resulting option.</typeparam>
+    /// <typeparam name="TOut">The type of the value contained in the resulting option.</typeparam>
     /// <returns>
-    /// A flattened <see cref="Option{T2}" /> resulting from applying the
+    /// A flattened <see cref="Option{TOut}" /> resulting from applying the
     /// transform function and flattening the nested option.
     /// </returns>
 #if !DEBUG
     [DebuggerStepThrough]
 #endif
-    public Option<T2> AndThen<TState, T2>(
+    public Option<TOut> AndThen<TState, TOut>(
         TState state,
-        Func<T, TState, Option<T2>> map) where T2 : notnull =>
+        Func<T, TState, Option<TOut>> map) where TOut : notnull =>
         Map(state, map).Flatten();
 
     /// <summary>
@@ -225,8 +225,8 @@ public abstract record Option<T> where T : notnull
     /// </summary>
     /// <param name="default">The default value for a <see cref="None{T}" />.</param>
     /// <param name="map">The map function.</param>
-    /// <typeparam name="T2">The return type of the map function.</typeparam>
-    public abstract T2 MapOr<T2>(T2 @default, Func<T, T2> map);
+    /// <typeparam name="TOut">The return type of the map function.</typeparam>
+    public abstract TOut MapOr<TOut>(TOut @default, Func<T, TOut> map);
 
     /// <summary>
     /// Returns the provided default result (if <see cref="None{T}" />), or
@@ -241,20 +241,20 @@ public abstract record Option<T> where T : notnull
     /// <param name="default">The default value for a <see cref="None{T}" />.</param>
     /// <param name="map">The map function.</param>
     /// <typeparam name="TState">The type of the state passed to the map function.</typeparam>
-    /// <typeparam name="T2">The return type of the map function.</typeparam>
-    public abstract T2 MapOr<TState, T2>(
+    /// <typeparam name="TOut">The return type of the map function.</typeparam>
+    public abstract TOut MapOr<TState, TOut>(
         TState state,
-        T2 @default,
-        Func<T, TState, T2> map);
+        TOut @default,
+        Func<T, TState, TOut> map);
 
     /// <summary>
-    /// Returns the <see langword="default" /> of <typeparamref name="T2" /> (if
+    /// Returns the <see langword="default" /> of <typeparamref name="TOut" /> (if
     /// <see cref="None{T}" />), or applies a function to the contained value (if
     /// <see cref="Some{T}" />).
     /// </summary>
     /// <param name="map">The map function.</param>
-    /// <typeparam name="T2">The return type of the map function.</typeparam>
-    public abstract T2? MapOrDefault<T2>(Func<T, T2> map) where T2 : notnull;
+    /// <typeparam name="TOut">The return type of the map function.</typeparam>
+    public abstract TOut? MapOrDefault<TOut>(Func<T, TOut> map) where TOut : notnull;
 
     /// <summary>
     /// Computes a default from a function (if <see cref="None{T}" />), or
@@ -265,8 +265,8 @@ public abstract record Option<T> where T : notnull
     /// <see cref="None{T}" />.
     /// </param>
     /// <param name="map">The map function.</param>
-    /// <typeparam name="T2">The return type of the map function.</typeparam>
-    public abstract T2 MapOrElse<T2>(Func<T2> createDefault, Func<T, T2> map);
+    /// <typeparam name="TOut">The return type of the map function.</typeparam>
+    public abstract TOut MapOrElse<TOut>(Func<TOut> createDefault, Func<T, TOut> map);
 
     /// <summary>
     /// Computes a default from a function (if <see cref="None{T}" />), or
@@ -284,11 +284,11 @@ public abstract record Option<T> where T : notnull
     /// </param>
     /// <param name="map">The map function.</param>
     /// <typeparam name="TState">The type of the state passed to both functions.</typeparam>
-    /// <typeparam name="T2">The return type of the map function.</typeparam>
-    public abstract T2 MapOrElse<TState, T2>(
+    /// <typeparam name="TOut">The return type of the map function.</typeparam>
+    public abstract TOut MapOrElse<TState, TOut>(
         TState state,
-        Func<TState, T2> createDefault,
-        Func<T, TState, T2> map);
+        Func<TState, TOut> createDefault,
+        Func<T, TState, TOut> map);
 
     /// <summary>
     /// Calls a function with a reference to the contained value if
@@ -363,14 +363,14 @@ public abstract record Option<T> where T : notnull
     /// a tuple.
     /// </summary>
     /// <param name="other">The other option.</param>
-    /// <typeparam name="T2">The type of the value contained in the other option.</typeparam>
+    /// <typeparam name="TOther">The type of the value contained in the other option.</typeparam>
     /// <returns>
     /// If the current option is <see cref="Some{T}" /> and
     /// <paramref name="other" /> is <see cref="Some{T}" />, this method returns
-    /// <c>Some&lt;(T, T2)&gt;</c>. Otherwise, <c>None&lt;(T, T2)&gt;</c> is returned.
+    /// <c>Some&lt;(T, TOther)&gt;</c>. Otherwise, <c>None&lt;(T, TOther)&gt;</c> is returned.
     /// </returns>
-    public abstract Option<(T, T2)> Zip<T2>(Option<T2> other)
-        where T2 : notnull;
+    public abstract Option<(T, TOther)> Zip<TOther>(Option<TOther> other)
+        where TOther : notnull;
 
     /// <summary>
     /// Zips the current option with another option using the provided

--- a/src/Waystone.Monads/Options/Some.cs
+++ b/src/Waystone.Monads/Options/Some.cs
@@ -1,4 +1,4 @@
-﻿namespace Waystone.Monads.Options;
+namespace Waystone.Monads.Options;
 
 using System;
 using System.Collections.Generic;
@@ -77,42 +77,42 @@ public sealed record Some<T> : Option<T>
         Value;
 
     /// <inheritdoc />
-    public override Option<T2> And<T2>(Option<T2> other) =>
+    public override Option<TOut> And<TOut>(Option<TOut> other) =>
         other;
 
     /// <inheritdoc />
-    public override Option<T2> Map<T2>(Func<T, T2> map) =>
+    public override Option<TOut> Map<TOut>(Func<T, TOut> map) =>
         map(Value);
 
     /// <inheritdoc />
-    public override Option<T2> Map<TState, T2>(
+    public override Option<TOut> Map<TState, TOut>(
         TState state,
-        Func<T, TState, T2> map) => map(Value, state);
+        Func<T, TState, TOut> map) => map(Value, state);
 
     /// <inheritdoc />
-    public override T2 MapOr<T2>(T2 @default, Func<T, T2> map) =>
+    public override TOut MapOr<TOut>(TOut @default, Func<T, TOut> map) =>
         map(Value);
 
     /// <inheritdoc />
-    public override T2 MapOr<TState, T2>(
+    public override TOut MapOr<TState, TOut>(
         TState state,
-        T2 @default,
-        Func<T, TState, T2> map) => map(Value, state);
+        TOut @default,
+        Func<T, TState, TOut> map) => map(Value, state);
 
     /// <inheritdoc />
-    public override T2 MapOrDefault<T2>(Func<T, T2> map) =>
+    public override TOut MapOrDefault<TOut>(Func<T, TOut> map) =>
         map(Value);
 
     /// <inheritdoc />
-    public override T2 MapOrElse<T2>(
-        Func<T2> createDefault,
-        Func<T, T2> map) => Match(map, createDefault);
+    public override TOut MapOrElse<TOut>(
+        Func<TOut> createDefault,
+        Func<T, TOut> map) => Match(map, createDefault);
 
     /// <inheritdoc />
-    public override T2 MapOrElse<TState, T2>(
+    public override TOut MapOrElse<TState, TOut>(
         TState state,
-        Func<TState, T2> createDefault,
-        Func<T, TState, T2> map) => map(Value, state);
+        Func<TState, TOut> createDefault,
+        Func<T, TState, TOut> map) => map(Value, state);
 
     /// <inheritdoc />
     public override Option<T> Inspect(Action<T> action)
@@ -144,14 +144,14 @@ public sealed record Some<T> : Option<T>
         other.IsSome ? Option.None<T>() : this;
 
     /// <inheritdoc />
-    public override Option<(T, T2)> Zip<T2>(Option<T2> other)
+    public override Option<(T, TOther)> Zip<TOther>(Option<TOther> other)
     {
-        if (other is Some<T2> otherSome)
+        if (other is Some<TOther> otherSome)
         {
             return Option.Some((Value, otherSome.Value));
         }
 
-        return Option.None<(T, T2)>();
+        return Option.None<(T, TOther)>();
     }
 
     /// <inheritdoc />

--- a/src/Waystone.Monads/PublicAPI.Shipped.txt
+++ b/src/Waystone.Monads/PublicAPI.Shipped.txt
@@ -230,8 +230,8 @@ Waystone.Monads.Options.None<T>.Equals(Waystone.Monads.Options.None<T>? other) -
 Waystone.Monads.Options.None<T>.None() -> void
 Waystone.Monads.Options.Option
 Waystone.Monads.Options.Option<T>
-Waystone.Monads.Options.Option<T>.AndThen<T2>(System.Func<T, Waystone.Monads.Options.Option<T2>!>! map) -> Waystone.Monads.Options.Option<T2>!
-Waystone.Monads.Options.Option<T>.AndThen<TState, T2>(TState state, System.Func<T, TState, Waystone.Monads.Options.Option<T2>!>! map) -> Waystone.Monads.Options.Option<T2>!
+Waystone.Monads.Options.Option<T>.AndThen<TOut>(System.Func<T, Waystone.Monads.Options.Option<TOut>!>! map) -> Waystone.Monads.Options.Option<TOut>!
+Waystone.Monads.Options.Option<T>.AndThen<TState, TOut>(TState state, System.Func<T, TState, Waystone.Monads.Options.Option<TOut>!>! map) -> Waystone.Monads.Options.Option<TOut>!
 Waystone.Monads.Options.Option<T>.Option(Waystone.Monads.Options.Option<T>! original) -> void
 Waystone.Monads.Options.Some<T>
 Waystone.Monads.Options.Some<T>.Equals(Waystone.Monads.Options.Some<T>? other) -> bool
@@ -436,7 +436,7 @@ Waystone.Monads.Results.Result<TOk, TErr>
 Waystone.Monads.Results.Result<TOk, TErr>.AndThen<TState, TOut>(TState state, System.Func<TOk, TState, Waystone.Monads.Results.Result<TOut, TErr>!>! createOther) -> Waystone.Monads.Results.Result<TOut, TErr>!
 Waystone.Monads.Results.Result<TOk, TErr>.Result(Waystone.Monads.Results.Result<TOk, TErr>! original) -> void
 abstract Waystone.Monads.Options.Option<T>.<Clone>$() -> Waystone.Monads.Options.Option<T>!
-abstract Waystone.Monads.Options.Option<T>.And<T2>(Waystone.Monads.Options.Option<T2>! other) -> Waystone.Monads.Options.Option<T2>!
+abstract Waystone.Monads.Options.Option<T>.And<TOut>(Waystone.Monads.Options.Option<TOut>! other) -> Waystone.Monads.Options.Option<TOut>!
 abstract Waystone.Monads.Options.Option<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>!
 abstract Waystone.Monads.Options.Option<T>.Expect(string! message) -> T
 abstract Waystone.Monads.Options.Option<T>.Filter(System.Func<T, bool>! predicate) -> Waystone.Monads.Options.Option<T>!
@@ -446,13 +446,13 @@ abstract Waystone.Monads.Options.Option<T>.IsNone.get -> bool
 abstract Waystone.Monads.Options.Option<T>.IsNoneOr(System.Func<T, bool>! predicate) -> bool
 abstract Waystone.Monads.Options.Option<T>.IsSome.get -> bool
 abstract Waystone.Monads.Options.Option<T>.IsSomeAnd(System.Func<T, bool>! predicate) -> bool
-abstract Waystone.Monads.Options.Option<T>.Map<T2>(System.Func<T, T2>! map) -> Waystone.Monads.Options.Option<T2>!
-abstract Waystone.Monads.Options.Option<T>.Map<TState, T2>(TState state, System.Func<T, TState, T2>! map) -> Waystone.Monads.Options.Option<T2>!
-abstract Waystone.Monads.Options.Option<T>.MapOr<T2>(T2 default, System.Func<T, T2>! map) -> T2
-abstract Waystone.Monads.Options.Option<T>.MapOr<TState, T2>(TState state, T2 default, System.Func<T, TState, T2>! map) -> T2
-abstract Waystone.Monads.Options.Option<T>.MapOrDefault<T2>(System.Func<T, T2>! map) -> T2?
-abstract Waystone.Monads.Options.Option<T>.MapOrElse<T2>(System.Func<T2>! createDefault, System.Func<T, T2>! map) -> T2
-abstract Waystone.Monads.Options.Option<T>.MapOrElse<TState, T2>(TState state, System.Func<TState, T2>! createDefault, System.Func<T, TState, T2>! map) -> T2
+abstract Waystone.Monads.Options.Option<T>.Map<TOut>(System.Func<T, TOut>! map) -> Waystone.Monads.Options.Option<TOut>!
+abstract Waystone.Monads.Options.Option<T>.Map<TState, TOut>(TState state, System.Func<T, TState, TOut>! map) -> Waystone.Monads.Options.Option<TOut>!
+abstract Waystone.Monads.Options.Option<T>.MapOr<TOut>(TOut default, System.Func<T, TOut>! map) -> TOut
+abstract Waystone.Monads.Options.Option<T>.MapOr<TState, TOut>(TState state, TOut default, System.Func<T, TState, TOut>! map) -> TOut
+abstract Waystone.Monads.Options.Option<T>.MapOrDefault<TOut>(System.Func<T, TOut>! map) -> TOut?
+abstract Waystone.Monads.Options.Option<T>.MapOrElse<TOut>(System.Func<TOut>! createDefault, System.Func<T, TOut>! map) -> TOut
+abstract Waystone.Monads.Options.Option<T>.MapOrElse<TState, TOut>(TState state, System.Func<TState, TOut>! createDefault, System.Func<T, TState, TOut>! map) -> TOut
 abstract Waystone.Monads.Options.Option<T>.Match(System.Action<T>! onSome, System.Action! onNone) -> void
 abstract Waystone.Monads.Options.Option<T>.Match<TOut>(System.Func<T, TOut>! onSome, System.Func<TOut>! onNone) -> TOut
 abstract Waystone.Monads.Options.Option<T>.OkOr<TErr>(TErr error) -> Waystone.Monads.Results.Result<T, TErr>!
@@ -465,7 +465,7 @@ abstract Waystone.Monads.Options.Option<T>.UnwrapOr(T value) -> T
 abstract Waystone.Monads.Options.Option<T>.UnwrapOrDefault() -> T?
 abstract Waystone.Monads.Options.Option<T>.UnwrapOrElse(System.Func<T>! else) -> T
 abstract Waystone.Monads.Options.Option<T>.Xor(Waystone.Monads.Options.Option<T>! other) -> Waystone.Monads.Options.Option<T>!
-abstract Waystone.Monads.Options.Option<T>.Zip<T2>(Waystone.Monads.Options.Option<T2>! other) -> Waystone.Monads.Options.Option<(T, T2)>!
+abstract Waystone.Monads.Options.Option<T>.Zip<TOther>(Waystone.Monads.Options.Option<TOther>! other) -> Waystone.Monads.Options.Option<(T, TOther)>!
 abstract Waystone.Monads.Options.Option<T>.ZipWith<TOther, TOut>(Waystone.Monads.Options.Option<TOther>! other, System.Func<T, TOther, TOut>! zip) -> Waystone.Monads.Options.Option<TOut>!
 abstract Waystone.Monads.Results.Result<TOk, TErr>.<Clone>$() -> Waystone.Monads.Results.Result<TOk, TErr>!
 abstract Waystone.Monads.Results.Result<TOk, TErr>.And<TOut>(Waystone.Monads.Results.Result<TOut, TErr>! other) -> Waystone.Monads.Results.Result<TOut, TErr>!
@@ -503,7 +503,7 @@ override Waystone.Monads.Configs.CallerInfo.Equals(object? obj) -> bool
 override Waystone.Monads.Configs.CallerInfo.GetHashCode() -> int
 override Waystone.Monads.Configs.CallerInfo.ToString() -> string!
 override Waystone.Monads.Options.None<T>.<Clone>$() -> Waystone.Monads.Options.Option<T>!
-override Waystone.Monads.Options.None<T>.And<T2>(Waystone.Monads.Options.Option<T2>! other) -> Waystone.Monads.Options.Option<T2>!
+override Waystone.Monads.Options.None<T>.And<TOut>(Waystone.Monads.Options.Option<TOut>! other) -> Waystone.Monads.Options.Option<TOut>!
 override Waystone.Monads.Options.None<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>!
 override Waystone.Monads.Options.None<T>.Equals(object? obj) -> bool
 override Waystone.Monads.Options.None<T>.Expect(string! message) -> T
@@ -515,13 +515,13 @@ override Waystone.Monads.Options.None<T>.IsNone.get -> bool
 override Waystone.Monads.Options.None<T>.IsNoneOr(System.Func<T, bool>! predicate) -> bool
 override Waystone.Monads.Options.None<T>.IsSome.get -> bool
 override Waystone.Monads.Options.None<T>.IsSomeAnd(System.Func<T, bool>! predicate) -> bool
-override Waystone.Monads.Options.None<T>.Map<T2>(System.Func<T, T2>! map) -> Waystone.Monads.Options.Option<T2>!
-override Waystone.Monads.Options.None<T>.Map<TState, T2>(TState state, System.Func<T, TState, T2>! map) -> Waystone.Monads.Options.Option<T2>!
-override Waystone.Monads.Options.None<T>.MapOr<T2>(T2 default, System.Func<T, T2>! map) -> T2
-override Waystone.Monads.Options.None<T>.MapOr<TState, T2>(TState state, T2 default, System.Func<T, TState, T2>! map) -> T2
-override Waystone.Monads.Options.None<T>.MapOrDefault<T2>(System.Func<T, T2>! map) -> T2
-override Waystone.Monads.Options.None<T>.MapOrElse<T2>(System.Func<T2>! createDefault, System.Func<T, T2>! map) -> T2
-override Waystone.Monads.Options.None<T>.MapOrElse<TState, T2>(TState state, System.Func<TState, T2>! createDefault, System.Func<T, TState, T2>! map) -> T2
+override Waystone.Monads.Options.None<T>.Map<TOut>(System.Func<T, TOut>! map) -> Waystone.Monads.Options.Option<TOut>!
+override Waystone.Monads.Options.None<T>.Map<TState, TOut>(TState state, System.Func<T, TState, TOut>! map) -> Waystone.Monads.Options.Option<TOut>!
+override Waystone.Monads.Options.None<T>.MapOr<TOut>(TOut default, System.Func<T, TOut>! map) -> TOut
+override Waystone.Monads.Options.None<T>.MapOr<TState, TOut>(TState state, TOut default, System.Func<T, TState, TOut>! map) -> TOut
+override Waystone.Monads.Options.None<T>.MapOrDefault<TOut>(System.Func<T, TOut>! map) -> TOut
+override Waystone.Monads.Options.None<T>.MapOrElse<TOut>(System.Func<TOut>! createDefault, System.Func<T, TOut>! map) -> TOut
+override Waystone.Monads.Options.None<T>.MapOrElse<TState, TOut>(TState state, System.Func<TState, TOut>! createDefault, System.Func<T, TState, TOut>! map) -> TOut
 override Waystone.Monads.Options.None<T>.Match(System.Action<T>! onSome, System.Action! onNone) -> void
 override Waystone.Monads.Options.None<T>.Match<TOut>(System.Func<T, TOut>! onSome, System.Func<TOut>! onNone) -> TOut
 override Waystone.Monads.Options.None<T>.OkOr<TErr>(TErr error) -> Waystone.Monads.Results.Result<T, TErr>!
@@ -535,13 +535,13 @@ override Waystone.Monads.Options.None<T>.UnwrapOr(T value) -> T
 override Waystone.Monads.Options.None<T>.UnwrapOrDefault() -> T?
 override Waystone.Monads.Options.None<T>.UnwrapOrElse(System.Func<T>! else) -> T
 override Waystone.Monads.Options.None<T>.Xor(Waystone.Monads.Options.Option<T>! other) -> Waystone.Monads.Options.Option<T>!
-override Waystone.Monads.Options.None<T>.Zip<T2>(Waystone.Monads.Options.Option<T2>! other) -> Waystone.Monads.Options.Option<(T, T2)>!
+override Waystone.Monads.Options.None<T>.Zip<TOther>(Waystone.Monads.Options.Option<TOther>! other) -> Waystone.Monads.Options.Option<(T, TOther)>!
 override Waystone.Monads.Options.None<T>.ZipWith<TOther, TOut>(Waystone.Monads.Options.Option<TOther>! other, System.Func<T, TOther, TOut>! zip) -> Waystone.Monads.Options.Option<TOut>!
 override Waystone.Monads.Options.Option<T>.Equals(object? obj) -> bool
 override Waystone.Monads.Options.Option<T>.GetHashCode() -> int
 override Waystone.Monads.Options.Option<T>.ToString() -> string!
 override Waystone.Monads.Options.Some<T>.<Clone>$() -> Waystone.Monads.Options.Option<T>!
-override Waystone.Monads.Options.Some<T>.And<T2>(Waystone.Monads.Options.Option<T2>! other) -> Waystone.Monads.Options.Option<T2>!
+override Waystone.Monads.Options.Some<T>.And<TOut>(Waystone.Monads.Options.Option<TOut>! other) -> Waystone.Monads.Options.Option<TOut>!
 override Waystone.Monads.Options.Some<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>!
 override Waystone.Monads.Options.Some<T>.Equals(object? obj) -> bool
 override Waystone.Monads.Options.Some<T>.Expect(string! message) -> T
@@ -553,13 +553,13 @@ override Waystone.Monads.Options.Some<T>.IsNone.get -> bool
 override Waystone.Monads.Options.Some<T>.IsNoneOr(System.Func<T, bool>! predicate) -> bool
 override Waystone.Monads.Options.Some<T>.IsSome.get -> bool
 override Waystone.Monads.Options.Some<T>.IsSomeAnd(System.Func<T, bool>! predicate) -> bool
-override Waystone.Monads.Options.Some<T>.Map<T2>(System.Func<T, T2>! map) -> Waystone.Monads.Options.Option<T2>!
-override Waystone.Monads.Options.Some<T>.Map<TState, T2>(TState state, System.Func<T, TState, T2>! map) -> Waystone.Monads.Options.Option<T2>!
-override Waystone.Monads.Options.Some<T>.MapOr<T2>(T2 default, System.Func<T, T2>! map) -> T2
-override Waystone.Monads.Options.Some<T>.MapOr<TState, T2>(TState state, T2 default, System.Func<T, TState, T2>! map) -> T2
-override Waystone.Monads.Options.Some<T>.MapOrDefault<T2>(System.Func<T, T2>! map) -> T2
-override Waystone.Monads.Options.Some<T>.MapOrElse<T2>(System.Func<T2>! createDefault, System.Func<T, T2>! map) -> T2
-override Waystone.Monads.Options.Some<T>.MapOrElse<TState, T2>(TState state, System.Func<TState, T2>! createDefault, System.Func<T, TState, T2>! map) -> T2
+override Waystone.Monads.Options.Some<T>.Map<TOut>(System.Func<T, TOut>! map) -> Waystone.Monads.Options.Option<TOut>!
+override Waystone.Monads.Options.Some<T>.Map<TState, TOut>(TState state, System.Func<T, TState, TOut>! map) -> Waystone.Monads.Options.Option<TOut>!
+override Waystone.Monads.Options.Some<T>.MapOr<TOut>(TOut default, System.Func<T, TOut>! map) -> TOut
+override Waystone.Monads.Options.Some<T>.MapOr<TState, TOut>(TState state, TOut default, System.Func<T, TState, TOut>! map) -> TOut
+override Waystone.Monads.Options.Some<T>.MapOrDefault<TOut>(System.Func<T, TOut>! map) -> TOut
+override Waystone.Monads.Options.Some<T>.MapOrElse<TOut>(System.Func<TOut>! createDefault, System.Func<T, TOut>! map) -> TOut
+override Waystone.Monads.Options.Some<T>.MapOrElse<TState, TOut>(TState state, System.Func<TState, TOut>! createDefault, System.Func<T, TState, TOut>! map) -> TOut
 override Waystone.Monads.Options.Some<T>.Match(System.Action<T>! onSome, System.Action! onNone) -> void
 override Waystone.Monads.Options.Some<T>.Match<TOut>(System.Func<T, TOut>! onSome, System.Func<TOut>! onNone) -> TOut
 override Waystone.Monads.Options.Some<T>.OkOr<TErr>(TErr error) -> Waystone.Monads.Results.Result<T, TErr>!
@@ -573,7 +573,7 @@ override Waystone.Monads.Options.Some<T>.UnwrapOr(T value) -> T
 override Waystone.Monads.Options.Some<T>.UnwrapOrDefault() -> T
 override Waystone.Monads.Options.Some<T>.UnwrapOrElse(System.Func<T>! else) -> T
 override Waystone.Monads.Options.Some<T>.Xor(Waystone.Monads.Options.Option<T>! other) -> Waystone.Monads.Options.Option<T>!
-override Waystone.Monads.Options.Some<T>.Zip<T2>(Waystone.Monads.Options.Option<T2>! other) -> Waystone.Monads.Options.Option<(T, T2)>!
+override Waystone.Monads.Options.Some<T>.Zip<TOther>(Waystone.Monads.Options.Option<TOther>! other) -> Waystone.Monads.Options.Option<(T, TOther)>!
 override Waystone.Monads.Options.Some<T>.ZipWith<TOther, TOut>(Waystone.Monads.Options.Option<TOther>! other, System.Func<T, TOther, TOut>! zip) -> Waystone.Monads.Options.Option<TOut>!
 override Waystone.Monads.Results.Err<TOk, TErr>.<Clone>$() -> Waystone.Monads.Results.Result<TOk, TErr>!
 override Waystone.Monads.Results.Err<TOk, TErr>.And<TOut>(Waystone.Monads.Results.Result<TOut, TErr>! other) -> Waystone.Monads.Results.Result<TOut, TErr>!


### PR DESCRIPTION
Option<T> called it T2 while every extension over it called it TOut, and a
generated awaited shape takes its type parameter names from the core member it
forwards to. So the drift, not anything about the shapes themselves, was what
kept And and MapOrDefault hand-written. Both are now generated.

TOut wins because it says what the thing is, and because the published
documentation already describes the surface that way — core-functionality.md
writes `default(TOut)` and `TOut : struct`, and nothing in the docs names T2.
This brings the code into line with what consumers are already reading, so no
paired docs PR is needed. Renamed on Map, And, AndThen, MapOr, MapOrDefault and
MapOrElse, including the TState overloads and the Some<T>/None<T> overrides.

Zip keeps a distinct name and becomes Zip<TOther> rather than Zip<TOut>: its
type parameter is the other input element, not an output, which is the role
ZipWith already spells TOther. Unzip<T1, T2> keeps T1 and T2, which are tuple
positions.

Renaming a type parameter is not breaking. A call site cannot name one, so no
source compiles differently and no assembly binds differently. The parameter
names that are genuinely source-breaking to converge are left alone and tracked
for v7.

PublicAPI.Shipped.txt moves 29 rows and adds or removes none: every RS0017 is
paired with an RS0016 differing only in the type parameter name.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>