### PR TITLE
feat: shape generated error codes with a declarative format

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/Ordering.cs
+++ b/sample/Waystone.Monads.Analyzers.Sample/Ordering.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Waystone.Monads.Results;
 using Waystone.Monads.Results.Errors;
 
-[ErrorCodeProvider]
+[ErrorCodeProvider(Format = "order.{member:kebab}")]
 internal enum OrderErrorCode
 {
     NotFound,
@@ -25,6 +25,10 @@ internal record Shipment(int OrderId, string TrackingNumber);
 /// <c>Result&lt;T, Error&gt;</c> and every failure carries a code the generator
 /// produced from <see cref="OrderErrorCode" />, so the codes the API returns are
 /// the same strings this file names.
+///
+/// The enum declares a format, so the codes are <c>order.not-found</c> rather than
+/// <c>OrderErrorCode.NotFound</c> — the shape you would want on a wire, without a
+/// runtime factory.
 /// </summary>
 internal class Ordering
 {

--- a/sample/Waystone.Monads.Analyzers.Sample/README.md
+++ b/sample/Waystone.Monads.Analyzers.Sample/README.md
@@ -47,6 +47,12 @@ The point is where those errors come from. `OrderErrorCode` is marked
   written against `OrderErrorProvider.ErrorCodeStrings` and cannot be written against
   `ErrorCode.FromEnum` at all — that call works its string out at run time.
 
+The enum also declares a format, `order.{member:kebab}`, so the codes are
+`order.not-found` rather than `OrderErrorCode.NotFound`. That is the shape you would
+actually put on a wire, and it is reached declaratively — no `ErrorCodeFactory`
+subclass, and nothing to install at startup. The format is evaluated at build time, so
+`StatusCodeFor` still switches on constants.
+
 Two details are pinned here on purpose, so a change to either breaks this build rather
 than only a snapshot test:
 
@@ -54,7 +60,8 @@ than only a snapshot test:
   `OrderErrorCodeProvider`. The generator takes a trailing `Error` or `ErrorCode` off
   the enum's name before adding its own suffix.
 - The `case` labels are the generated constants, so a change to the code scheme stops
-  this file compiling.
+  this file compiling, and a change to the casing rules changes what they compare
+  against.
 
 This project imports `Waystone.Monads.SourceGenerators.props` to load the generator,
 the same way it imports the analyzer props. A consumer installing the NuGet package

--- a/src/Waystone.Monads.Analyzers/AGENTS.md
+++ b/src/Waystone.Monads.Analyzers/AGENTS.md
@@ -28,6 +28,17 @@ rule. A *disabled* rule at warning severity fires nothing and so builds clean;
 
 ## Gotchas
 
+**`WM2018` shares source with the generator.** `ErrorCodeFormat.cs` is a linked
+`Compile` item from `Waystone.Monads.SourceGenerators`, not a project reference — the
+two analyzer assemblies cannot reference each other, and the rule keys on the
+*generated* code, so it has to resolve `[ErrorCodeProvider(Format = ...)]` and
+`[assembly: ErrorCodeFormat]` exactly as the generator does. A second copy of the
+parser would let the rule and the generator disagree about what code an enum produces,
+which is the one thing this rule cannot afford to be wrong about. Deriving the code
+from the enum name instead is wrong in both directions once anyone sets a format:
+`FlagsACollisionCausedByASharedFormat` and `IgnoresASharedNameWhenTheFormatsDiffer`
+pin both.
+
 **`WM2018` is the only rule that aggregates across declarations.** Every other
 analyzer decides from one node or one symbol; `ErrorCodeReuseAnalyzer` has to see two
 enums at once, so it collects into a `ConcurrentBag` under `RegisterSymbolAction` and

--- a/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Waystone.Monads.SourceGenerators.ErrorCodes;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
@@ -20,10 +21,16 @@ public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
     {
         if (symbols.ErrorCodeProviderAttribute is null) return;
 
-        var providers = new ConcurrentBag<IFieldSymbol>();
+        var providers = new ConcurrentBag<Provided>();
+
+        string? assemblyFormat = AssemblyFormat(context.Compilation);
 
         context.RegisterSymbolAction(
-            symbol => Collect((INamedTypeSymbol)symbol.Symbol, symbols, providers),
+            symbol => Collect(
+                (INamedTypeSymbol)symbol.Symbol,
+                symbols,
+                assemblyFormat,
+                providers),
             SymbolKind.NamedType);
 
         context.RegisterCompilationEndAction(end => Report(end, providers));
@@ -32,44 +39,105 @@ public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
     private static void Collect(
         INamedTypeSymbol type,
         MonadSymbols symbols,
-        ConcurrentBag<IFieldSymbol> providers)
+        string? assemblyFormat,
+        ConcurrentBag<Provided> providers)
     {
-        if (type.TypeKind != TypeKind.Enum || !IsProvider(type, symbols)) return;
+        if (type.TypeKind != TypeKind.Enum) return;
+
+        AttributeData? provider = type.GetAttributes()
+           .FirstOrDefault(
+                attribute => SymbolEqualityComparer.Default.Equals(
+                    attribute.AttributeClass,
+                    symbols.ErrorCodeProviderAttribute));
+
+        if (provider is null) return;
+
+        if (!ErrorCodeFormat.TryParse(
+                DeclaredFormat(provider) ?? assemblyFormat ?? ErrorCodeFormat.Default,
+                out ErrorCodeFormat? format,
+                out _))
+        {
+            return;
+        }
 
         foreach (IFieldSymbol member in type.GetMembers().OfType<IFieldSymbol>())
         {
-            if (member.IsConst) providers.Add(member);
+            if (!member.IsConst) continue;
+
+            providers.Add(
+                new Provided(member, format!.Apply(type.Name, member.Name)));
         }
     }
 
-    private static bool IsProvider(INamedTypeSymbol type, MonadSymbols symbols) =>
-        type.GetAttributes()
-            .Any(
-                 attribute => SymbolEqualityComparer.Default.Equals(
-                     attribute.AttributeClass,
-                     symbols.ErrorCodeProviderAttribute));
+    /// <summary>
+    /// The format the enum declares, resolved the same way the generator resolves
+    /// it.
+    /// </summary>
+    /// <remarks>
+    /// The rule keys on the generated code rather than on the enum name, so the
+    /// format has to be applied here too. Without it the rule is wrong in both
+    /// directions once anyone sets a format: two enums with different names and one
+    /// shared format collide and would go unreported, and two enums sharing a name
+    /// with different formats do not collide and would be reported anyway.
+    /// <c>ErrorCodeFormat</c> is compiled into this assembly from the generator's
+    /// copy rather than duplicated, so the two can only ever agree.
+    /// </remarks>
+    private static string? DeclaredFormat(AttributeData provider)
+    {
+        foreach (KeyValuePair<string, TypedConstant> argument in
+                 provider.NamedArguments)
+        {
+            if (argument.Key == "Format" && argument.Value.Value is string declared)
+            {
+                return declared;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? AssemblyFormat(Compilation compilation)
+    {
+        foreach (AttributeData attribute in compilation.Assembly.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString()
+             != MonadSymbols.ErrorCodeFormatAttributeMetadataName)
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 1
+             && attribute.ConstructorArguments[0].Value is string format)
+            {
+                return format;
+            }
+        }
+
+        return null;
+    }
 
     private static void Report(
         CompilationAnalysisContext context,
-        ConcurrentBag<IFieldSymbol> providers)
+        ConcurrentBag<Provided> providers)
     {
-        foreach (IGrouping<string, IFieldSymbol> collision in providers
-                    .GroupBy(CodeOf, StringComparer.Ordinal)
+        foreach (IGrouping<string, Provided> collision in providers
+                    .GroupBy(provided => provided.Code, StringComparer.Ordinal)
                     .Where(group => group.Count() > 1))
         {
-            List<IFieldSymbol> ordered = collision
-                                        .OrderBy(
-                                             member => member.ToDisplayString(),
-                                             StringComparer.Ordinal)
-                                        .ToList();
+            List<Provided> ordered = collision
+                                    .OrderBy(
+                                         provided =>
+                                             provided.Member.ToDisplayString(),
+                                         StringComparer.Ordinal)
+                                    .ToList();
 
-            IFieldSymbol first = ordered[0];
+            Provided first = ordered[0];
 
-            foreach (IFieldSymbol later in ordered.Skip(1))
+            foreach (Provided later in ordered.Skip(1))
             {
                 if (SymbolEqualityComparer.Default.Equals(
-                        first.ContainingType,
-                        later.ContainingType))
+                        first.Member.ContainingType,
+                        later.Member.ContainingType))
                 {
                     continue;
                 }
@@ -77,15 +145,25 @@ public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
                 context.ReportDiagnostic(
                     Diagnostic.Create(
                         Rules.ErrorCodeReusedAcrossEnums,
-                        later.Locations.FirstOrDefault(
+                        later.Member.Locations.FirstOrDefault(
                             location => location.IsInSource),
-                        first.ToDisplayString(),
-                        later.ToDisplayString(),
+                        first.Member.ToDisplayString(),
+                        later.Member.ToDisplayString(),
                         collision.Key));
             }
         }
     }
 
-    private static string CodeOf(IFieldSymbol member) =>
-        $"{member.ContainingType.Name}.{member.Name}";
+    private readonly struct Provided
+    {
+        public Provided(IFieldSymbol member, string code)
+        {
+            Member = member;
+            Code = code;
+        }
+
+        public IFieldSymbol Member { get; }
+
+        public string Code { get; }
+    }
 }

--- a/src/Waystone.Monads.Analyzers/MonadSymbols.cs
+++ b/src/Waystone.Monads.Analyzers/MonadSymbols.cs
@@ -23,6 +23,8 @@ public sealed class MonadSymbols
         "Waystone.Monads.Results.Errors.Error";
     public const string ErrorCodeProviderAttributeMetadataName =
         "Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute";
+    public const string ErrorCodeFormatAttributeMetadataName =
+        "Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute";
 
     private MonadSymbols(
         INamedTypeSymbol option,

--- a/src/Waystone.Monads.Analyzers/Waystone.Monads.Analyzers.csproj
+++ b/src/Waystone.Monads.Analyzers/Waystone.Monads.Analyzers.csproj
@@ -21,6 +21,11 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup Label="Shared with the generator, which owns the format language">
+        <Compile Include="..\Waystone.Monads.SourceGenerators\ErrorCodes\ErrorCodeFormat.cs"
+                 Link="Shared\ErrorCodeFormat.cs"/>
+    </ItemGroup>
+
     <ItemGroup>
         <None Include="AnalyzerReleases.Shipped.md"/>
         <None Include="AnalyzerReleases.Unshipped.md"/>

--- a/src/Waystone.Monads.SourceGenerators/AGENTS.md
+++ b/src/Waystone.Monads.SourceGenerators/AGENTS.md
@@ -28,12 +28,31 @@ resolves the attribute by metadata name through `ForAttributeWithMetadataName`, 
 `ErrorCode` and `Error` through `compilation.GetTypeByMetadataName`, reporting
 `WMG0004` rather than emitting source that cannot compile.
 
-**The generated codes are the default `ErrorCodeFactory` scheme, baked in.**
-`{EnumTypeName}.{MemberName}`, matching `ErrorCodeFactory.FromEnum`. A consumer who
+**The scheme is declarative and evaluated at compile time.** `ErrorCodeFormat` parses
+`{enum}` and `{member}` with an optional `kebab`, `snake`, `lower` or `upper` casing,
+and the default is `{enum}.{member}` so an enum that sets nothing gets exactly what
+`ErrorCodeFactory.FromEnum` produces. Precedence is the enum's `Format`, then the
+assembly's `[ErrorCodeFormat]`, then that default.
+
+This exists because the alternative does not work: a generator cannot execute a
+factory. `ErrorCodeFactory.FromEnum` is arbitrary C# that runs later, and the compiler
+has no facility to invoke user code and read the result back. So a consumer who
 installs a custom factory through `MonadOptions.UseErrorCodeFactory` changes the
-runtime string and not the generated one; that divergence is documented on the
-GitBook page rather than detected, because the factory is a runtime value the
-generator cannot see.
+runtime string and not the generated one, which is why the factory is being obsoleted
+in favour of the format — see DRA-112.
+
+**`ErrorCodeFormat.cs` is compiled into `Waystone.Monads.Analyzers` as well**, as a
+linked `Compile` item rather than a project reference, because `WM2018` keys on the
+generated code and has to resolve the format identically. Two copies of the parser
+would let the rule and the generator disagree about what code an enum produces, which
+is exactly the bug the rule exists to catch. The two assemblies cannot reference each
+other, so shared source is the only mechanism.
+
+**`ApplyToUndeclared` folds everything that does not depend on the member into a
+literal**, so the `default:` arm is a concatenation of constants around one
+`ToString()`. The member's own casing is dropped there rather than emitted as a runtime
+call: an undeclared value renders as digits, and all four casings are the identity on
+digits. `EveryCasingIsTheIdentityOnDigits` is what makes that safe to rely on.
 
 **The nesting is what makes member names safe.** `ErrorCodeStrings`, `ErrorCodes`
 and `Errors` each hold one member per enum member, named verbatim, so an enum member

--- a/src/Waystone.Monads.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -11,3 +11,5 @@ WMG0001 | Usage | Error | An error code provider enum cannot be a flags enum
 WMG0002 | Usage | Error | An error code provider enum cannot alias a value
 WMG0003 | Usage | Error | An error code provider member name collides with a generated type
 WMG0004 | Usage | Error | The Waystone.Monads error types are not resolvable
+WMG0005 | Usage | Error | The error code format cannot be used
+WMG0006 | Usage | Error | The error code format does not distinguish members

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeFormat.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeFormat.cs
@@ -1,0 +1,334 @@
+namespace Waystone.Monads.SourceGenerators.ErrorCodes;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+/// <summary>
+/// A parsed error code format: the literal text and placeholders of something like
+/// <c>"order.{member:kebab}"</c>.
+/// </summary>
+internal sealed class ErrorCodeFormat
+{
+    public const string Default = "{enum}.{member}";
+
+    public const string EnumPlaceholder = "enum";
+    public const string MemberPlaceholder = "member";
+
+    private readonly List<Segment> _segments;
+
+    private ErrorCodeFormat(List<Segment> segments)
+    {
+        _segments = segments;
+    }
+
+    /// <summary>Whether any segment substitutes the member name.</summary>
+    public bool UsesMember
+    {
+        get
+        {
+            foreach (Segment segment in _segments)
+            {
+                if (segment.Placeholder == MemberPlaceholder) return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses <paramref name="format" />, or returns the reason it is not a usable
+    /// format.
+    /// </summary>
+    public static bool TryParse(
+        string? format,
+        out ErrorCodeFormat? parsed,
+        out string? error)
+    {
+        parsed = null;
+        error = null;
+
+        if (format is null || format.Length == 0)
+        {
+            error = "the format is empty";
+
+            return false;
+        }
+
+        var segments = new List<Segment>();
+        var literal = new StringBuilder();
+        var i = 0;
+
+        while (i < format.Length)
+        {
+            char current = format[i];
+
+            if (current == '{' && i + 1 < format.Length && format[i + 1] == '{')
+            {
+                literal.Append('{');
+                i += 2;
+
+                continue;
+            }
+
+            if (current == '}' && i + 1 < format.Length && format[i + 1] == '}')
+            {
+                literal.Append('}');
+                i += 2;
+
+                continue;
+            }
+
+            if (current == '}')
+            {
+                error = $"'}}' at position {i} closes nothing";
+
+                return false;
+            }
+
+            if (current != '{')
+            {
+                literal.Append(current);
+                i++;
+
+                continue;
+            }
+
+            int close = format.IndexOf('}', i);
+
+            if (close < 0)
+            {
+                error = $"the placeholder opened at position {i} is not closed";
+
+                return false;
+            }
+
+            string body = format.Substring(i + 1, close - i - 1);
+
+            if (!TryParsePlaceholder(body, out string? name, out string? transform, out error))
+            {
+                return false;
+            }
+
+            if (literal.Length > 0)
+            {
+                segments.Add(Segment.Literal(literal.ToString()));
+                literal.Clear();
+            }
+
+            segments.Add(Segment.For(name!, transform));
+            i = close + 1;
+        }
+
+        if (literal.Length > 0) segments.Add(Segment.Literal(literal.ToString()));
+
+        parsed = new ErrorCodeFormat(segments);
+
+        return true;
+    }
+
+    /// <summary>Applies the format to a concrete enum and member name.</summary>
+    public string Apply(string enumName, string memberName)
+    {
+        var builder = new StringBuilder();
+
+        foreach (Segment segment in _segments)
+        {
+            builder.Append(
+                segment.Placeholder switch
+                {
+                    null => segment.Text!,
+                    EnumPlaceholder => Casing.Apply(enumName, segment.Transform),
+                    _ => Casing.Apply(memberName, segment.Transform),
+                });
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Renders the format as a C# expression for a value that is not a declared
+    /// member, where the member's name is only known at run time.
+    /// </summary>
+    /// <remarks>
+    /// Every part that does not depend on the member is folded to a literal here, so
+    /// the emitted expression is a concatenation of constants around one
+    /// <c>ToString()</c>. The member's own transform is dropped rather than emitted:
+    /// an undeclared value renders as its digits, and all four transforms are the
+    /// identity on digits, so applying one would cost a call and change nothing.
+    /// </remarks>
+    public string ApplyToUndeclared(string enumName, string valueExpression)
+    {
+        var parts = new List<string>();
+        var literal = new StringBuilder();
+
+        foreach (Segment segment in _segments)
+        {
+            if (segment.Placeholder == MemberPlaceholder)
+            {
+                if (literal.Length > 0)
+                {
+                    parts.Add(Quote(literal.ToString()));
+                    literal.Clear();
+                }
+
+                parts.Add(valueExpression);
+
+                continue;
+            }
+
+            literal.Append(
+                segment.Placeholder is null
+                    ? segment.Text!
+                    : Casing.Apply(enumName, segment.Transform));
+        }
+
+        if (literal.Length > 0) parts.Add(Quote(literal.ToString()));
+
+        return parts.Count == 0 ? "\"\"" : string.Join(" + ", parts);
+    }
+
+    private static bool TryParsePlaceholder(
+        string body,
+        out string? name,
+        out string? transform,
+        out string? error)
+    {
+        name = null;
+        transform = null;
+        error = null;
+
+        int colon = body.IndexOf(':');
+
+        string rawName = colon < 0 ? body : body.Substring(0, colon);
+
+        transform = colon < 0 ? null : body.Substring(colon + 1);
+
+        if (rawName != EnumPlaceholder && rawName != MemberPlaceholder)
+        {
+            error =
+                $"'{{{body}}}' is not a placeholder. Use '{{{EnumPlaceholder}}}' or '{{{MemberPlaceholder}}}'";
+
+            return false;
+        }
+
+        if (transform is not null && !Casing.IsKnown(transform))
+        {
+            error =
+                $"'{transform}' is not a casing. Use {Casing.Known}";
+
+            return false;
+        }
+
+        name = rawName;
+
+        return true;
+    }
+
+    private static string Quote(string text) =>
+        "\"" + text.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+
+    private readonly struct Segment
+    {
+        private Segment(string? text, string? placeholder, string? transform)
+        {
+            Text = text;
+            Placeholder = placeholder;
+            Transform = transform;
+        }
+
+        public string? Text { get; }
+
+        public string? Placeholder { get; }
+
+        public string? Transform { get; }
+
+        public static Segment Literal(string text) => new Segment(text, null, null);
+
+        public static Segment For(string placeholder, string? transform) =>
+            new Segment(null, placeholder, transform);
+    }
+}
+
+internal static class Casing
+{
+    public const string Kebab = "kebab";
+    public const string Snake = "snake";
+    public const string Lower = "lower";
+    public const string Upper = "upper";
+
+    public const string Known = "'kebab', 'snake', 'lower' or 'upper'";
+
+    public static bool IsKnown(string transform) =>
+        transform is Kebab or Snake or Lower or Upper;
+
+    public static string Apply(string identifier, string? transform) =>
+        transform switch
+        {
+            null => identifier,
+            Lower => identifier.ToLowerInvariant(),
+            Upper => identifier.ToUpperInvariant(),
+            Kebab => Join(identifier, '-'),
+            _ => Join(identifier, '_'),
+        };
+
+    /// <summary>
+    /// Splits an identifier into words and rejoins them lowercased.
+    /// </summary>
+    /// <remarks>
+    /// A boundary falls where a lowercase or digit meets an uppercase
+    /// (<c>NotFound</c>), before the last uppercase of a run that runs into a
+    /// lowercase (<c>HTTPNotFound</c> gives <c>http-not-found</c>, not
+    /// <c>h-t-t-p-not-found</c>), and between letters and digits
+    /// (<c>Error404</c> gives <c>error-404</c>). Existing separators are treated as
+    /// boundaries too, so an identifier that already carries one does not double it.
+    /// </remarks>
+    private static string Join(string identifier, char separator)
+    {
+        var builder = new StringBuilder(identifier.Length + 4);
+
+        for (var i = 0; i < identifier.Length; i++)
+        {
+            char current = identifier[i];
+
+            if (current is '_' or '-')
+            {
+                Separate(builder, separator);
+
+                continue;
+            }
+
+            if (i > 0 && IsBoundary(identifier, i)) Separate(builder, separator);
+
+            builder.Append(char.ToLowerInvariant(current));
+        }
+
+        return builder.ToString().Trim(separator);
+    }
+
+    private static bool IsBoundary(string identifier, int i)
+    {
+        char current = identifier[i];
+        char previous = identifier[i - 1];
+
+        if (char.IsDigit(current) != char.IsDigit(previous)
+         && (char.IsLetterOrDigit(current) && char.IsLetterOrDigit(previous)))
+        {
+            return true;
+        }
+
+        if (!char.IsUpper(current)) return false;
+
+        if (!char.IsUpper(previous)) return true;
+
+        return i + 1 < identifier.Length && char.IsLower(identifier[i + 1]);
+    }
+
+    private static void Separate(StringBuilder builder, char separator)
+    {
+        if (builder.Length > 0 && builder[builder.Length - 1] != separator)
+        {
+            builder.Append(separator);
+        }
+    }
+}

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeProviderGenerator.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeProviderGenerator.cs
@@ -24,6 +24,9 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
     internal const string ErrorMetadataName =
         "Waystone.Monads.Results.Errors.Error";
 
+    internal const string FormatAttributeMetadataName =
+        "Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute";
+
     private const string FlagsMetadataName = "System.FlagsAttribute";
 
     private static readonly string[] ReservedMemberNames =
@@ -101,6 +104,30 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
                 enumType.Name);
         }
 
+        string? requested = RequestedFormat(context.Attributes[0], compilation);
+
+        if (!ErrorCodeFormat.TryParse(
+                requested ?? ErrorCodeFormat.Default,
+                out ErrorCodeFormat? format,
+                out string? formatError))
+        {
+            return Failure(
+                hintName,
+                Rules.UnusableFormat,
+                location,
+                enumType.Name,
+                formatError!);
+        }
+
+        if (!format!.UsesMember)
+        {
+            return Failure(
+                hintName,
+                Rules.FormatOmitsMember,
+                location,
+                enumType.Name);
+        }
+
         List<IFieldSymbol> members = enumType.GetMembers()
                                              .OfType<IFieldSymbol>()
                                              .Where(
@@ -150,8 +177,47 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
             hintName,
             diagnostics.Count > 0
                 ? null
-                : ErrorCodeProviderWriter.Emit(enumType, providerName, members),
+                : ErrorCodeProviderWriter.Emit(
+                    enumType,
+                    providerName,
+                    members,
+                    format),
             new EquatableArray<DiagnosticInfo>(diagnostics.ToArray()));
+    }
+
+    /// <summary>
+    /// The format the enum asks for, then the one the assembly asks for, then null
+    /// for the built-in default.
+    /// </summary>
+    private static string? RequestedFormat(
+        AttributeData provider,
+        Compilation compilation)
+    {
+        foreach (KeyValuePair<string, TypedConstant> argument in
+                 provider.NamedArguments)
+        {
+            if (argument.Key == "Format" && argument.Value.Value is string declared)
+            {
+                return declared;
+            }
+        }
+
+        foreach (AttributeData attribute in compilation.Assembly.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString()
+             != FormatAttributeMetadataName)
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 1
+             && attribute.ConstructorArguments[0].Value is string assemblyWide)
+            {
+                return assemblyWide;
+            }
+        }
+
+        return null;
     }
 
     private static string? MissingErrorType(Compilation compilation)

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeProviderWriter.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeProviderWriter.cs
@@ -20,7 +20,8 @@ internal static class ErrorCodeProviderWriter
     public static string Emit(
         INamedTypeSymbol enumType,
         string providerName,
-        IReadOnlyList<IFieldSymbol> members)
+        IReadOnlyList<IFieldSymbol> members,
+        ErrorCodeFormat format)
     {
         string qualified =
             enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
@@ -50,9 +51,10 @@ internal static class ErrorCodeProviderWriter
 
         writer.Line(depth, "{");
 
-        string undeclared = $"\"{enumType.Name}.\" + value.ToString()";
+        string undeclared =
+            format.ApplyToUndeclared(enumType.Name, "value.ToString()");
 
-        WriteStrings(writer, depth + 1, qualified, enumType.Name, members);
+        WriteStrings(writer, depth + 1, qualified, enumType, members, format);
         writer.Blank();
         WriteCodes(writer, depth + 1, qualified, members);
         writer.Blank();
@@ -97,8 +99,9 @@ internal static class ErrorCodeProviderWriter
         Writer writer,
         int depth,
         string qualified,
-        string enumName,
-        IReadOnlyList<IFieldSymbol> members)
+        INamedTypeSymbol enumType,
+        IReadOnlyList<IFieldSymbol> members,
+        ErrorCodeFormat format)
     {
         writer.Line(
             depth,
@@ -119,7 +122,7 @@ internal static class ErrorCodeProviderWriter
 
             writer.Line(
                 depth + 1,
-                $"public const string {name} = \"{enumName}.{name}\";");
+                $"public const string {name} = {Quote(format.Apply(enumType.Name, name))};");
         }
 
         writer.Line(depth, "}");
