### PR TITLE
feat: add WM2018, do not reuse an error code across enums

### DIFF
--- a/src/Waystone.Monads.Analyzers/AGENTS.md
+++ b/src/Waystone.Monads.Analyzers/AGENTS.md
@@ -28,6 +28,15 @@ rule. A *disabled* rule at warning severity fires nothing and so builds clean;
 
 ## Gotchas
 
+**`WM2018` is the only rule that aggregates across declarations.** Every other
+analyzer decides from one node or one symbol; `ErrorCodeReuseAnalyzer` has to see two
+enums at once, so it collects into a `ConcurrentBag` under `RegisterSymbolAction` and
+reports from `RegisterCompilationEndAction`. `Initialize` calls
+`EnableConcurrentExecution`, so the collection must be thread-safe and the *order*
+must not matter — it reports on the second member in ordinal order by display string
+rather than on whichever symbol arrived second, or the same source would blame a
+different declaration between runs.
+
 **`IsExtensionMethod` is not a reliable test.** The library's extensions are C# 14
 `extension` blocks, and the compiler emits a compatibility static method that
 older Roslyn sees as a classic extension. A rule keyed on `IsExtensionMethod`

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -68,3 +68,11 @@ WM1007 | Reliability | Warning | A type derives from Option or Result
 WM1009 | Reliability | Warning | Option of bool or of an enum with a zero member
 WM1010 | Reliability | Warning | The default of a value type is used as an Option value
 WM2014 | Usage | Info | FlatMap has been renamed to AndThen
+
+## Release 6.2.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+WM2018 | Usage | Info | An error code is reused across enums

--- a/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
@@ -1,0 +1,91 @@
+namespace Waystone.Monads.Analyzers;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rules.ErrorCodeReusedAcrossEnums);
+
+    protected override void Register(
+        CompilationStartAnalysisContext context,
+        MonadSymbols symbols)
+    {
+        if (symbols.ErrorCodeProviderAttribute is null) return;
+
+        var providers = new ConcurrentBag<IFieldSymbol>();
+
+        context.RegisterSymbolAction(
+            symbol => Collect((INamedTypeSymbol)symbol.Symbol, symbols, providers),
+            SymbolKind.NamedType);
+
+        context.RegisterCompilationEndAction(end => Report(end, providers));
+    }
+
+    private static void Collect(
+        INamedTypeSymbol type,
+        MonadSymbols symbols,
+        ConcurrentBag<IFieldSymbol> providers)
+    {
+        if (type.TypeKind != TypeKind.Enum || !IsProvider(type, symbols)) return;
+
+        foreach (IFieldSymbol member in type.GetMembers().OfType<IFieldSymbol>())
+        {
+            if (member.IsConst) providers.Add(member);
+        }
+    }
+
+    private static bool IsProvider(INamedTypeSymbol type, MonadSymbols symbols) =>
+        type.GetAttributes()
+            .Any(
+                 attribute => SymbolEqualityComparer.Default.Equals(
+                     attribute.AttributeClass,
+                     symbols.ErrorCodeProviderAttribute));
+
+    private static void Report(
+        CompilationAnalysisContext context,
+        ConcurrentBag<IFieldSymbol> providers)
+    {
+        foreach (IGrouping<string, IFieldSymbol> collision in providers
+                    .GroupBy(CodeOf, StringComparer.Ordinal)
+                    .Where(group => group.Count() > 1))
+        {
+            List<IFieldSymbol> ordered = collision
+                                        .OrderBy(
+                                             member => member.ToDisplayString(),
+                                             StringComparer.Ordinal)
+                                        .ToList();
+
+            IFieldSymbol first = ordered[0];
+
+            foreach (IFieldSymbol later in ordered.Skip(1))
+            {
+                if (SymbolEqualityComparer.Default.Equals(
+                        first.ContainingType,
+                        later.ContainingType))
+                {
+                    continue;
+                }
+
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        Rules.ErrorCodeReusedAcrossEnums,
+                        later.Locations.FirstOrDefault(
+                            location => location.IsInSource),
+                        first.ToDisplayString(),
+                        later.ToDisplayString(),
+                        collision.Key));
+            }
+        }
+    }
+
+    private static string CodeOf(IFieldSymbol member) =>
+        $"{member.ContainingType.Name}.{member.Name}";
+}

--- a/src/Waystone.Monads.Analyzers/MonadSymbols.cs
+++ b/src/Waystone.Monads.Analyzers/MonadSymbols.cs
@@ -21,6 +21,8 @@ public sealed class MonadSymbols
         "Waystone.Monads.Results.Result";
     public const string ErrorMetadataName =
         "Waystone.Monads.Results.Errors.Error";
