### PR TITLE
feat: review generated error codes against a committed registry

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/.globalconfig
+++ b/sample/Waystone.Monads.Analyzers.Sample/.globalconfig
@@ -1,0 +1,9 @@
+# WM2019 and WM2020 ship as suggestions. A project that commits an ErrorCodes.txt
+# wants a divergence to be visible in CI, so raise them here.
+#
+# This has to be a global config rather than an .editorconfig section: WM2020 is
+# reported against ErrorCodes.txt, which has no syntax tree, and a path-matched
+# [*] section cannot set the severity of a diagnostic that has no tree.
+is_global = true
+dotnet_diagnostic.WM2019.severity = warning
+dotnet_diagnostic.WM2020.severity = warning

--- a/sample/Waystone.Monads.Analyzers.Sample/ErrorCodes.txt
+++ b/sample/Waystone.Monads.Analyzers.Sample/ErrorCodes.txt
@@ -1,0 +1,7 @@
+# Every error code this project publishes. WM2019 and WM2020 keep it honest;
+# the code fix on WM2019 rewrites it. Read the diff before committing one.
+order.address-incomplete
+order.already-shipped
+order.not-found
+order.out-of-stock
+order.payment-declined

--- a/sample/Waystone.Monads.Analyzers.Sample/README.md
+++ b/sample/Waystone.Monads.Analyzers.Sample/README.md
@@ -53,6 +53,14 @@ actually put on a wire, and it is reached declaratively — no `ErrorCodeFactory
 subclass, and nothing to install at startup. The format is evaluated at build time, so
 `StatusCodeFor` still switches on constants.
 
+`ErrorCodes.txt` lists every code the project publishes, and the `AdditionalFiles` item
+in the csproj is what opts in. `WM2019` reports a generated code the file does not list
+and `WM2020` an entry nothing generates, so a rename cannot change a wire contract
+without showing up as a line in a diff. The `.globalconfig` raises both to warnings —
+and it has to be a global config rather than an `.editorconfig` section, because
+`WM2020` is reported against `ErrorCodes.txt`, which has no syntax tree for a
+path-matched section to apply to.
+
 Two details are pinned here on purpose, so a change to either breaks this build rather
 than only a snapshot test:
 

--- a/sample/Waystone.Monads.Analyzers.Sample/Waystone.Monads.Analyzers.Sample.csproj
+++ b/sample/Waystone.Monads.Analyzers.Sample/Waystone.Monads.Analyzers.Sample.csproj
@@ -11,6 +11,10 @@
         <ProjectReference Include="..\..\src\Waystone.Monads\Waystone.Monads.csproj"/>
     </ItemGroup>
 
+    <ItemGroup Label="Opts this project into the error code registry rules">
+        <AdditionalFiles Include="ErrorCodes.txt"/>
+    </ItemGroup>
+
     <Import Project="..\..\src\Waystone.Monads.Analyzers\Waystone.Monads.Analyzers.props"/>
     <Import Project="..\..\src\Waystone.Monads.SourceGenerators\Waystone.Monads.SourceGenerators.props"/>
 

--- a/src/Waystone.Monads.Analyzers.CodeFixes/UpdateErrorCodeRegistryCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/UpdateErrorCodeRegistryCodeFix.cs
@@ -1,0 +1,80 @@
+namespace Waystone.Monads.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Writes the error code registry the compilation implies.
+/// </summary>
+/// <remarks>
+/// Not a <see cref="MonadCodeFix" />: that base resolves a syntax node and a semantic
+/// model for the document the diagnostic sits in, and this fix edits an additional
+/// document and needs neither.
+/// <para>
+/// One invocation writes the whole file, so a run started from any one missing code
+/// also takes out every stale entry. That is what makes the absence of a fix-all
+/// provider harmless — a fix-all would apply the same rewrite once per diagnostic.
+/// </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class UpdateErrorCodeRegistryCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("WM2019");
+
+    public override FixAllProvider? GetFixAllProvider() => null;
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        TextDocument? registry = context.Document.Project.AdditionalDocuments
+           .FirstOrDefault(document => ErrorCodeRegistry.Matches(document.Name));
+
+        if (registry is null) return Task.CompletedTask;
+
+        DocumentId id = registry.Id;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Update " + ErrorCodeRegistry.FileName,
+                token => UpdateAsync(context.Document.Project, id, token),
+                nameof(UpdateErrorCodeRegistryCodeFix)),
+            context.Diagnostics);
+
+        return Task.CompletedTask;
+    }
+
+    private static async Task<Solution> UpdateAsync(
+        Project project,
+        DocumentId id,
+        CancellationToken cancellationToken)
+    {
+        TextDocument? registry = project.GetAdditionalDocument(id);
+
+        Compilation? compilation =
+            await project.GetCompilationAsync(cancellationToken)
+                         .ConfigureAwait(false);
+
+        if (registry is null || compilation is null) return project.Solution;
+
+        var symbols = MonadSymbols.TryCreate(compilation);
+
+        if (symbols?.ErrorCodeProviderAttribute is null) return project.Solution;
+
+        SourceText existing = await registry.GetTextAsync(cancellationToken)
+                                            .ConfigureAwait(false);
+
+        return project.Solution.WithAdditionalDocumentText(
+            id,
+            SourceText.From(
+                ErrorCodeRegistry.Render(
+                    existing,
+                    ErrorCodeProviders.CodesIn(compilation, symbols))));
+    }
+}

--- a/src/Waystone.Monads.Analyzers/AGENTS.md
+++ b/src/Waystone.Monads.Analyzers/AGENTS.md
@@ -39,6 +39,33 @@ from the enum name instead is wrong in both directions once anyone sets a format
 `FlagsACollisionCausedByASharedFormat` and `IgnoresASharedNameWhenTheFormatsDiffer`
 pin both.
 
+**A diagnostic reported from a compilation end action cannot have a code fix.** It
+lands in `AnalysisResult.CompilationDiagnostics` and is a *non-local* diagnostic even
+when its location is an ordinary source span; Roslyn's code fix service will not offer
+a fix for one, and `CodeFixTest` fails with "Code fix is attempting to provide a fix for
+a non-local analyzer diagnostic" rather than letting you ship a fix nobody can reach.
+`CodeFixTestBehaviors.SkipLocalDiagnosticCheck` silences the test and changes nothing
+about the IDE, so do not reach for it. This is why `WM2019` reports from a symbol action
+and `WM2020` — which cannot know an entry is stale until every enum has been seen — has
+no fix at all. Both rules read the same two sets; the split is entirely about
+fixability.
+
+**A rule that reports from a compilation end action needs
+`WellKnownDiagnosticTags.CompilationEnd`.** Roslyn reads the tag to decide when to run
+the end action, so without it the rule can go quiet in the IDE while still firing on the
+command line. `WM2018` and `WM2020` are the only two, and
+`RulesTests.OnlyTheAggregatingRulesAreTaggedCompilationEnd` pins the pair, because
+nothing in the build notices a missing tag.
+
+**A path-based `.editorconfig` cannot set the severity of `WM2020`.** Roslyn resolves
+`dotnet_diagnostic.X.severity` per syntax tree, and `WM2020` is reported against
+`ErrorCodes.txt`, which has none — so a `[*]` section is simply not consulted and the
+rule stays at its default however the section is written. Escalating it takes a global
+analyzer config: `is_global = true` in a `.globalconfig`. `WM2019` is reported on the
+enum member and does respond to `.editorconfig`, so the two rules need different
+configuration to reach the same severity. The sample carries a `.globalconfig` that
+does it, which is the only executable statement of this anywhere.
+
 **`WM2018` is the only rule that aggregates across declarations.** Every other
 analyzer decides from one node or one symbol; `ErrorCodeReuseAnalyzer` has to see two
 enums at once, so it collects into a `ConcurrentBag` under `RegisterSymbolAction` and

--- a/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.Analyzers/AnalyzerReleases.Shipped.md
@@ -76,3 +76,5 @@ WM2014 | Usage | Info | FlatMap has been renamed to AndThen
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 WM2018 | Usage | Info | An error code is reused across enums
+WM2019 | Usage | Info | A generated error code is not in the error code registry
+WM2020 | Usage | Info | The error code registry lists a code nothing generates

--- a/src/Waystone.Monads.Analyzers/ErrorCodeProviders.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeProviders.cs
@@ -1,0 +1,168 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Waystone.Monads.SourceGenerators.ErrorCodes;
+
+/// <summary>
+/// The error codes an <c>[ErrorCodeProvider]</c> enum generates, resolved the way the
+/// generator resolves them.
+/// </summary>
+/// <remarks>
+/// Both <c>WM2018</c> and <c>WM2019</c> key on the generated code rather than on the
+/// enum's name, so both have to apply the declared format and both have to apply the
+/// same one. <c>ErrorCodeFormat</c> is the generator's own parser, compiled into this
+/// assembly as a linked source file, so the three cannot disagree about what an enum
+/// produces.
+/// </remarks>
+public static class ErrorCodeProviders
+{
+    /// <summary>
+    /// One entry per member of <paramref name="type" /> when it is an attributed enum,
+    /// and nothing at all when it is not.
+    /// </summary>
+    public static ImmutableArray<Provided> Collect(
+        INamedTypeSymbol type,
+        MonadSymbols symbols,
+        string? assemblyFormat)
+    {
+        if (type.TypeKind != TypeKind.Enum) return ImmutableArray<Provided>.Empty;
+
+        AttributeData? provider = type.GetAttributes()
+           .FirstOrDefault(
+                attribute => SymbolEqualityComparer.Default.Equals(
+                    attribute.AttributeClass,
+                    symbols.ErrorCodeProviderAttribute));
+
+        if (provider is null) return ImmutableArray<Provided>.Empty;
+
+        if (!ErrorCodeFormat.TryParse(
+                DeclaredFormat(provider) ?? assemblyFormat ?? ErrorCodeFormat.Default,
+                out ErrorCodeFormat? format,
+                out _))
+        {
+            return ImmutableArray<Provided>.Empty;
+        }
+
+        ImmutableArray<Provided>.Builder provided =
+            ImmutableArray.CreateBuilder<Provided>();
+
+        foreach (IFieldSymbol member in type.GetMembers().OfType<IFieldSymbol>())
+        {
+            if (!member.IsConst) continue;
+
+            provided.Add(new Provided(member, format!.Apply(type.Name, member.Name)));
+        }
+
+        return provided.ToImmutable();
+    }
+
+    /// <summary>
+    /// Every code the compilation's attributed enums generate, wherever they are
+    /// declared.
+    /// </summary>
+    /// <remarks>
+    /// This walks the whole compilation, which an analyzer must not do — it is here
+    /// for the code fix, which has no symbol callbacks to hang off and one edit to
+    /// make.
+    /// </remarks>
+    public static ImmutableArray<string> CodesIn(
+        Compilation compilation,
+        MonadSymbols symbols)
+    {
+        string? assemblyFormat = AssemblyFormat(compilation);
+
+        ImmutableArray<string>.Builder codes = ImmutableArray.CreateBuilder<string>();
+
+        foreach (INamedTypeSymbol type in Types(compilation.GlobalNamespace))
+        {
+            foreach (Provided provided in Collect(type, symbols, assemblyFormat))
+            {
+                codes.Add(provided.Code);
+            }
+        }
+
+        return codes.ToImmutable();
+    }
+
+    /// <summary>
+    /// The format the assembly declares through <c>[ErrorCodeFormat]</c>, or
+    /// <c>null</c> when it declares none.
+    /// </summary>
+    public static string? AssemblyFormat(Compilation compilation)
+    {
+        foreach (AttributeData attribute in compilation.Assembly.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString()
+             != MonadSymbols.ErrorCodeFormatAttributeMetadataName)
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 1
+             && attribute.ConstructorArguments[0].Value is string format)
+            {
+                return format;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> Types(INamespaceSymbol space)
+    {
+        foreach (INamespaceOrTypeSymbol member in space.GetMembers())
+        {
+            if (member is INamespaceSymbol nested)
+            {
+                foreach (INamedTypeSymbol type in Types(nested)) yield return type;
+            }
+            else if (member is INamedTypeSymbol type)
+            {
+                yield return type;
+
+                foreach (INamedTypeSymbol inner in Nested(type)) yield return inner;
+            }
+        }
+    }
+
+    private static IEnumerable<INamedTypeSymbol> Nested(INamedTypeSymbol type)
+    {
+        foreach (INamedTypeSymbol member in type.GetTypeMembers())
+        {
+            yield return member;
+
+            foreach (INamedTypeSymbol inner in Nested(member)) yield return inner;
+        }
+    }
+
+    private static string? DeclaredFormat(AttributeData provider)
+    {
+        foreach (KeyValuePair<string, TypedConstant> argument in
+                 provider.NamedArguments)
+        {
+            if (argument.Key == "Format" && argument.Value.Value is string declared)
+            {
+                return declared;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>One enum member and the code it generates.</summary>
+    public readonly struct Provided
+    {
+        public Provided(IFieldSymbol member, string code)
+        {
+            Member = member;
+            Code = code;
+        }
+
+        public IFieldSymbol Member { get; }
+
+        public string Code { get; }
+    }
+}

--- a/src/Waystone.Monads.Analyzers/ErrorCodeRegistry.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeRegistry.cs
@@ -1,0 +1,144 @@
+namespace Waystone.Monads.Analyzers;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+/// <summary>
+/// The committed list of every error code an <c>[ErrorCodeProvider]</c> enum in the
+/// project generates.
+/// </summary>
+/// <remarks>
+/// A project opts in by adding an <c>ErrorCodes.txt</c> as an
+/// <c>AdditionalFiles</c> item, the way a project opts into the public API analyzers
+/// by adding a <c>PublicAPI.Shipped.txt</c>. Nothing else turns the rules on, and a
+/// project without the file never sees them.
+/// <para>
+/// The file is not generated. A generator cannot write it — <c>RS1035</c> bans file
+/// IO in an analyzer or a generator, and for good reason: a build that writes into
+/// the source tree is not reproducible and races itself under parallel builds. So the
+/// registry is an ordinary committed file, a diagnostic reports when it diverges from
+/// the compilation, and a code fix writes the correction through the workspace.
+/// </para>
+/// </remarks>
+public static class ErrorCodeRegistry
+{
+    /// <summary>The name of the file, matched without regard to its directory.</summary>
+    public const string FileName = "ErrorCodes.txt";
+
+    /// <summary>
+    /// Whether <paramref name="path" /> names the registry, whatever directory it is
+    /// in.
+    /// </summary>
+    public static bool Matches(string? path) =>
+        path is not null
+     && string.Equals(NameOf(path), FileName, StringComparison.OrdinalIgnoreCase);
+
+    internal static AdditionalText? Find(ImmutableArray<AdditionalText> files)
+    {
+        foreach (AdditionalText file in files)
+        {
+            if (Matches(file.Path)) return file;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The codes the file lists, in the order it lists them. Blank lines and lines
+    /// starting with <c>#</c> are ignored, and a repeated code is kept once.
+    /// </summary>
+    internal static ImmutableArray<Entry> Parse(SourceText text)
+    {
+        ImmutableArray<Entry>.Builder entries = ImmutableArray.CreateBuilder<Entry>();
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (TextLine line in text.Lines)
+        {
+            string content = line.ToString().Trim();
+
+            if (content.Length == 0 || content[0] == '#') continue;
+
+            if (!seen.Add(content)) continue;
+
+            entries.Add(
+                new Entry(
+                    content,
+                    line.Span,
+                    text.Lines.GetLinePositionSpan(line.Span)));
+        }
+
+        return entries.ToImmutable();
+    }
+
+    /// <summary>
+    /// The content the file should have: its leading comment block, then every code
+    /// once, ordinally sorted.
+    /// </summary>
+    /// <remarks>
+    /// Sorting means a rename shows up as one removal and one addition rather than as
+    /// a reordering of everything after it, which is the whole point of committing the
+    /// file. The existing line ending is kept so the rewrite does not turn the file
+    /// over from CRLF to LF or back on whoever runs the fix.
+    /// <para>
+    /// Public because the code fix calls it. The fix recomputes the file from the
+    /// compilation rather than reading it off the diagnostic: WM2019 has to be a local
+    /// diagnostic for a fix to be offered at all, and a local diagnostic knows only
+    /// about its own enum.
+    /// </para>
+    /// </remarks>
+    public static string Render(SourceText existing, IEnumerable<string> codes)
+    {
+        string newLine = existing.ToString().IndexOf("\r\n", StringComparison.Ordinal)
+                      >= 0
+            ? "\r\n"
+            : "\n";
+
+        var builder = new StringBuilder();
+
+        foreach (TextLine line in existing.Lines)
+        {
+            string content = line.ToString().Trim();
+
+            if (content.Length == 0 || content[0] != '#') break;
+
+            builder.Append(content).Append(newLine);
+        }
+
+        foreach (string code in codes.Distinct(StringComparer.Ordinal)
+                                     .OrderBy(code => code, StringComparer.Ordinal))
+        {
+            builder.Append(code).Append(newLine);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string NameOf(string path)
+    {
+        int separator = path.LastIndexOfAny(new[] { '/', '\\' });
+
+        return separator < 0 ? path : path.Substring(separator + 1);
+    }
+
+    internal readonly struct Entry
+    {
+        public Entry(string code, TextSpan span, LinePositionSpan lineSpan)
+        {
+            Code = code;
+            Span = span;
+            LineSpan = lineSpan;
+        }
+
+        public string Code { get; }
+
+        public TextSpan Span { get; }
+
+        public LinePositionSpan LineSpan { get; }
+    }
+}

--- a/src/Waystone.Monads.Analyzers/ErrorCodeRegistryAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeRegistryAnalyzer.cs
@@ -1,0 +1,118 @@
+namespace Waystone.Monads.Analyzers;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ErrorCodeRegistryAnalyzer : MonadAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(
+            Rules.ErrorCodeMissingFromRegistry,
+            Rules.StaleErrorCodeRegistryEntry);
+
+    protected override void Register(
+        CompilationStartAnalysisContext context,
+        MonadSymbols symbols)
+    {
+        if (symbols.ErrorCodeProviderAttribute is null) return;
+
+        AdditionalText? registry =
+            ErrorCodeRegistry.Find(context.Options.AdditionalFiles);
+
+        if (registry is null) return;
+
+        SourceText? text = registry.GetText(context.CancellationToken);
+
+        if (text is null) return;
+
+        ImmutableArray<ErrorCodeRegistry.Entry> entries =
+            ErrorCodeRegistry.Parse(text);
+
+        var registered = new HashSet<string>(
+            entries.Select(entry => entry.Code),
+            StringComparer.Ordinal);
+
+        var generated = new ConcurrentBag<string>();
+
+        string? assemblyFormat =
+            ErrorCodeProviders.AssemblyFormat(context.Compilation);
+
+        context.RegisterSymbolAction(
+            symbol => Inspect(symbol, symbols, assemblyFormat, registered, generated),
+            SymbolKind.NamedType);
+
+        context.RegisterCompilationEndAction(
+            end => ReportStale(end, registry, entries, generated));
+    }
+
+    /// <summary>
+    /// Reports every member of one enum whose code the registry does not list, and
+    /// records what the enum generates for the end action.
+    /// </summary>
+    /// <remarks>
+    /// This has to be a symbol action rather than part of the compilation end action
+    /// below, even though both rules read the same set. A diagnostic reported from a
+    /// compilation end action is a non-local diagnostic, and neither Roslyn's code fix
+    /// service nor the analyzer testing library will offer a fix for one — so reporting
+    /// WM2019 from the end action would leave a rule whose fix exists and is never
+    /// reachable.
+    /// </remarks>
+    private static void Inspect(
+        SymbolAnalysisContext context,
+        MonadSymbols symbols,
+        string? assemblyFormat,
+        HashSet<string> registered,
+        ConcurrentBag<string> generated)
+    {
+        foreach (ErrorCodeProviders.Provided provided in ErrorCodeProviders.Collect(
+                     (INamedTypeSymbol)context.Symbol,
+                     symbols,
+                     assemblyFormat))
+        {
+            generated.Add(provided.Code);
+
+            if (registered.Contains(provided.Code)) continue;
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Rules.ErrorCodeMissingFromRegistry,
+                    provided.Member.Locations.FirstOrDefault(
+                        location => location.IsInSource),
+                    provided.Member.ToDisplayString(),
+                    provided.Code,
+                    ErrorCodeRegistry.FileName));
+        }
+    }
+
+    /// <summary>
+    /// Reports every entry no enum in the compilation generates, which cannot be known
+    /// until every enum has been seen.
+    /// </summary>
+    private static void ReportStale(
+        CompilationAnalysisContext context,
+        AdditionalText registry,
+        ImmutableArray<ErrorCodeRegistry.Entry> entries,
+        ConcurrentBag<string> generated)
+    {
+        var codes = new HashSet<string>(generated, StringComparer.Ordinal);
+
+        foreach (ErrorCodeRegistry.Entry stale in entries)
+        {
+            if (codes.Contains(stale.Code)) continue;
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Rules.StaleErrorCodeRegistryEntry,
+                    Location.Create(registry.Path, stale.Span, stale.LineSpan),
+                    stale.Code,
+                    ErrorCodeRegistry.FileName));
+        }
+    }
+}

--- a/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Waystone.Monads.SourceGenerators.ErrorCodes;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
@@ -21,119 +20,45 @@ public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
     {
         if (symbols.ErrorCodeProviderAttribute is null) return;
 
-        var providers = new ConcurrentBag<Provided>();
+        var providers = new ConcurrentBag<ErrorCodeProviders.Provided>();
 
-        string? assemblyFormat = AssemblyFormat(context.Compilation);
+        string? assemblyFormat =
+            ErrorCodeProviders.AssemblyFormat(context.Compilation);
 
         context.RegisterSymbolAction(
-            symbol => Collect(
-                (INamedTypeSymbol)symbol.Symbol,
-                symbols,
-                assemblyFormat,
-                providers),
+            symbol =>
+            {
+                foreach (ErrorCodeProviders.Provided provided in
+                         ErrorCodeProviders.Collect(
+                             (INamedTypeSymbol)symbol.Symbol,
+                             symbols,
+                             assemblyFormat))
+                {
+                    providers.Add(provided);
+                }
+            },
             SymbolKind.NamedType);
 
         context.RegisterCompilationEndAction(end => Report(end, providers));
     }
 
-    private static void Collect(
-        INamedTypeSymbol type,
-        MonadSymbols symbols,
-        string? assemblyFormat,
-        ConcurrentBag<Provided> providers)
-    {
-        if (type.TypeKind != TypeKind.Enum) return;
-
-        AttributeData? provider = type.GetAttributes()
-           .FirstOrDefault(
-                attribute => SymbolEqualityComparer.Default.Equals(
-                    attribute.AttributeClass,
-                    symbols.ErrorCodeProviderAttribute));
-
-        if (provider is null) return;
-
-        if (!ErrorCodeFormat.TryParse(
-                DeclaredFormat(provider) ?? assemblyFormat ?? ErrorCodeFormat.Default,
-                out ErrorCodeFormat? format,
-                out _))
-        {
-            return;
-        }
-
-        foreach (IFieldSymbol member in type.GetMembers().OfType<IFieldSymbol>())
-        {
-            if (!member.IsConst) continue;
-
-            providers.Add(
-                new Provided(member, format!.Apply(type.Name, member.Name)));
-        }
-    }
-
-    /// <summary>
-    /// The format the enum declares, resolved the same way the generator resolves
-    /// it.
-    /// </summary>
-    /// <remarks>
-    /// The rule keys on the generated code rather than on the enum name, so the
-    /// format has to be applied here too. Without it the rule is wrong in both
-    /// directions once anyone sets a format: two enums with different names and one
-    /// shared format collide and would go unreported, and two enums sharing a name
-    /// with different formats do not collide and would be reported anyway.
-    /// <c>ErrorCodeFormat</c> is compiled into this assembly from the generator's
-    /// copy rather than duplicated, so the two can only ever agree.
-    /// </remarks>
-    private static string? DeclaredFormat(AttributeData provider)
-    {
-        foreach (KeyValuePair<string, TypedConstant> argument in
-                 provider.NamedArguments)
-        {
-            if (argument.Key == "Format" && argument.Value.Value is string declared)
-            {
-                return declared;
-            }
-        }
-
-        return null;
-    }
-
-    private static string? AssemblyFormat(Compilation compilation)
-    {
-        foreach (AttributeData attribute in compilation.Assembly.GetAttributes())
-        {
-            if (attribute.AttributeClass?.ToDisplayString()
-             != MonadSymbols.ErrorCodeFormatAttributeMetadataName)
-            {
-                continue;
-            }
-
-            if (attribute.ConstructorArguments.Length == 1
-             && attribute.ConstructorArguments[0].Value is string format)
-            {
-                return format;
-            }
-        }
-
-        return null;
-    }
-
     private static void Report(
         CompilationAnalysisContext context,
-        ConcurrentBag<Provided> providers)
+        ConcurrentBag<ErrorCodeProviders.Provided> providers)
     {
-        foreach (IGrouping<string, Provided> collision in providers
+        foreach (IGrouping<string, ErrorCodeProviders.Provided> collision in providers
                     .GroupBy(provided => provided.Code, StringComparer.Ordinal)
                     .Where(group => group.Count() > 1))
         {
-            List<Provided> ordered = collision
-                                    .OrderBy(
-                                         provided =>
-                                             provided.Member.ToDisplayString(),
-                                         StringComparer.Ordinal)
-                                    .ToList();
+            List<ErrorCodeProviders.Provided> ordered = collision
+               .OrderBy(
+                    provided => provided.Member.ToDisplayString(),
+                    StringComparer.Ordinal)
+               .ToList();
 
-            Provided first = ordered[0];
+            ErrorCodeProviders.Provided first = ordered[0];
 
-            foreach (Provided later in ordered.Skip(1))
+            foreach (ErrorCodeProviders.Provided later in ordered.Skip(1))
             {
                 if (SymbolEqualityComparer.Default.Equals(
                         first.Member.ContainingType,
@@ -152,18 +77,5 @@ public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
                         collision.Key));
             }
         }
-    }
-
-    private readonly struct Provided
-    {
-        public Provided(IFieldSymbol member, string code)
-        {
-            Member = member;
-            Code = code;
-        }
-
-        public IFieldSymbol Member { get; }
-
-        public string Code { get; }
     }
 }

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -268,7 +268,40 @@ public static class Rules
         "WM2018",
         "Do not reuse an error code across enums",
         "'{0}' and '{1}' both generate the error code '{2}', so the two errors are indistinguishable to anything reading the code",
-        "An [ErrorCodeProvider] enum generates one code per member from the enum's own name and the member's, so two enums sharing a name in different namespaces generate the same code for every member name they share. No two independent error taxonomies legitimately share a wire code, and consumers reading the code cannot tell which error occurred. Rename one of the enums or the colliding member.");
+        "An [ErrorCodeProvider] enum generates one code per member from the enum's own name and the member's, so two enums sharing a name in different namespaces generate the same code for every member name they share. No two independent error taxonomies legitimately share a wire code, and consumers reading the code cannot tell which error occurred. Rename one of the enums or the colliding member.",
+        WellKnownDiagnosticTags.CompilationEnd);
+
+    /// <remarks>
+    /// Reported on the enum member rather than on the registry, because the member is
+    /// the thing a reader can act on and the registry line does not exist yet. Reported
+    /// from a symbol action rather than from the compilation end action that WM2020
+    /// uses, even though the two read the same set: a diagnostic reported at the end of
+    /// a compilation is a non-local diagnostic, and neither Roslyn's code fix service
+    /// nor the analyzer testing library offers a fix for one. Reporting from the end
+    /// action would leave the fix unreachable.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor ErrorCodeMissingFromRegistry = Idiom(
+        "WM2019",
+        "Add a generated error code to the registry",
+        "'{0}' generates the error code '{1}', which '{2}' does not list",
+        "A project with an ErrorCodes.txt has opted into reviewing its error codes as a committed list, the way PublicAPI.Shipped.txt makes the public API reviewable. A code missing from the list is a wire contract that reached consumers without anyone reading the diff. Invoke the code fix, then read the added line before committing it.");
+
+    /// <remarks>
+    /// Reported at the registry's own line, which is an external file location rather
+    /// than a location in a syntax tree. That is what the public API analyzers do for
+    /// RS0017 and it is the only honest place to point: nothing in the source
+    /// corresponds to an entry no enum generates. Whether an entry is stale cannot be
+    /// known until every enum has been seen, so this has to come from the compilation
+    /// end action, and that makes it non-local and unfixable. The WM2019 fix rewrites
+    /// the whole file including the removals, so the two travel together in practice;
+    /// a project whose only divergence is a stale entry deletes the named line by hand.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor StaleErrorCodeRegistryEntry = Idiom(
+        "WM2020",
+        "Remove an error code the project no longer generates",
+        "'{1}' lists the error code '{0}', which no error code provider in this project generates",
+        "An entry left behind by a rename or a deletion claims a code the project no longer produces, so the list stops describing the project and the review it exists for stops being worth reading. Delete the line, or restore the member that generated it if the code was removed by mistake.",
+        WellKnownDiagnosticTags.CompilationEnd);
 
     public static readonly DiagnosticDescriptor NullableReturnCouldBeOption = Migration(
         "WM3001",

--- a/test/Waystone.Monads.Analyzers.Tests/ErrorCodeRegistryAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/ErrorCodeRegistryAnalyzerTests.cs
@@ -1,0 +1,184 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Threading.Tasks;
+using Xunit;
+
+public sealed class ErrorCodeRegistryAnalyzerTests
+{
+    private const string Enum = """
+        using Waystone.Monads.Results.Errors;
+
+        namespace Ordering;
+
+        [ErrorCodeProvider]
+        public enum OrderErrorCode
+        {
+            NotFound,
+            AlreadyShipped,
+        }
+        """;
+
+    private const string Complete = """
+        OrderErrorCode.AlreadyShipped
+        OrderErrorCode.NotFound
+
+        """;
+
+    [Fact]
+    public Task SaysNothingWhenTheRegistryMatches() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(Enum, Complete);
+
+    /// <summary>
+    /// A project without the file has not opted in, so neither rule may fire however
+    /// many attributed enums it declares.
+    /// </summary>
+    [Fact]
+    public Task SaysNothingWithoutARegistry() =>
+        Verify.RawAnalyzerAsync<ErrorCodeRegistryAnalyzer>(Enum);
+
+    [Fact]
+    public Task ReportsACodeTheRegistryDoesNotList() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(
+            Enum,
+            """
+            OrderErrorCode.NotFound
+
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(9, 5, 9, 19)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.AlreadyShipped",
+                       "OrderErrorCode.AlreadyShipped",
+                       "ErrorCodes.txt"));
+
+    [Fact]
+    public Task ReportsEveryCodeWhenTheRegistryIsEmpty() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(
+            Enum,
+            "",
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(9, 5, 9, 19)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.AlreadyShipped",
+                       "OrderErrorCode.AlreadyShipped",
+                       "ErrorCodes.txt"),
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(8, 5, 8, 13)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.NotFound",
+                       "OrderErrorCode.NotFound",
+                       "ErrorCodes.txt"));
+
+    [Fact]
+    public Task ReportsAnEntryNothingGenerates() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(
+            Enum,
+            """
+            OrderErrorCode.AlreadyShipped
+            OrderErrorCode.Cancelled
+            OrderErrorCode.NotFound
+
+            """,
+            Verify.Diagnostic(Rules.StaleErrorCodeRegistryEntry)
+                  .WithSpan("ErrorCodes.txt", 2, 1, 2, 25)
+                  .WithArguments("OrderErrorCode.Cancelled", "ErrorCodes.txt"));
+
+    /// <summary>
+    /// The registry holds the generated code, so a format changes every line of it.
+    /// A file listing the default codes is entirely stale once the enum declares a
+    /// format, and entirely missing the new ones.
+    /// </summary>
+    [Fact]
+    public Task FollowsTheDeclaredFormat() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering;
+
+            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            public enum OrderErrorCode
+            {
+                NotFound,
+            }
+            """,
+            """
+            order.not-found
+
+            """);
+
+    [Fact]
+    public Task IgnoresCommentsAndBlankLines() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(
+            Enum,
+            """
+            # Every error code this project publishes. Reviewed on change.
+
+            OrderErrorCode.AlreadyShipped
+            OrderErrorCode.NotFound
+
+            """);
+
+    /// <summary>
+    /// A registry in a project with no attributed enum at all is entirely stale,
+    /// which is the shape of a project that removed its last provider.
+    /// </summary>
+    [Fact]
+    public Task ReportsEveryEntryWhenNothingIsAttributed() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(
+            """
+            namespace Ordering;
+
+            public enum OrderErrorCode
+            {
+                NotFound,
+            }
+            """,
+            """
+            OrderErrorCode.NotFound
+
+            """,
+            Verify.Diagnostic(Rules.StaleErrorCodeRegistryEntry)
+                  .WithSpan("ErrorCodes.txt", 1, 1, 1, 24)
+                  .WithArguments("OrderErrorCode.NotFound", "ErrorCodes.txt"));
+
+    /// <summary>
+    /// Two enums generating one code report twice, once on each member. Both point at
+    /// the same line to add, which reads as redundant until you notice that either
+    /// member alone is enough to require the line and neither is the one to remove —
+    /// which of the two should keep the code is WM2018's report, not this one's.
+    /// </summary>
+    [Fact]
+    public Task ReportsOnEveryMemberBehindASharedCode() =>
+        Verify.RegistryAnalyzerAsync<ErrorCodeRegistryAnalyzer>(
+            """
+            using Waystone.Monads.Results.Errors;
+
+            namespace Ordering;
+
+            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            public enum OrderErrorCode
+            {
+                NotFound,
+            }
+
+            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            public enum ShipmentErrorCode
+            {
+                NotFound,
+            }
+            """,
+            "",
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(8, 5, 8, 13)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.NotFound",
+                       "order.not-found",
+                       "ErrorCodes.txt"),
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(14, 5, 14, 13)
+                  .WithArguments(
+                       "Ordering.ShipmentErrorCode.NotFound",
+                       "order.not-found",
+                       "ErrorCodes.txt"));
+}

--- a/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/RulesTests.cs
@@ -59,11 +59,30 @@ public class RulesTests
            .Description.ToString()
            .ShouldStartWith("Disabled by default.");
 
+    /// <summary>
+    /// The two rules that report from a compilation end action, and the only two that
+    /// may carry the tag.
+    /// </summary>
+    /// <remarks>
+    /// Roslyn reads <c>CompilationEnd</c> to decide when to run an analyzer's end
+    /// action, so a rule that reports from one and does not carry it can go quiet in
+    /// the IDE. Nothing else in the build notices, which is why this is pinned.
+    /// </remarks>
+    [Fact]
+    public void OnlyTheAggregatingRulesAreTaggedCompilationEnd() =>
+        Descriptors
+           .Where(
+                rule => rule.CustomTags.Contains(
+                    WellKnownDiagnosticTags.CompilationEnd))
+           .Select(rule => rule.Id)
+           .OrderBy(id => id, StringComparer.Ordinal)
+           .ShouldBe(["WM2018", "WM2020"]);
+
     [Fact]
     public void EveryTierIsPopulated()
     {
         MisuseRules().Count.ShouldBe(7);
-        IdiomRules().Count.ShouldBe(17);
+        IdiomRules().Count.ShouldBe(19);
         MigrationRules().Count.ShouldBe(2);
     }
 

--- a/test/Waystone.Monads.Analyzers.Tests/UpdateErrorCodeRegistryCodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/UpdateErrorCodeRegistryCodeFixTests.cs
@@ -1,0 +1,126 @@
+namespace Waystone.Monads.Analyzers;
+
+using System.Threading.Tasks;
+using Xunit;
+
+public sealed class UpdateErrorCodeRegistryCodeFixTests
+{
+    private const string Enum = """
+        using Waystone.Monads.Results.Errors;
+
+        namespace Ordering;
+
+        [ErrorCodeProvider]
+        public enum OrderErrorCode
+        {
+            NotFound,
+            AlreadyShipped,
+        }
+        """;
+
+    [Fact]
+    public Task WritesAnEmptyRegistry() =>
+        Verify.RegistryCodeFixAsync<ErrorCodeRegistryAnalyzer,
+            UpdateErrorCodeRegistryCodeFix>(
+            Enum,
+            "",
+            """
+            OrderErrorCode.AlreadyShipped
+            OrderErrorCode.NotFound
+
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(8, 5, 8, 13)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.NotFound",
+                       "OrderErrorCode.NotFound",
+                       "ErrorCodes.txt"),
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(9, 5, 9, 19)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.AlreadyShipped",
+                       "OrderErrorCode.AlreadyShipped",
+                       "ErrorCodes.txt"));
+
+    /// <summary>
+    /// One invocation writes the whole file, so a run started from a missing code
+    /// takes the stale entry out at the same time. That is what makes the absence of a
+    /// fix-all provider harmless.
+    /// </summary>
+    [Fact]
+    public Task AddsAndRemovesInOnePass() =>
+        Verify.RegistryCodeFixAsync<ErrorCodeRegistryAnalyzer,
+            UpdateErrorCodeRegistryCodeFix>(
+            Enum,
+            """
+            OrderErrorCode.Cancelled
+            OrderErrorCode.NotFound
+
+            """,
+            """
+            OrderErrorCode.AlreadyShipped
+            OrderErrorCode.NotFound
+
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(9, 5, 9, 19)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.AlreadyShipped",
+                       "OrderErrorCode.AlreadyShipped",
+                       "ErrorCodes.txt"),
+            Verify.Diagnostic(Rules.StaleErrorCodeRegistryEntry)
+                  .WithSpan("ErrorCodes.txt", 1, 1, 1, 25)
+                  .WithArguments("OrderErrorCode.Cancelled", "ErrorCodes.txt"));
+
+    /// <summary>
+    /// The leading comment block survives the rewrite, so a header explaining what the
+    /// file is for does not have to be restored after every fix.
+    /// </summary>
+    [Fact]
+    public Task KeepsTheLeadingComment() =>
+        Verify.RegistryCodeFixAsync<ErrorCodeRegistryAnalyzer,
+            UpdateErrorCodeRegistryCodeFix>(
+            Enum,
+            """
+            # Reviewed on change.
+            OrderErrorCode.NotFound
+
+            """,
+            """
+            # Reviewed on change.
+            OrderErrorCode.AlreadyShipped
+            OrderErrorCode.NotFound
+
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(9, 5, 9, 19)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.AlreadyShipped",
+                       "OrderErrorCode.AlreadyShipped",
+                       "ErrorCodes.txt"));
+
+    /// <summary>
+    /// The written file is ordinally sorted whatever order the entries arrived in, so
+    /// adding a code shows up as one added line rather than as a reordering.
+    /// </summary>
+    [Fact]
+    public Task SortsWhatItWrites() =>
+        Verify.RegistryCodeFixAsync<ErrorCodeRegistryAnalyzer,
+            UpdateErrorCodeRegistryCodeFix>(
+            Enum,
+            """
+            OrderErrorCode.NotFound
+
+            """,
+            """
+            OrderErrorCode.AlreadyShipped
+            OrderErrorCode.NotFound
+
+            """,
+            Verify.Diagnostic(Rules.ErrorCodeMissingFromRegistry)
+                  .WithSpan(9, 5, 9, 19)
+                  .WithArguments(
+                       "Ordering.OrderErrorCode.AlreadyShipped",
+                       "OrderErrorCode.AlreadyShipped",
+                       "ErrorCodes.txt"));
+}

--- a/test/Waystone.Monads.Analyzers.Tests/Verify.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/Verify.cs
@@ -48,6 +48,70 @@ internal static class Verify
         return test.RunAsync();
     }
 
+    /// <summary>
+    /// Runs the analyzer over <paramref name="rawSource" /> with an
+    /// <c>ErrorCodes.txt</c> additional file, which is what opts a project into the
+    /// registry rules.
+    /// </summary>
+    public static Task RegistryAnalyzerAsync<TAnalyzer>(
+        string rawSource,
+        string registry,
+        params DiagnosticResult[] expected)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        var test = new AnalyzerTest<TAnalyzer> { TestCode = rawSource };
+
+        test.TestState.AdditionalFiles.Add(
+            (ErrorCodeRegistry.FileName, registry));
+
+        test.ExpectedDiagnostics.AddRange(expected);
+
+        return test.RunAsync();
+    }
+
+    /// <summary>
+    /// Applies the code fix and asserts on the resulting <c>ErrorCodes.txt</c> rather
+    /// than on the source, which the fix does not touch.
+    /// </summary>
+    public static Task RegistryCodeFixAsync<TAnalyzer, TCodeFix>(
+        string rawSource,
+        string registry,
+        string fixedRegistry,
+        params DiagnosticResult[] expected)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        var test = new CodeFixTest<TAnalyzer, TCodeFix>
+        {
+            TestCode = rawSource,
+            FixedCode = rawSource,
+        };
+
+        test.TestState.AdditionalFiles.Add(
+            (ErrorCodeRegistry.FileName, registry));
+
+        test.FixedState.AdditionalFiles.Add(
+            (ErrorCodeRegistry.FileName, fixedRegistry));
+
+        ExpectNothingAfterTheFix(test);
+
+        test.ExpectedDiagnostics.AddRange(expected);
+
+        return test.RunAsync();
+    }
+
+    /// <summary>
+    /// The fixed state expects exactly the diagnostics passed to it and inherits none.
+    /// The default is to inherit every unfixable diagnostic from the test state, which
+    /// is wrong here: WM2020 has no fix of its own and the WM2019 fix removes the entry
+    /// it reports on anyway, so it does not survive into the fixed state.
+    /// </summary>
+    private static void ExpectNothingAfterTheFix<TAnalyzer, TCodeFix>(
+        CodeFixTest<TAnalyzer, TCodeFix> test)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new() =>
+        test.FixedState.InheritanceMode = StateInheritanceMode.Explicit;
+
     public static Task CompilerDiagnosticsAsync(
         string rawSource,
         params DiagnosticResult[] expected)


### PR DESCRIPTION
An error code is a wire contract and a rename changes it silently. This makes the
whole set reviewable the way the public API analyzers make the public surface
reviewable: add an `ErrorCodes.txt` as an `AdditionalFiles` item and the codes
become a committed list that a change has to move on purpose.

WM2019 reports a generated code the file does not list, WM2020 an entry no
provider generates, and the WM2019 fix rewrites the whole file from the
compilation — additions, removals, sorted, leading comment kept — so a rename
lands as one removed line and one added line in a diff.

The file is not generated. RS1035 bans file IO in a generator, and a build that
writes into the source tree is not reproducible and races itself under parallel
builds, so this is a committed file the workspace edits.

Two things found while wiring it up, both pinned:

A diagnostic reported from a compilation end action is a *non-local* diagnostic
even when its location is an ordinary source span, and neither Roslyn's code fix
service nor the testing library will offer a fix for one. That is why WM2019
reports from a symbol action and WM2020, which cannot know an entry is stale until
every enum has been seen, has no fix. Both read the same two sets; the split is
entirely about fixability.

A rule reporting from a compilation end action needs
`WellKnownDiagnosticTags.CompilationEnd` or it can go quiet in the IDE while still
firing on the command line. WM2018 was missing it and now carries it, and
`OnlyTheAggregatingRulesAreTaggedCompilationEnd` pins the pair, since nothing in
the build notices a missing tag.

Also: WM2020's severity cannot be raised from a path-matched `.editorconfig`,
including `[*]`, because Roslyn resolves those per syntax tree and `ErrorCodes.txt`
has none. The sample carries a `.globalconfig` that does it, which is the only
executable statement of that anywhere.

Refs DRA-89

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>