@@ -272,6 +275,9 @@ internal static class ErrorCodeProviderWriter
 
         writer.Line(depth, "}");
     }
+
+    private static string Quote(string text) =>
+        "\"" + text.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
 
     private static string AccessibilityOf(INamedTypeSymbol enumType) =>
         enumType.DeclaredAccessibility == Accessibility.Public

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/Rules.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/Rules.cs
@@ -35,4 +35,20 @@ internal static class Rules
         "Usage",
         DiagnosticSeverity.Error,
         true);
+
+    public static readonly DiagnosticDescriptor UnusableFormat = new(
+        "WMG0005",
+        "The error code format cannot be used",
+        "The error code format for '{0}' cannot be used: {1}",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true);
+
+    public static readonly DiagnosticDescriptor FormatOmitsMember = new(
+        "WMG0006",
+        "The error code format does not distinguish members",
+        "The error code format for '{0}' has no '{{member}}' placeholder, so every member would get the same code",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true);
 }

--- a/src/Waystone.Monads/PublicAPI.Shipped.txt
+++ b/src/Waystone.Monads/PublicAPI.Shipped.txt
@@ -246,8 +246,13 @@ Waystone.Monads.Results.Errors.ErrorCode
 Waystone.Monads.Results.Errors.ErrorCode.ErrorCode(Waystone.Monads.Results.Errors.ErrorCode! original) -> void
 Waystone.Monads.Results.Errors.ErrorCode.ErrorCode(string! value) -> void
 Waystone.Monads.Results.Errors.ErrorCode.Value.get -> string!
+Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute
+Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute.ErrorCodeFormatAttribute(string! format) -> void
+Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute.Format.get -> string!
 Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute
 Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute.ErrorCodeProviderAttribute() -> void
+Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute.Format.get -> string?
+Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute.Format.set -> void
 Waystone.Monads.Results.Extensions.AndThenExtensions
 Waystone.Monads.Results.Extensions.AndThenExtensions.extension<TOk, TErr>(System.Threading.Tasks.Task<Waystone.Monads.Results.Result<TOk, TErr>!>!)
 Waystone.Monads.Results.Extensions.AndThenExtensions.extension<TOk, TErr>(System.Threading.Tasks.Task<Waystone.Monads.Results.Result<TOk, TErr>!>!).AndThenAsync<TOut>(System.Func<TOk, System.Threading.Tasks.Task<Waystone.Monads.Results.Result<TOut, TErr>!>!>! factory) -> System.Threading.Tasks.ValueTask<Waystone.Monads.Results.Result<TOut, TErr>!>

--- a/src/Waystone.Monads/Results/Errors/ErrorCodeFormatAttribute.cs
+++ b/src/Waystone.Monads/Results/Errors/ErrorCodeFormatAttribute.cs
@@ -1,0 +1,43 @@
+namespace Waystone.Monads.Results.Errors;
+
+using System;
+
+/// <summary>
+/// Sets the scheme every generated error code in this project follows, for each
+/// enum that does not set its own through
+/// <see cref="ErrorCodeProviderAttribute.Format" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply once, at assembly level: <c>[assembly: ErrorCodeFormat("{enum:kebab}.{member:kebab}")]</c>.
+/// </para>
+/// <para>
+/// Takes the placeholders <c>{enum}</c> and <c>{member}</c>, each optionally
+/// followed by a casing: <c>kebab</c>, <c>snake</c>, <c>lower</c> or <c>upper</c>.
+/// Write a literal brace as <c>{{</c> or <c>}}</c>. Without this attribute the
+/// scheme is <c>"{enum}.{member}"</c>, which is what the default
+/// <see cref="Configs.ErrorCodeFactory" /> produces.
+/// </para>
+/// <para>
+/// The scheme is baked into the generated members at build time, so it applies
+/// per project. An enum in a referenced assembly keeps the scheme that assembly
+/// was built with.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class ErrorCodeFormatAttribute : Attribute
+{
+    /// <summary>
+    /// Sets the scheme every generated error code in this project follows.
+    /// </summary>
+    /// <param name="format">
+    /// The scheme, for example <c>"{enum:kebab}.{member:kebab}"</c>.
+    /// </param>
+    public ErrorCodeFormatAttribute(string format)
+    {
+        Format = format;
+    }
+
+    /// <summary>The scheme the generated codes follow.</summary>
+    public string Format { get; }
+}