+    public const string ErrorCodeProviderAttributeMetadataName =
+        "Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute";
 
     private MonadSymbols(
         INamedTypeSymbol option,
@@ -32,6 +34,7 @@ public sealed class MonadSymbols
         INamedTypeSymbol err,
         INamedTypeSymbol resultFactory,
         INamedTypeSymbol? error,
+        INamedTypeSymbol? errorCodeProviderAttribute,
         INamedTypeSymbol? task,
         INamedTypeSymbol? valueTask)
     {
@@ -44,6 +47,7 @@ public sealed class MonadSymbols
         Err = err;
         ResultFactory = resultFactory;
         Error = error;
+        ErrorCodeProviderAttribute = errorCodeProviderAttribute;
         Task = task;
         ValueTask = valueTask;
     }
@@ -65,6 +69,8 @@ public sealed class MonadSymbols
     public INamedTypeSymbol ResultFactory { get; }
 
     public INamedTypeSymbol? Error { get; }
+
+    public INamedTypeSymbol? ErrorCodeProviderAttribute { get; }
 
     public INamedTypeSymbol? Task { get; }
 
@@ -105,6 +111,8 @@ public sealed class MonadSymbols
             err,
             resultFactory,
             compilation.GetTypeByMetadataName(ErrorMetadataName),
+            compilation.GetTypeByMetadataName(
+                ErrorCodeProviderAttributeMetadataName),
             compilation.GetTypeByMetadataName(
                 "System.Threading.Tasks.Task`1"),
             compilation.GetTypeByMetadataName(

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -254,6 +254,22 @@ public static class Rules
         "The delegate passed to '{0}' captures '{1}', so a closure is allocated on every call. Pass the value to the '{0}' overload that takes state instead.",
         "Map, MapErr, MapOr, MapOrElse, Filter, AndThen, Try and TryAsync each have an overload that takes a state argument and hands it to the delegate. A lambda that captures a local or a parameter allocates a display class every time the call site runs; passing the value as state lets the delegate close over nothing, so the compiler caches it. Where more than one value is captured, pass them as a tuple.");
 
+    /// <remarks>
+    /// Keyed on the generated code string rather than on the enum name, because
+    /// the name is only half of it: two enums called <c>OrderError</c> in
+    /// different namespaces collide on the members they share and on nothing
+    /// else, so reporting the type would name a pair that may generate no
+    /// overlapping code at all. Reported on the second declaration in ordinal
+    /// order rather than on both, so a concurrent compilation does not vary in
+    /// which one it blames. There is no code fix: the fix is a rename, and which
+    /// of the two enums should keep the code is not derivable from the source.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor ErrorCodeReusedAcrossEnums = Idiom(
+        "WM2018",
+        "Do not reuse an error code across enums",
+        "'{0}' and '{1}' both generate the error code '{2}', so the two errors are indistinguishable to anything reading the code",
+        "An [ErrorCodeProvider] enum generates one code per member from the enum's own name and the member's, so two enums sharing a name in different namespaces generate the same code for every member name they share. No two independent error taxonomies legitimately share a wire code, and consumers reading the code cannot tell which error occurred. Rename one of the enums or the colliding member.");
+
     public static readonly DiagnosticDescriptor NullableReturnCouldBeOption = Migration(
         "WM3001",
         "Prefer an Option over a nullable return",

--- a/test/Waystone.Monads.Analyzers.Tests/ErrorCodeReuseAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/ErrorCodeReuseAnalyzerTests.cs
@@ -1,0 +1,168 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Threading.Tasks;
+using Xunit;
+
+public class ErrorCodeReuseAnalyzerTests
+{
+    [Fact]
+    public Task FlagsTwoEnumsSharingANameAndAMember() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+
+            namespace Shipping
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    {|#0:NotFound|},
+                }
+            }
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeReusedAcrossEnums)
+                  .WithLocation(0)
+                  .WithArguments(
+                       "Ordering.OrderError.NotFound",
+                       "Shipping.OrderError.NotFound",
+                       "OrderError.NotFound"));
+
+    [Fact]
+    public Task FlagsEveryColligingMemberOfThePair() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    NotFound,
+                    Cancelled,
+                }
+            }
+
+            namespace Shipping
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    {|#0:NotFound|},
+                    {|#1:Cancelled|},
+                }
+            }
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeReusedAcrossEnums)
+                  .WithLocation(0)
+                  .WithArguments(
+                       "Ordering.OrderError.NotFound",
+                       "Shipping.OrderError.NotFound",
+                       "OrderError.NotFound"),
+            Verify.Diagnostic(Rules.ErrorCodeReusedAcrossEnums)
+                  .WithLocation(1)
+                  .WithArguments(
+                       "Ordering.OrderError.Cancelled",
+                       "Shipping.OrderError.Cancelled",
+                       "OrderError.Cancelled"));
+
+    [Fact]
+    public Task IgnoresASharedNameWithNoSharedMember() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+
+            namespace Shipping
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    AlreadyShipped,
+                }
+            }
+            """);
+
+    [Fact]
+    public Task IgnoresASharedMemberUnderDifferentEnumNames() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+
+            namespace Shipping
+            {
+                [ErrorCodeProvider]
+                internal enum ShipmentError
+                {
+                    NotFound,
+                }
+            }
+            """);
+
+    [Fact]
+    public Task IgnoresAnEnumThatIsNotAProvider() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+
+            namespace Shipping
+            {
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+            """);
+
+    [Fact]
+    public Task IgnoresAnAliasWithinOneEnum() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    NotFound = 1,
+                    Missing = 1,
+                }
+            }
+            """);
+}

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -63,7 +63,7 @@ public class RulesTests
     public void EveryTierIsPopulated()
     {
         MisuseRules().Count.ShouldBe(7);
-        IdiomRules().Count.ShouldBe(16);
+        IdiomRules().Count.ShouldBe(17);
         MigrationRules().Count.ShouldBe(2);
     }
 

