### PR TITLE
feat: obsolete the run-time enum error code path

### DIFF
--- a/src/Waystone.Monads/Configs/ErrorCodeFactory.cs
+++ b/src/Waystone.Monads/Configs/ErrorCodeFactory.cs
@@ -18,8 +18,19 @@ public class ErrorCodeFactory
     private const string NameOfException = nameof(Exception);
 
     /// <summary>Creates a new instance of <see cref="ErrorCode" /> from an Enum value.</summary>
+    /// <remarks>
+    /// Overriding this to shape your codes has been replaced by the declarative
+    /// format on
+    /// <see cref="Results.Errors.ErrorCodeProviderAttribute.Format" />, or on
+    /// <see cref="Results.Errors.ErrorCodeFormatAttribute" /> for a whole assembly.
+    /// A format is read at compile time, so the generated constants, the analyzers
+    /// and the error code registry all agree on what an enum produces; an override
+    /// here runs too late for any of them to see.
+    /// </remarks>
     /// <param name="enum">The enum value to convert into an Error Code.</param>
     /// <returns>The created <see cref="ErrorCode" />.</returns>
+    [Obsolete(
+        "Shape error codes with [ErrorCodeProvider(Format = \"...\")] on the enum, or [assembly: ErrorCodeFormat(\"...\")] for every enum in the assembly. This member will be removed in 7.0.0.")]
     public virtual ErrorCode FromEnum(Enum @enum)
     {
         Type enumType = @enum.GetType();

--- a/src/Waystone.Monads/Results/Errors/Error.cs
+++ b/src/Waystone.Monads/Results/Errors/Error.cs
@@ -1,4 +1,4 @@
-﻿namespace Waystone.Monads.Results.Errors;
+namespace Waystone.Monads.Results.Errors;
 
 using System;
 using Configs;
@@ -56,7 +56,9 @@ public record Error
     /// </param>
     /// <returns>The created <see cref="Error" /></returns>
     public static Error FromEnum(Enum value, string message) => new(
+#pragma warning disable CS0618
         ErrorCode.FromEnum(value),
+#pragma warning restore CS0618
         message);
 
     /// <summary>Creates a new instance of <see cref="Error" /> from an exception.</summary>

--- a/src/Waystone.Monads/Results/Errors/ErrorCode.cs
+++ b/src/Waystone.Monads/Results/Errors/ErrorCode.cs
@@ -29,11 +29,22 @@ public record ErrorCode
     /// <remarks>
     /// Uses the <see cref="ErrorCodeFactory" /> configured in
     /// <see cref="MonadOptions" />.
+    /// <para>
+    /// This works the code out by reflection at run time, so it cannot apply the
+    /// format declared on the enum and nothing tells you when a rename changes the
+    /// code. Mark the enum with <c>[ErrorCodeProvider]</c> and use the generated
+    /// <c>ToErrorCode()</c> extension, or the generated <c>ErrorCodes</c> constant
+    /// where the member is known at the call site.
+    /// </para>
     /// </remarks>
     /// <param name="value">The enum value to create the error code from.</param>
     /// <returns>The created instance of <see cref="ErrorCode" />.</returns>
+    [Obsolete(
+        "Mark the enum with [ErrorCodeProvider] and use the generated ToErrorCode() extension, or the generated ErrorCodes constants, instead of working the code out at run time. This member will be removed in 7.0.0.")]
     public static ErrorCode FromEnum(Enum value) =>
+#pragma warning disable CS0618
         MonadOptions.Current.ErrorCodeFactory.FromEnum(value);
+#pragma warning restore CS0618
 
     /// <summary>
     /// (Not Recommended) Creates an instance of an <see cref="ErrorCode" />

--- a/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeProviderGeneratorTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeProviderGeneratorTests.cs
@@ -148,8 +148,10 @@ public sealed class ErrorCodeProviderGeneratorTests
                     NotFound,
                 }
                 """)
+#pragma warning disable CS0618
               .Source.ShouldContain(
                    $"= \"{ErrorCode.FromEnum(Fixture.OrderError.NotFound).Value}\";");
+#pragma warning restore CS0618
     }
 
     [Fact]

--- a/test/Waystone.Monads.SourceGenerators.Tests/GeneratedErrorCodeTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/GeneratedErrorCodeTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 /// </summary>
 public sealed class GeneratedErrorCodeTests
 {
+#pragma warning disable CS0618
     [Fact]
     public void TheConstantMatchesTheRuntimeFactory() =>
         ShipmentErrorProvider.ErrorCodeStrings.NotFound.ShouldBe(
@@ -21,6 +22,7 @@ public sealed class GeneratedErrorCodeTests
     public void TheErrorCodeMatchesTheRuntimeFactory() =>
         ShipmentErrorProvider.ErrorCodes.AlreadyShipped.ShouldBe(
             ErrorCode.FromEnum(ShipmentError.AlreadyShipped));
+#pragma warning restore CS0618
 
     [Fact]
     public void TheErrorFactoryCarriesTheCodeAndMessage()
@@ -80,14 +82,18 @@ public sealed class GeneratedErrorCodeTests
             ((ShipmentError)99).ToErrorCodeString()
                                .ShouldBe("ShipmentError.99");
 
+#pragma warning disable CS0618
             ErrorCode.FromEnum(ShipmentError.NotFound)
                      .Value.ShouldBe("custom.ShipmentError.NotFound");
+#pragma warning restore CS0618
         }
     }
 
     private sealed class PrefixingFactory : ErrorCodeFactory
     {
+#pragma warning disable CS0672
         public override ErrorCode FromEnum(System.Enum @enum) =>
+#pragma warning restore CS0672
             new ErrorCode($"custom.{@enum.GetType().Name}.{@enum}");
     }
 }

--- a/test/Waystone.Monads.Tests/Configs/ErrorCodeFactoryTests.cs
+++ b/test/Waystone.Monads.Tests/Configs/ErrorCodeFactoryTests.cs
@@ -21,7 +21,9 @@ public sealed class ErrorCodeFactoryTests
     [Fact]
     public void WhenInvokingFromEnum_ThenReturnExpectedCode()
     {
+#pragma warning disable CS0618
         var result = _sut.FromEnum(TestErrorCodes.Failure);
+#pragma warning restore CS0618
         result.Value.ShouldBe($"{nameof(TestErrorCodes)}.Failure");
     }
 

--- a/test/Waystone.Monads.Tests/Configs/MonadOptionsScopeTests.cs
+++ b/test/Waystone.Monads.Tests/Configs/MonadOptionsScopeTests.cs
@@ -121,6 +121,7 @@ public sealed class MonadOptionsScopeTests
     }
 
     [Fact]
+#pragma warning disable CS0618
     public void GivenScope_WhenOverridingErrorCodeFactory_ThenUseScopedFactory()
     {
         string global = ErrorCode.FromEnum(TestErrorCodes.Failure).Value;
@@ -134,6 +135,7 @@ public sealed class MonadOptionsScopeTests
 
         ErrorCode.FromEnum(TestErrorCodes.Failure).Value.ShouldBe(global);
     }
+#pragma warning restore CS0618
 
     [Fact]
     public void
@@ -194,7 +196,9 @@ public sealed class MonadOptionsScopeTests
 
     private sealed class PrefixingErrorCodeFactory : ErrorCodeFactory
     {
+#pragma warning disable CS0672
         public override ErrorCode FromEnum(Enum @enum) =>
+#pragma warning restore CS0672
             new($"scoped.{@enum}");
     }
 }

--- a/test/Waystone.Monads.Tests/Results/Errors/ErrorCodeTests.cs
+++ b/test/Waystone.Monads.Tests/Results/Errors/ErrorCodeTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Waystone.Monads.Results.Errors;
+namespace Waystone.Monads.Results.Errors;
 
 using System;
 using Shouldly;
@@ -39,7 +39,9 @@ public sealed class ErrorCodeTests
     [Fact]
     public void GivenEnum_WhenCreatingErrorCode_ThenReturnExpectedCode()
     {
+#pragma warning disable CS0618
         ErrorCode result = ErrorCode.FromEnum(TestErrorCodes.TestValue);
+#pragma warning restore CS0618
         result.Value.ShouldBe("TestErrorCodes.TestValue");
         result.ToString().ShouldBe("TestErrorCodes.TestValue");
     }


### PR DESCRIPTION
ErrorCodeFactory.FromEnum and ErrorCode.FromEnum both work a code out by
reflection at run time, which is exactly what [ErrorCodeProvider] replaces.
A run-time code cannot carry the declared Format, cannot be seen by the
compiler when a member is renamed, and cannot be reviewed by WM2018 or the
error code registry. Both are obsoleted here with a message naming the
generated members and 7.0.0 as the release that removes them.

FromException is untouched — a factory that overrides only that keeps working.

Error.FromEnum and the call inside ErrorCode.FromEnum suppress CS0618 rather
than change behaviour, since neither is being deprecated and src treats
warnings as errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>