--- a/src/Waystone.Monads/Results/Errors/ErrorCodeProviderAttribute.cs
+++ b/src/Waystone.Monads/Results/Errors/ErrorCodeProviderAttribute.cs
@@ -30,4 +30,22 @@ using System;
 [AttributeUsage(AttributeTargets.Enum)]
 public sealed class ErrorCodeProviderAttribute : Attribute
 {
+    /// <summary>
+    /// The scheme the generated codes of this enum follow, overriding any
+    /// <see cref="ErrorCodeFormatAttribute" /> on the assembly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Takes the placeholders <c>{enum}</c> and <c>{member}</c>, each optionally
+    /// followed by a casing: <c>kebab</c>, <c>snake</c>, <c>lower</c> or
+    /// <c>upper</c>. Write a literal brace as <c>{{</c> or <c>}}</c>. Defaults to
+    /// <c>"{enum}.{member}"</c>, which is the scheme the default
+    /// <see cref="Configs.ErrorCodeFactory" /> produces.
+    /// </para>
+    /// <para>
+    /// For example <c>"order.{member:kebab}"</c> gives the member
+    /// <c>NotFound</c> the code <c>order.not-found</c>.
+    /// </para>
+    /// </remarks>
+    public string? Format { get; set; }
 }

--- a/test/Waystone.Monads.Analyzers.Tests/ErrorCodeReuseAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/ErrorCodeReuseAnalyzerTests.cs
@@ -165,4 +165,102 @@ public class ErrorCodeReuseAnalyzerTests
                 }
             }
             """);
+
+    /// <summary>
+    /// The rule keys on the generated code, not the enum name, so a shared format
+    /// makes differently named enums collide. This is the false negative the rule
+    /// would have had if it kept deriving the code from the enum name.
+    /// </summary>
+    [Fact]
+    public Task FlagsACollisionCausedByASharedFormat() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider(Format = "order.{member:kebab}")]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+
+            namespace Shipping
+            {
+                [ErrorCodeProvider(Format = "order.{member:kebab}")]
+                internal enum ShipmentError
+                {
+                    {|#0:NotFound|},
+                }
+            }
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeReusedAcrossEnums)
+                  .WithLocation(0)
+                  .WithArguments(
+                       "Ordering.OrderError.NotFound",
+                       "Shipping.ShipmentError.NotFound",
+                       "order.not-found"));
+
+    /// <summary>
+    /// And the false positive: two enums sharing a name no longer collide once their
+    /// formats differ.
+    /// </summary>
+    [Fact]
+    public Task IgnoresASharedNameWhenTheFormatsDiffer() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider(Format = "order.{member}")]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+
+            namespace Shipping
+            {
+                [ErrorCodeProvider(Format = "shipping.{member}")]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+            """);
+
+    [Fact]
+    public Task AppliesTheAssemblyWideFormat() =>
+        Verify.RawAnalyzerAsync<ErrorCodeReuseAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            [assembly: ErrorCodeFormat("{member:kebab}")]
+
+            namespace Ordering
+            {
+                [ErrorCodeProvider]
+                internal enum OrderError
+                {
+                    NotFound,
+                }
+            }
+
+            namespace Shipping
+            {
+                [ErrorCodeProvider]
+                internal enum ShipmentError
+                {
+                    {|#0:NotFound|},
+                }
+            }
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeReusedAcrossEnums)
+                  .WithLocation(0)
+                  .WithArguments(
+                       "Ordering.OrderError.NotFound",
+                       "Shipping.ShipmentError.NotFound",
+                       "not-found"));
 }