--- a/test/Waystone.Monads.Analyzers.Tests/Verify.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/Verify.cs
@@ -1,4 +1,4 @@
-﻿namespace Waystone.Monads.Analyzers;
+namespace Waystone.Monads.Analyzers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -25,6 +25,23 @@ internal static class Verify
         where TAnalyzer : DiagnosticAnalyzer, new()
     {
         var test = new AnalyzerTest<TAnalyzer> { TestCode = Wrap(source) };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+
+        return test.RunAsync();
+    }
+
+    /// <summary>
+    /// Runs the analyzer over <paramref name="rawSource" /> without the usings and
+    /// the <c>Subject</c> wrapper, for a rule whose subject is a whole compilation
+    /// rather than a member.
+    /// </summary>
+    public static Task RawAnalyzerAsync<TAnalyzer>(
+        string rawSource,
+        params DiagnosticResult[] expected)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        var test = new AnalyzerTest<TAnalyzer> { TestCode = rawSource };
 
         test.ExpectedDiagnostics.AddRange(expected);
 


### PR DESCRIPTION
Closes DRA-89 (second of two). Stacked on #103, which adds the generator.

An `[ErrorCodeProvider]` enum builds each code from its own name and the
member's, so two enums sharing a name in different namespaces generate the same
code for every member name they share. `Ordering.OrderError.NotFound` and
`Shipping.OrderError.NotFound` both generate `"OrderError.NotFound"`, and nothing
reading the code can tell the two errors apart. No two independent error
taxonomies legitimately share a wire code.

`WM2018` reports it. `Idiom` factory, category `Usage`, severity `Info`, enabled
by default. It neither throws nor silently no-ops, so it does not earn `WM1`.

## The first cross-declaration rule

Every other analyzer in the project decides from one node or one symbol.
`ErrorCodeReuseAnalyzer` has to see two enums at once, so it collects into a
`ConcurrentBag` under `RegisterSymbolAction` and reports from
`RegisterCompilationEndAction` — the first use of compilation-end here.

`MonadAnalyzer.Initialize` calls `EnableConcurrentExecution`, so the collection
has to be thread-safe *and* order-independent. It reports on the second member in
ordinal order by display string rather than on whichever symbol arrived second,
or the same source would blame a different declaration between runs. That is
recorded in the analyzer `AGENTS.md`.

Keyed on the generated code string rather than on the enum name, because the name
is only half of it: two enums called `OrderError` collide on the members they
share and on nothing else, so reporting the type would name a pair that may
generate no overlapping code at all. One diagnostic per colliding member.

No code fix: the fix is a rename, and which of the two enums keeps the code is
not derivable from the source.

## Also here

`MonadSymbols` gains `ErrorCodeProviderAttribute`, resolved by metadata name like
the rest — the analyzer still never references `Waystone.Monads`. The rule goes
silent when the attribute is absent.

`Verify.RawAnalyzerAsync` is new, mirroring the existing `RawCodeFixAsync`. The
harness's `Wrap` puts a snippet with no `class` into `internal class Subject`,
which cannot hold two same-named enums in two namespaces, so a compilation-scoped
rule needs the unwrapped variant.

## Verification

* Six cases: a collision, a pair with three colliding members, a shared enum name
  with no shared member, a shared member name under different enum names, an
  unattributed enum, and an alias within one enum.
* `RulesTests` picks the descriptor up by reflection, so the help link, the title
  length, the `Info` default, the enabled default and the "only WM1 ships at
  warning" invariant are all asserted already. `IdiomRules().Count` bumped to 17.
* Release row under 6.2.0.
* Full framework matrix locally.

## Merge order

Neither this title nor #103's carries a `!`, so the stack lands as a single minor
bump. The paired docs PR in `draekien-industries/docs` covers `WM2018` and the
generator together — merge both of these first.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