--- a/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeFormatGenerationTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeFormatGenerationTests.cs
@@ -1,0 +1,157 @@
+namespace Waystone.Monads.SourceGenerators;
+
+using Shouldly;
+using Xunit;
+
+public sealed class ErrorCodeFormatGenerationTests
+{
+    private const string Enum = """
+        [ErrorCodeProvider]
+        public enum OrderError
+        {
+            NotFound,
+        }
+        """;
+
+    [Fact]
+    public void DefaultsToTheFactoryScheme()
+    {
+        GeneratorRun run = Verify.Run(Enum);
+
+        run.CompilationDiagnostics.ShouldBeEmpty();
+        run.GeneratorDiagnostics.ShouldBeEmpty();
+        run.Source.ShouldContain("NotFound = \"OrderError.NotFound\";");
+    }
+
+    [Fact]
+    public void TakesTheFormatFromTheEnum()
+    {
+        GeneratorRun run = Verify.Run(
+            """
+            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            public enum OrderError
+            {
+                NotFound,
+                AlreadyShipped,
+            }
+            """);
+
+        run.CompilationDiagnostics.ShouldBeEmpty();
+        run.Source.ShouldContain("NotFound = \"order.not-found\";");
+        run.Source.ShouldContain("AlreadyShipped = \"order.already-shipped\";");
+    }
+
+    [Fact]
+    public void TakesTheFormatFromTheAssembly()
+    {
+        GeneratorRun run = Verify.RunWithAssemblyAttributes(
+            """[assembly: ErrorCodeFormat("{enum:kebab}/{member:snake}")]""",
+            Enum);
+
+        run.CompilationDiagnostics.ShouldBeEmpty();
+        run.Source.ShouldContain("NotFound = \"order-error/not_found\";");
+    }
+
+    [Fact]
+    public void TheEnumOverridesTheAssembly()
+    {
+        GeneratorRun run = Verify.RunWithAssemblyAttributes(
+            """[assembly: ErrorCodeFormat("{enum:kebab}/{member:snake}")]""",
+            """
+            [ErrorCodeProvider(Format = "{member:upper}")]
+            public enum OrderError
+            {
+                NotFound,
+            }
+            """);
+
+        run.CompilationDiagnostics.ShouldBeEmpty();
+        run.Source.ShouldContain("NotFound = \"NOTFOUND\";");
+    }
+
+    [Fact]
+    public void AppliesTheFormatToTheUndeclaredValueArmToo()
+    {
+        GeneratorRun run = Verify.Run(
+            """
+            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            public enum OrderError
+            {
+                NotFound,
+            }
+            """);
+
+        run.CompilationDiagnostics.ShouldBeEmpty();
+        run.Source.ShouldContain("return \"order.\" + value.ToString();");
+
+        run.Source.ShouldContain(
+            "return new global::Waystone.Monads.Results.Errors.ErrorCode(\"order.\" + value.ToString());");
+    }
+
+    [Fact]
+    public void ReportsAnUnusableFormat()
+    {
+        GeneratorRun run = Verify.Run(
+            """
+            [ErrorCodeProvider(Format = "{member:pascal}")]
+            public enum OrderError
+            {
+                NotFound,
+            }
+            """);
+
+        run.DiagnosticIds.ShouldBe(["WMG0005"]);
+        run.Source.ShouldBeEmpty();
+
+        run.GeneratorDiagnostics[0]
+           .GetMessage()
+           .ShouldContain("'pascal' is not a casing");
+    }
+
+    [Fact]
+    public void ReportsAFormatThatDoesNotDistinguishMembers()
+    {
+        GeneratorRun run = Verify.Run(
+            """
+            [ErrorCodeProvider(Format = "{enum:kebab}")]
+            public enum OrderError
+            {
+                NotFound,
+                AlreadyShipped,
+            }
+            """);
+
+        run.DiagnosticIds.ShouldBe(["WMG0006"]);
+        run.Source.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// A custom format changes what <c>WM2018</c> sees, since that rule keys on the
+    /// generated code rather than on the enum name. Two enums with different names
+    /// can now collide, and two enums sharing a name need not.
+    /// </summary>
+    [Fact]
+    public void AFormatCanMakeDifferentlyNamedEnumsShareACode()
+    {
+        GeneratorRun first = Verify.Run(
+            """
+            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            public enum OrderError
+            {
+                NotFound,
+            }
+            """);
+
+        GeneratorRun second = Verify.Run(
+            """
+            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            public enum ShipmentError
+            {
+                NotFound,
+            }
+            """);
+
+        first.Source.ShouldContain("\"order.not-found\"");
+        second.Source.ShouldContain("\"order.not-found\"");
+    }
+}

--- a/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeFormatTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeFormatTests.cs
@@ -1,0 +1,122 @@
+namespace Waystone.Monads.SourceGenerators;
+
+using Shouldly;
+using Waystone.Monads.SourceGenerators.ErrorCodes;
+using Xunit;
+
+public sealed class ErrorCodeFormatTests
+{
+    [Theory]
+    [InlineData("{enum}.{member}", "OrderError", "NotFound", "OrderError.NotFound")]
+    [InlineData("{member}", "OrderError", "NotFound", "NotFound")]
+    [InlineData("order.{member}", "OrderError", "NotFound", "order.NotFound")]
+    [InlineData("{enum}/{member}", "OrderError", "NotFound", "OrderError/NotFound")]
+    [InlineData("{{{member}}}", "OrderError", "NotFound", "{NotFound}")]
+    public void AppliesLiteralsAndPlaceholders(
+        string format,
+        string enumName,
+        string memberName,
+        string expected)
+    {
+        ErrorCodeFormat.TryParse(format, out ErrorCodeFormat? parsed, out string? error)
+                       .ShouldBeTrue(error);
+
+        parsed!.Apply(enumName, memberName).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("kebab", "NotFound", "not-found")]
+    [InlineData("kebab", "HTTPNotFound", "http-not-found")]
+    [InlineData("kebab", "Error404", "error-404")]
+    [InlineData("kebab", "Already_Shipped", "already-shipped")]
+    [InlineData("kebab", "Payment", "payment")]
+    [InlineData("snake", "NotFound", "not_found")]
+    [InlineData("snake", "HTTPNotFound", "http_not_found")]
+    [InlineData("lower", "NotFound", "notfound")]
+    [InlineData("upper", "NotFound", "NOTFOUND")]
+    public void AppliesTheCasing(string casing, string memberName, string expected)
+    {
+        ErrorCodeFormat.TryParse(
+                            "{member:" + casing + "}",
+                            out ErrorCodeFormat? parsed,
+                            out string? error)
+                       .ShouldBeTrue(error);
+
+        parsed!.Apply("OrderError", memberName).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void CasesTheEnumAndMemberIndependently()
+    {
+        ErrorCodeFormat.TryParse(
+            "{enum:upper}.{member:kebab}",
+            out ErrorCodeFormat? parsed,
+            out _);
+
+        parsed!.Apply("OrderError", "NotFound").ShouldBe("ORDERERROR.not-found");
+    }
+
+    [Theory]
+    [InlineData("", "the format is empty")]
+    [InlineData("{member", "is not closed")]
+    [InlineData("a}b{member}", "closes nothing")]
+    [InlineData("{code}", "is not a placeholder")]
+    [InlineData("{member:pascal}", "is not a casing")]
+    public void RejectsAnUnusableFormat(string format, string expected)
+    {
+        ErrorCodeFormat.TryParse(format, out ErrorCodeFormat? parsed, out string? error)
+                       .ShouldBeFalse();
+
+        parsed.ShouldBeNull();
+        error.ShouldNotBeNull().ShouldContain(expected);
+    }
+
+    [Theory]
+    [InlineData("{enum}.{member}", true)]
+    [InlineData("{member:kebab}", true)]
+    [InlineData("{enum}", false)]
+    [InlineData("literal", false)]
+    public void KnowsWhetherTheMemberIsUsed(string format, bool expected)
+    {
+        ErrorCodeFormat.TryParse(format, out ErrorCodeFormat? parsed, out _);
+
+        parsed!.UsesMember.ShouldBe(expected);
+    }
+
+    /// <summary>
+    /// The undeclared-value expression folds every part that does not depend on the
+    /// member into a literal, so the emitted code is a concatenation of constants
+    /// around one <c>ToString()</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("{enum}.{member}", "\"OrderError.\" + value.ToString()")]
+    [InlineData("{member}", "value.ToString()")]
+    [InlineData("{enum:kebab}/{member}-x", "\"order-error/\" + value.ToString() + \"-x\"")]
+    public void RendersTheUndeclaredValueExpression(string format, string expected)
+    {
+        ErrorCodeFormat.TryParse(format, out ErrorCodeFormat? parsed, out _);
+
+        parsed!.ApplyToUndeclared("OrderError", "value.ToString()")
+               .ShouldBe(expected);
+    }
+
+    /// <summary>
+    /// All four casings are the identity on digits, which is why the member's casing
+    /// is dropped from the undeclared-value expression rather than emitted as a
+    /// runtime call.
+    /// </summary>
+    [Theory]
+    [InlineData("kebab")]
+    [InlineData("snake")]
+    [InlineData("lower")]
+    [InlineData("upper")]
+    public void EveryCasingIsTheIdentityOnDigits(string casing)
+    {
+        ErrorCodeFormat.TryParse(
+            "{member:" + casing + "}",
+            out ErrorCodeFormat? parsed,
+            out _);
+
+        parsed!.Apply("OrderError", "99").ShouldBe("99");
+    }
+}

--- a/test/Waystone.Monads.SourceGenerators.Tests/Verify.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/Verify.cs
@@ -25,7 +25,23 @@ internal static class Verify
     /// generated along with every diagnostic the run produced.
     /// </summary>
     public static GeneratorRun Run(string source) =>
-        Run(source, withMonadsReference: true);
+        Run(Preamble + source, withMonadsReference: true);
+
+    /// <summary>
+    /// Runs the generator with assembly-level attributes, which have to precede the
+    /// file-scoped namespace and so cannot be appended to the preamble.
+    /// </summary>
+    public static GeneratorRun RunWithAssemblyAttributes(
+        string attributes,
+        string source) =>
+        Run(
+            "using Waystone.Monads.Results.Errors;"
+          + Environment.NewLine
+          + attributes
+          + Environment.NewLine
+          + Preamble
+          + source,
+            withMonadsReference: true);
 
     /// <summary>
     /// Runs the generator over a compilation that does not reference
@@ -76,9 +92,7 @@ internal static class Verify
 
     private static GeneratorRun Run(string source, bool withMonadsReference)
     {
-        CSharpCompilation compilation = Compile(
-            withMonadsReference ? Preamble + source : source,
-            withMonadsReference);
+        CSharpCompilation compilation = Compile(source, withMonadsReference);
 
         GeneratorDriver driver = Driver()
            .RunGeneratorsAndUpdateCompilation(


### PR DESCRIPTION
`[ErrorCodeProvider]` baked in one scheme, `{enum}.{member}`, which is the
default `ErrorCodeFactory`'s. A consumer who wanted anything else had to install
a factory, and a factory cannot reach the generated members — the generator runs
at build time and cannot execute user code. So the two disagreed, with no way to
close the gap.

The scheme is now declarative. `Format` on the attribute, `[assembly:
ErrorCodeFormat]` for a project-wide default, `{enum}` and `{member}` with an
optional `kebab`, `snake`, `lower` or `upper` casing. Precedence is the enum,
then the assembly, then `{enum}.{member}` — so an enum that sets nothing is
unchanged.

WMG0005 reports a format that does not parse and WMG0006 one that leaves out
`{member}`, which would give every member the same code.

WM2018 keys on the generated code rather than on the enum name, so it has to
resolve the format identically or it is wrong in both directions: two
differently named enums sharing a format collide and would go unreported, and
two enums sharing a name with different formats do not collide and would be
reported anyway. `ErrorCodeFormat.cs` is compiled into the analyzers assembly as
a linked source file — the two assemblies cannot reference each other, and a
second copy of the parser could drift from the first.

Refs DRA-89, DRA-112

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>