### PR TITLE
refactor: name the generated error code container a catalog

### DIFF
--- a/sample/Waystone.Monads.Analyzers.Sample/Ordering.cs
+++ b/sample/Waystone.Monads.Analyzers.Sample/Ordering.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Waystone.Monads.Results;
 using Waystone.Monads.Results.Errors;
 
-[ErrorCodeProvider(Format = "order.{member:kebab}")]
+[ErrorCodeCatalog(Format = "order.{member:kebab}")]
 internal enum OrderErrorCode
 {
     NotFound,
@@ -55,21 +55,21 @@ internal class Ordering
     /// what to do with a code rather than with an exception type. The
     /// <c>case</c> labels are what make this method possible at all — a label
     /// needs a compile-time constant, which is what
-    /// <c>ErrorCodeStrings</c> gives you and <c>ErrorCode.FromEnum</c> cannot.
+    /// <c>Names</c> gives you and <c>ErrorCode.FromEnum</c> cannot.
     /// </summary>
     internal int StatusCodeFor(Error error)
     {
         switch (error.Code.Value)
         {
-            case OrderErrorProvider.ErrorCodeStrings.NotFound:
+            case OrderErrorCodeCatalog.Names.NotFound:
                 return 404;
-            case OrderErrorProvider.ErrorCodeStrings.AlreadyShipped:
+            case OrderErrorCodeCatalog.Names.AlreadyShipped:
                 return 409;
-            case OrderErrorProvider.ErrorCodeStrings.AddressIncomplete:
+            case OrderErrorCodeCatalog.Names.AddressIncomplete:
                 return 422;
-            case OrderErrorProvider.ErrorCodeStrings.OutOfStock:
+            case OrderErrorCodeCatalog.Names.OutOfStock:
                 return 409;
-            case OrderErrorProvider.ErrorCodeStrings.PaymentDeclined:
+            case OrderErrorCodeCatalog.Names.PaymentDeclined:
                 return 402;
             default:
                 return 500;
@@ -80,20 +80,20 @@ internal class Ordering
         _orders.TryGetValue(orderId, out Order order)
             ? Result.Ok<Order>(order)
             : Result.Err<Order>(
-                OrderErrorProvider.Errors.NotFound(
+                OrderErrorCodeCatalog.Errors.NotFound(
                     $"no order with id {orderId}"));
 
     private Result<Order, Error> NotYetShipped(Order order) =>
         _shipped.Contains(order.Id)
             ? Result.Err<Order>(
-                OrderErrorProvider.Errors.AlreadyShipped(
+                OrderErrorCodeCatalog.Errors.AlreadyShipped(
                     $"order {order.Id} shipped already and cannot be placed again"))
             : Result.Ok<Order>(order);
 
     private Result<Order, Error> Deliverable(Order order) =>
         string.IsNullOrWhiteSpace(order.Postcode)
             ? Result.Err<Order>(
-                OrderErrorProvider.Errors.AddressIncomplete(
+                OrderErrorCodeCatalog.Errors.AddressIncomplete(
                     $"order {order.Id} has no postcode"))
             : Result.Ok<Order>(order);
 
@@ -122,7 +122,7 @@ internal class Ordering
     private Result<Reservation, Error> Charge(Reservation reservation) =>
         reservation.Order.Quantity > 3
             ? Result.Err<Reservation>(
-                OrderErrorProvider.Errors.PaymentDeclined(
+                OrderErrorCodeCatalog.Errors.PaymentDeclined(
                     $"the issuer declined the charge for order {reservation.Order.Id}"))
             : Result.Ok<Reservation>(reservation);
 

--- a/sample/Waystone.Monads.Analyzers.Sample/README.md
+++ b/sample/Waystone.Monads.Analyzers.Sample/README.md
@@ -35,16 +35,16 @@ Every step returns a `Result<T, Error>` and they compose with `AndThen`, so the 
 failure short-circuits the rest and the caller gets one `Error`.
 
 The point is where those errors come from. `OrderErrorCode` is marked
-`[ErrorCodeProvider]`, and the generator turns it into everything the pipeline needs:
+`[ErrorCodeCatalog]`, and the generator turns it into everything the pipeline needs:
 
-- `OrderErrorProvider.Errors.NotFound(message)` builds the failed step's `Error` with
+- `OrderErrorCodeCatalog.Errors.NotFound(message)` builds the failed step's `Error` with
   the right code already attached, so no step has to name a code as a string.
 - `refusal.Value.ToError(message)` in `Reserve` handles the other direction. The
   warehouse hands back a bare `OrderErrorCode`, and the extension attaches a message
   at the boundary where one is worth writing.
 - `StatusCodeFor` switches on the code to pick an HTTP status. **This is the method
   the feature exists for.** A `case` label needs a compile-time constant, so it can be
-  written against `OrderErrorProvider.ErrorCodeStrings` and cannot be written against
+  written against `OrderErrorCodeCatalog.Names` and cannot be written against
   `ErrorCode.FromEnum` at all — that call works its string out at run time.
 
 The enum also declares a format, `order.{member:kebab}`, so the codes are
@@ -64,9 +64,9 @@ path-matched section to apply to.
 Two details are pinned here on purpose, so a change to either breaks this build rather
 than only a snapshot test:
 
-- The enum is `OrderErrorCode` and the generated class is `OrderErrorProvider`, not
-  `OrderErrorCodeProvider`. The generator takes a trailing `Error` or `ErrorCode` off
-  the enum's name before adding its own suffix.
+- The enum is `OrderErrorCode` and the generated class is `OrderErrorCodeCatalog`.
+  The generator appends `Catalog` to the enum's name and trims nothing off it, so the
+  repetition in the name here is the enum's to fix, not the generator's to hide.
 - The `case` labels are the generated constants, so a change to the code scheme stops
   this file compiling, and a change to the casing rules changes what they compare
   against.

--- a/src/Waystone.Monads.Analyzers.CodeFixes/UpdateErrorCodeRegistryCodeFix.cs
+++ b/src/Waystone.Monads.Analyzers.CodeFixes/UpdateErrorCodeRegistryCodeFix.cs
@@ -65,7 +65,7 @@ public sealed class UpdateErrorCodeRegistryCodeFix : CodeFixProvider
 
         var symbols = MonadSymbols.TryCreate(compilation);
 
-        if (symbols?.ErrorCodeProviderAttribute is null) return project.Solution;
+        if (symbols?.ErrorCodeCatalogAttribute is null) return project.Solution;
 
         SourceText existing = await registry.GetTextAsync(cancellationToken)
                                             .ConfigureAwait(false);
@@ -75,6 +75,6 @@ public sealed class UpdateErrorCodeRegistryCodeFix : CodeFixProvider
             SourceText.From(
                 ErrorCodeRegistry.Render(
                     existing,
-                    ErrorCodeProviders.CodesIn(compilation, symbols))));
+                    ErrorCodeCatalogs.CodesIn(compilation, symbols))));
     }
 }

--- a/src/Waystone.Monads.Analyzers/AGENTS.md
+++ b/src/Waystone.Monads.Analyzers/AGENTS.md
@@ -31,7 +31,7 @@ rule. A *disabled* rule at warning severity fires nothing and so builds clean;
 **`WM2018` shares source with the generator.** `ErrorCodeFormat.cs` is a linked
 `Compile` item from `Waystone.Monads.SourceGenerators`, not a project reference — the
 two analyzer assemblies cannot reference each other, and the rule keys on the
-*generated* code, so it has to resolve `[ErrorCodeProvider(Format = ...)]` and
+*generated* code, so it has to resolve `[ErrorCodeCatalog(Format = ...)]` and
 `[assembly: ErrorCodeFormat]` exactly as the generator does. A second copy of the
 parser would let the rule and the generator disagree about what code an enum produces,
 which is the one thing this rule cannot afford to be wrong about. Deriving the code

--- a/src/Waystone.Monads.Analyzers/ErrorCodeCatalogs.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeCatalogs.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 using Waystone.Monads.SourceGenerators.ErrorCodes;
 
 /// <summary>
-/// The error codes an <c>[ErrorCodeProvider]</c> enum generates, resolved the way the
+/// The error codes an <c>[ErrorCodeCatalog]</c> enum generates, resolved the way the
 /// generator resolves them.
 /// </summary>
 /// <remarks>
@@ -17,46 +17,46 @@ using Waystone.Monads.SourceGenerators.ErrorCodes;
 /// assembly as a linked source file, so the three cannot disagree about what an enum
 /// produces.
 /// </remarks>
-public static class ErrorCodeProviders
+public static class ErrorCodeCatalogs
 {
     /// <summary>
     /// One entry per member of <paramref name="type" /> when it is an attributed enum,
     /// and nothing at all when it is not.
     /// </summary>
-    public static ImmutableArray<Provided> Collect(
+    public static ImmutableArray<Declared> Collect(
         INamedTypeSymbol type,
         MonadSymbols symbols,
         string? assemblyFormat)
     {
-        if (type.TypeKind != TypeKind.Enum) return ImmutableArray<Provided>.Empty;
+        if (type.TypeKind != TypeKind.Enum) return ImmutableArray<Declared>.Empty;
 
-        AttributeData? provider = type.GetAttributes()
+        AttributeData? catalog = type.GetAttributes()
            .FirstOrDefault(
                 attribute => SymbolEqualityComparer.Default.Equals(
                     attribute.AttributeClass,
-                    symbols.ErrorCodeProviderAttribute));
+                    symbols.ErrorCodeCatalogAttribute));
 
-        if (provider is null) return ImmutableArray<Provided>.Empty;
+        if (catalog is null) return ImmutableArray<Declared>.Empty;
 
         if (!ErrorCodeFormat.TryParse(
-                DeclaredFormat(provider) ?? assemblyFormat ?? ErrorCodeFormat.Default,
+                DeclaredFormat(catalog) ?? assemblyFormat ?? ErrorCodeFormat.Default,
                 out ErrorCodeFormat? format,
                 out _))
         {
-            return ImmutableArray<Provided>.Empty;
+            return ImmutableArray<Declared>.Empty;
         }
 
-        ImmutableArray<Provided>.Builder provided =
-            ImmutableArray.CreateBuilder<Provided>();
+        ImmutableArray<Declared>.Builder declared =
+            ImmutableArray.CreateBuilder<Declared>();
 
         foreach (IFieldSymbol member in type.GetMembers().OfType<IFieldSymbol>())
         {
             if (!member.IsConst) continue;
 
-            provided.Add(new Provided(member, format!.Apply(type.Name, member.Name)));
+            declared.Add(new Declared(member, format!.Apply(type.Name, member.Name)));
         }
 
-        return provided.ToImmutable();
+        return declared.ToImmutable();
     }
 
     /// <summary>
@@ -78,9 +78,9 @@ public static class ErrorCodeProviders
 
         foreach (INamedTypeSymbol type in Types(compilation.GlobalNamespace))
         {
-            foreach (Provided provided in Collect(type, symbols, assemblyFormat))
+            foreach (Declared declared in Collect(type, symbols, assemblyFormat))
             {
-                codes.Add(provided.Code);
+                codes.Add(declared.Code);
             }
         }
 
@@ -138,10 +138,10 @@ public static class ErrorCodeProviders
         }
     }
 
-    private static string? DeclaredFormat(AttributeData provider)
+    private static string? DeclaredFormat(AttributeData catalog)
     {
         foreach (KeyValuePair<string, TypedConstant> argument in
-                 provider.NamedArguments)
+                 catalog.NamedArguments)
         {
             if (argument.Key == "Format" && argument.Value.Value is string declared)
             {
@@ -153,9 +153,9 @@ public static class ErrorCodeProviders
     }
 
     /// <summary>One enum member and the code it generates.</summary>
-    public readonly struct Provided
+    public readonly struct Declared
     {
-        public Provided(IFieldSymbol member, string code)
+        public Declared(IFieldSymbol member, string code)
         {
             Member = member;
             Code = code;

--- a/src/Waystone.Monads.Analyzers/ErrorCodeRegistry.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeRegistry.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
 /// <summary>
-/// The committed list of every error code an <c>[ErrorCodeProvider]</c> enum in the
+/// The committed list of every error code an <c>[ErrorCodeCatalog]</c> enum in the
 /// project generates.
 /// </summary>
 /// <remarks>

--- a/src/Waystone.Monads.Analyzers/ErrorCodeRegistryAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeRegistryAnalyzer.cs
@@ -21,7 +21,7 @@ public sealed class ErrorCodeRegistryAnalyzer : MonadAnalyzer
         CompilationStartAnalysisContext context,
         MonadSymbols symbols)
     {
-        if (symbols.ErrorCodeProviderAttribute is null) return;
+        if (symbols.ErrorCodeCatalogAttribute is null) return;
 
         AdditionalText? registry =
             ErrorCodeRegistry.Find(context.Options.AdditionalFiles);
@@ -42,7 +42,7 @@ public sealed class ErrorCodeRegistryAnalyzer : MonadAnalyzer
         var generated = new ConcurrentBag<string>();
 
         string? assemblyFormat =
-            ErrorCodeProviders.AssemblyFormat(context.Compilation);
+            ErrorCodeCatalogs.AssemblyFormat(context.Compilation);
 
         context.RegisterSymbolAction(
             symbol => Inspect(symbol, symbols, assemblyFormat, registered, generated),
@@ -71,22 +71,22 @@ public sealed class ErrorCodeRegistryAnalyzer : MonadAnalyzer
         HashSet<string> registered,
         ConcurrentBag<string> generated)
     {
-        foreach (ErrorCodeProviders.Provided provided in ErrorCodeProviders.Collect(
+        foreach (ErrorCodeCatalogs.Declared declared in ErrorCodeCatalogs.Collect(
                      (INamedTypeSymbol)context.Symbol,
                      symbols,
                      assemblyFormat))
         {
-            generated.Add(provided.Code);
+            generated.Add(declared.Code);
 
-            if (registered.Contains(provided.Code)) continue;
+            if (registered.Contains(declared.Code)) continue;
 
             context.ReportDiagnostic(
                 Diagnostic.Create(
                     Rules.ErrorCodeMissingFromRegistry,
-                    provided.Member.Locations.FirstOrDefault(
+                    declared.Member.Locations.FirstOrDefault(
                         location => location.IsInSource),
-                    provided.Member.ToDisplayString(),
-                    provided.Code,
+                    declared.Member.ToDisplayString(),
+                    declared.Code,
                     ErrorCodeRegistry.FileName));
         }
     }

--- a/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
+++ b/src/Waystone.Monads.Analyzers/ErrorCodeReuseAnalyzer.cs
@@ -18,47 +18,47 @@ public sealed class ErrorCodeReuseAnalyzer : MonadAnalyzer
         CompilationStartAnalysisContext context,
         MonadSymbols symbols)
     {
-        if (symbols.ErrorCodeProviderAttribute is null) return;
+        if (symbols.ErrorCodeCatalogAttribute is null) return;
 
-        var providers = new ConcurrentBag<ErrorCodeProviders.Provided>();
+        var declarations = new ConcurrentBag<ErrorCodeCatalogs.Declared>();
 
         string? assemblyFormat =
-            ErrorCodeProviders.AssemblyFormat(context.Compilation);
+            ErrorCodeCatalogs.AssemblyFormat(context.Compilation);
 
         context.RegisterSymbolAction(
             symbol =>
             {
-                foreach (ErrorCodeProviders.Provided provided in
-                         ErrorCodeProviders.Collect(
+                foreach (ErrorCodeCatalogs.Declared declared in
+                         ErrorCodeCatalogs.Collect(
                              (INamedTypeSymbol)symbol.Symbol,
                              symbols,
                              assemblyFormat))
                 {
-                    providers.Add(provided);
+                    declarations.Add(declared);
                 }
             },
             SymbolKind.NamedType);
 
-        context.RegisterCompilationEndAction(end => Report(end, providers));
+        context.RegisterCompilationEndAction(end => Report(end, declarations));
     }
 
     private static void Report(
         CompilationAnalysisContext context,
-        ConcurrentBag<ErrorCodeProviders.Provided> providers)
+        ConcurrentBag<ErrorCodeCatalogs.Declared> declarations)
     {
-        foreach (IGrouping<string, ErrorCodeProviders.Provided> collision in providers
-                    .GroupBy(provided => provided.Code, StringComparer.Ordinal)
+        foreach (IGrouping<string, ErrorCodeCatalogs.Declared> collision in declarations
+                    .GroupBy(declared => declared.Code, StringComparer.Ordinal)
                     .Where(group => group.Count() > 1))
         {
-            List<ErrorCodeProviders.Provided> ordered = collision
+            List<ErrorCodeCatalogs.Declared> ordered = collision
                .OrderBy(
-                    provided => provided.Member.ToDisplayString(),
+                    declared => declared.Member.ToDisplayString(),
                     StringComparer.Ordinal)
                .ToList();
 
-            ErrorCodeProviders.Provided first = ordered[0];
+            ErrorCodeCatalogs.Declared first = ordered[0];
 
-            foreach (ErrorCodeProviders.Provided later in ordered.Skip(1))
+            foreach (ErrorCodeCatalogs.Declared later in ordered.Skip(1))
             {
                 if (SymbolEqualityComparer.Default.Equals(
                         first.Member.ContainingType,

--- a/src/Waystone.Monads.Analyzers/MonadSymbols.cs
+++ b/src/Waystone.Monads.Analyzers/MonadSymbols.cs
@@ -21,8 +21,8 @@ public sealed class MonadSymbols
         "Waystone.Monads.Results.Result";
     public const string ErrorMetadataName =
         "Waystone.Monads.Results.Errors.Error";
-    public const string ErrorCodeProviderAttributeMetadataName =
-        "Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute";
+    public const string ErrorCodeCatalogAttributeMetadataName =
+        "Waystone.Monads.Results.Errors.ErrorCodeCatalogAttribute";
     public const string ErrorCodeFormatAttributeMetadataName =
         "Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute";
 
@@ -36,7 +36,7 @@ public sealed class MonadSymbols
         INamedTypeSymbol err,
         INamedTypeSymbol resultFactory,
         INamedTypeSymbol? error,
-        INamedTypeSymbol? errorCodeProviderAttribute,
+        INamedTypeSymbol? errorCodeCatalogAttribute,
         INamedTypeSymbol? task,
         INamedTypeSymbol? valueTask)
     {
@@ -49,7 +49,7 @@ public sealed class MonadSymbols
         Err = err;
         ResultFactory = resultFactory;
         Error = error;
-        ErrorCodeProviderAttribute = errorCodeProviderAttribute;
+        ErrorCodeCatalogAttribute = errorCodeCatalogAttribute;
         Task = task;
         ValueTask = valueTask;
     }
@@ -72,7 +72,7 @@ public sealed class MonadSymbols
 
     public INamedTypeSymbol? Error { get; }
 
-    public INamedTypeSymbol? ErrorCodeProviderAttribute { get; }
+    public INamedTypeSymbol? ErrorCodeCatalogAttribute { get; }
 
     public INamedTypeSymbol? Task { get; }
 
@@ -114,7 +114,7 @@ public sealed class MonadSymbols
             resultFactory,
             compilation.GetTypeByMetadataName(ErrorMetadataName),
             compilation.GetTypeByMetadataName(
-                ErrorCodeProviderAttributeMetadataName),
+                ErrorCodeCatalogAttributeMetadataName),
             compilation.GetTypeByMetadataName(
                 "System.Threading.Tasks.Task`1"),
             compilation.GetTypeByMetadataName(

--- a/src/Waystone.Monads.Analyzers/Rules.cs
+++ b/src/Waystone.Monads.Analyzers/Rules.cs
@@ -268,7 +268,7 @@ public static class Rules
         "WM2018",
         "Do not reuse an error code across enums",
         "'{0}' and '{1}' both generate the error code '{2}', so the two errors are indistinguishable to anything reading the code",
-        "An [ErrorCodeProvider] enum generates one code per member from the enum's own name and the member's, so two enums sharing a name in different namespaces generate the same code for every member name they share. No two independent error taxonomies legitimately share a wire code, and consumers reading the code cannot tell which error occurred. Rename one of the enums or the colliding member.",
+        "An [ErrorCodeCatalog] enum generates one code per member from the enum's own name and the member's, so two enums sharing a name in different namespaces generate the same code for every member name they share. No two independent error taxonomies legitimately share a wire code, and consumers reading the code cannot tell which error occurred. Rename one of the enums or the colliding member.",
         WellKnownDiagnosticTags.CompilationEnd);
 
     /// <remarks>
@@ -299,7 +299,7 @@ public static class Rules
     public static readonly DiagnosticDescriptor StaleErrorCodeRegistryEntry = Idiom(
         "WM2020",
         "Remove an error code the project no longer generates",
-        "'{1}' lists the error code '{0}', which no error code provider in this project generates",
+        "'{1}' lists the error code '{0}', which no error code catalog in this project generates",
         "An entry left behind by a rename or a deletion claims a code the project no longer produces, so the list stops describing the project and the review it exists for stops being worth reading. Delete the line, or restore the member that generated it if the code was removed by mistake.",
         WellKnownDiagnosticTags.CompilationEnd);
 

--- a/src/Waystone.Monads.SourceGenerators/AGENTS.md
+++ b/src/Waystone.Monads.SourceGenerators/AGENTS.md
@@ -1,7 +1,7 @@
 # Waystone.Monads.SourceGenerators
 
 Emits the error code members of an enum a consumer marked with
-`[ErrorCodeProvider]` — the code strings, the `ErrorCode` fields, the `Error`
+`[ErrorCodeCatalog]` — the code strings, the `ErrorCode` fields, the `Error`
 factories and the three extensions that map a value to each.
 
 ## Why this is not Waystone.SourceGenerators
@@ -20,7 +20,7 @@ every consumer gets it on upgrade with no opt-out beyond not applying the attrib
 ## The generator contract
 
 **The attribute is hand-written public API in `Waystone.Monads`, not emitted.**
-`ErrorCodeProviderAttribute` lives next to `ErrorCode` so it is discoverable in
+`ErrorCodeCatalogAttribute` lives next to `ErrorCode` so it is discoverable in
 IntelliSense and in the published API reference without knowing a generator exists.
 That puts it under deprecate-never-remove, and it needs a `PublicAPI` entry like any
 other public type. The generator still must not reference `Waystone.Monads`: it
@@ -54,7 +54,7 @@ literal**, so the `default:` arm is a concatenation of constants around one
 call: an undeclared value renders as digits, and all four casings are the identity on
 digits. `EveryCasingIsTheIdentityOnDigits` is what makes that safe to rely on.
 
-**The nesting is what makes member names safe.** `ErrorCodeStrings`, `ErrorCodes`
+**The nesting is what makes member names safe.** `Names`, `Codes`
 and `Errors` each hold one member per enum member, named verbatim, so an enum member
 called `NotFoundCode` cannot collide with the generated name for `NotFound`. The
 price is `WMG0003`, and only that: a member named after one of the three *nested
@@ -105,12 +105,14 @@ cref is CS1574, which is an error in any consumer with
 CS1591 is on by default in a consumer with a documentation file, and the generated
 surface is public.
 
-**Two enums can generate one class name.** `OrderError` and `OrderErrorCode` both
-dedupe to `OrderErrorProvider`. The hint name is keyed on the *enum* name, not the
-provider name, so the driver does not throw a duplicate-hint-name exception and the
-consumer sees a plain CS0101 naming both generated files.
+**The catalog name is the enum's name plus `Catalog`, and nothing is trimmed off
+it.** An earlier version deduplicated a trailing `Error` or `ErrorCode`, which gave
+`OrderError` and `OrderErrorCode` one class name and a CS0101 the generator never
+reported. Do not reintroduce trimming: the hint name is keyed on the *enum* name, so a
+collision here does not throw a duplicate-hint-name exception and surfaces only as a
+confusing error in the consumer.
 
-**`StringBuilder.AppendLine` writes CRLF on Windows.** `ErrorCodeProviderWriter`
+**`StringBuilder.AppendLine` writes CRLF on Windows.** `ErrorCodeCatalogWriter`
 appends `'\n'` directly and never calls `AppendLine`, so the emitted source does not
 vary by build platform. The snapshot test normalises its expected literal too, since
 git may check the test file out either way.
@@ -121,6 +123,6 @@ git may check the test file out either way.
 `Verify.Run` drives it over a synthetic compilation and asserts the emitted text and
 the diagnostics. `GeneratedErrorCodeTests` is the stronger one: the test project
 imports `Waystone.Monads.SourceGenerators.props`, so it declares a real
-`[ErrorCodeProvider]` enum and calls the generated members, which proves the emitted
+`[ErrorCodeCatalog]` enum and calls the generated members, which proves the emitted
 source compiles and agrees with `ErrorCode.FromEnum` at runtime rather than by
 inspection.

--- a/src/Waystone.Monads.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/Waystone.Monads.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -7,9 +7,9 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-WMG0001 | Usage | Error | An error code provider enum cannot be a flags enum
-WMG0002 | Usage | Error | An error code provider enum cannot alias a value
-WMG0003 | Usage | Error | An error code provider member name collides with a generated type
+WMG0001 | Usage | Error | An error code catalog enum cannot be a flags enum
+WMG0002 | Usage | Error | An error code catalog enum cannot alias a value
+WMG0003 | Usage | Error | An error code catalog member name collides with a generated type
 WMG0004 | Usage | Error | The Waystone.Monads error types are not resolvable
 WMG0005 | Usage | Error | The error code format cannot be used
 WMG0006 | Usage | Error | The error code format does not distinguish members

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeCatalogGenerator.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeCatalogGenerator.cs
@@ -10,13 +10,13 @@ using Microsoft.CodeAnalysis.Text;
 
 /// <summary>
 /// Generates the error code constants, error codes and error factories of an enum
-/// marked with <c>[ErrorCodeProvider]</c>.
+/// marked with <c>[ErrorCodeCatalog]</c>.
 /// </summary>
 [Generator(LanguageNames.CSharp)]
-public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
+public sealed class ErrorCodeCatalogGenerator : IIncrementalGenerator
 {
     internal const string AttributeMetadataName =
-        "Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute";
+        "Waystone.Monads.Results.Errors.ErrorCodeCatalogAttribute";
 
     internal const string ErrorCodeMetadataName =
         "Waystone.Monads.Results.Errors.ErrorCode";
@@ -31,9 +31,9 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
 
     private static readonly string[] ReservedMemberNames =
     [
-        ErrorCodeProviderWriter.ErrorCodeStringsClass,
-        ErrorCodeProviderWriter.ErrorCodesClass,
-        ErrorCodeProviderWriter.ErrorsClass,
+        ErrorCodeCatalogWriter.NamesClass,
+        ErrorCodeCatalogWriter.CodesClass,
+        ErrorCodeCatalogWriter.ErrorsClass,
     ];
 
     /// <inheritdoc />
@@ -77,7 +77,7 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
             ((EnumDeclarationSyntax)context.TargetNode).Identifier.GetLocation();
 
         string hintName = HintNameFor(enumType);
-        string providerName = ProviderNameFor(enumType.Name);
+        string catalogName = CatalogNameFor(enumType.Name);
         Compilation compilation = context.SemanticModel.Compilation;
 
         string? missing = MissingErrorType(compilation);
@@ -148,7 +148,7 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
                     LocationOf(member, location),
                     enumType.Name,
                     member.Name,
-                    providerName));
+                    catalogName));
         }
 
         var seen = new Dictionary<string, IFieldSymbol>(StringComparer.Ordinal);
@@ -177,9 +177,9 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
             hintName,
             diagnostics.Count > 0
                 ? null
-                : ErrorCodeProviderWriter.Emit(
+                : ErrorCodeCatalogWriter.Emit(
                     enumType,
-                    providerName,
+                    catalogName,
                     members,
                     format),
             new EquatableArray<DiagnosticInfo>(diagnostics.ToArray()));
@@ -190,11 +190,11 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
     /// for the built-in default.
     /// </summary>
     private static string? RequestedFormat(
-        AttributeData provider,
+        AttributeData catalog,
         Compilation compilation)
     {
         foreach (KeyValuePair<string, TypedConstant> argument in
-                 provider.NamedArguments)
+                 catalog.NamedArguments)
         {
             if (argument.Key == "Format" && argument.Value.Value is string declared)
             {
@@ -248,24 +248,17 @@ public sealed class ErrorCodeProviderGenerator : IIncrementalGenerator
      ?? fallback;
 
     /// <summary>
-    /// The generated class is named after the enum with a trailing <c>Error</c> or
-    /// <c>ErrorCode</c> deduplicated, so <c>OrderError</c> and <c>OrderErrorCode</c>
-    /// both produce <c>OrderErrorProvider</c>.
+    /// The generated class is the enum's own name with <c>Catalog</c> appended, so
+    /// <c>OrderFailure</c> produces <c>OrderFailureCatalog</c> and
+    /// <c>OrderError</c> produces <c>OrderErrorCatalog</c>.
     /// </summary>
-    internal static string ProviderNameFor(string enumName)
-    {
-        foreach (string suffix in new[] { "ErrorCode", "Error" })
-        {
-            if (enumName.Length > suffix.Length
-             && enumName.EndsWith(suffix, StringComparison.Ordinal))
-            {
-                return enumName.Substring(0, enumName.Length - suffix.Length)
-                     + "ErrorProvider";
-            }
-        }
-
-        return enumName + "ErrorProvider";
-    }
+    /// <remarks>
+    /// Nothing is trimmed off the enum's name. An earlier version deduplicated a
+    /// trailing <c>Error</c> or <c>ErrorCode</c>, which gave two different enums in
+    /// one namespace — <c>OrderError</c> and <c>OrderErrorCode</c> — the same
+    /// generated name and a collision the generator did not report.
+    /// </remarks>
+    internal static string CatalogNameFor(string enumName) => enumName + "Catalog";
 
     private static string HintNameFor(INamedTypeSymbol enumType) =>
         enumType.ContainingNamespace.IsGlobalNamespace

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeCatalogWriter.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeCatalogWriter.cs
@@ -67,8 +67,8 @@ internal static class ErrorCodeCatalogWriter
             qualified,
             members,
             "string",
-            "ToErrorCodeString",
-            "error code string",
+            "ToErrorCodeName",
+            "error code name",
             member => $"{NamesClass}.{member.Name}",
             undeclared);
 
@@ -105,7 +105,7 @@ internal static class ErrorCodeCatalogWriter
     {
         writer.Line(
             depth,
-            $"/// <summary>The error code string of every <c>{qualified}</c> member.</summary>");
+            $"/// <summary>The error code name of every <c>{qualified}</c> member.</summary>");
 
         writer.Line(depth, $"public static class {NamesClass}");
         writer.Line(depth, "{");
@@ -118,7 +118,7 @@ internal static class ErrorCodeCatalogWriter
 
             writer.Line(
                 depth + 1,
-                $"/// <summary>The error code string of <c>{qualified}.{name}</c>.</summary>");
+                $"/// <summary>The error code name of <c>{qualified}.{name}</c>.</summary>");
 
             writer.Line(
                 depth + 1,

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeCatalogWriter.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/ErrorCodeCatalogWriter.cs
@@ -5,10 +5,10 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
-internal static class ErrorCodeProviderWriter
+internal static class ErrorCodeCatalogWriter
 {
-    public const string ErrorCodeStringsClass = "ErrorCodeStrings";
-    public const string ErrorCodesClass = "ErrorCodes";
+    public const string NamesClass = "Names";
+    public const string CodesClass = "Codes";
     public const string ErrorsClass = "Errors";
 
     private const string ErrorCodeType =
@@ -19,7 +19,7 @@ internal static class ErrorCodeProviderWriter
 
     public static string Emit(
         INamedTypeSymbol enumType,
-        string providerName,
+        string catalogName,
         IReadOnlyList<IFieldSymbol> members,
         ErrorCodeFormat format)
     {
@@ -47,7 +47,7 @@ internal static class ErrorCodeProviderWriter
 
         writer.Line(
             depth,
-            $"{AccessibilityOf(enumType)} static partial class {providerName}");
+            $"{AccessibilityOf(enumType)} static partial class {catalogName}");
 
         writer.Line(depth, "{");
 
@@ -69,7 +69,7 @@ internal static class ErrorCodeProviderWriter
             "string",
             "ToErrorCodeString",
             "error code string",
-            member => $"{ErrorCodeStringsClass}.{member.Name}",
+            member => $"{NamesClass}.{member.Name}",
             undeclared);
 
         writer.Blank();
@@ -82,7 +82,7 @@ internal static class ErrorCodeProviderWriter
             ErrorCodeType,
             "ToErrorCode",
             "error code",
-            member => $"{ErrorCodesClass}.{member.Name}",
+            member => $"{CodesClass}.{member.Name}",
             $"new {ErrorCodeType}({undeclared})");
 
         writer.Blank();
@@ -107,7 +107,7 @@ internal static class ErrorCodeProviderWriter
             depth,
             $"/// <summary>The error code string of every <c>{qualified}</c> member.</summary>");
 
-        writer.Line(depth, $"public static class {ErrorCodeStringsClass}");
+        writer.Line(depth, $"public static class {NamesClass}");
         writer.Line(depth, "{");
 
         for (var i = 0; i < members.Count; i++)
@@ -138,7 +138,7 @@ internal static class ErrorCodeProviderWriter
             depth,
             $"/// <summary>The error code of every <c>{qualified}</c> member.</summary>");
 
-        writer.Line(depth, $"public static class {ErrorCodesClass}");
+        writer.Line(depth, $"public static class {CodesClass}");
         writer.Line(depth, "{");
 
         for (var i = 0; i < members.Count; i++)
@@ -153,7 +153,7 @@ internal static class ErrorCodeProviderWriter
 
             writer.Line(
                 depth + 1,
-                $"public static readonly {ErrorCodeType} {name} = new {ErrorCodeType}({ErrorCodeStringsClass}.{name});");
+                $"public static readonly {ErrorCodeType} {name} = new {ErrorCodeType}({NamesClass}.{name});");
         }
 
         writer.Line(depth, "}");
@@ -196,7 +196,7 @@ internal static class ErrorCodeProviderWriter
 
             writer.Line(
                 depth + 2,
-                $"return new {ErrorType}({ErrorCodesClass}.{name}, message);");
+                $"return new {ErrorType}({CodesClass}.{name}, message);");
 
             writer.Line(depth + 1, "}");
         }

--- a/src/Waystone.Monads.SourceGenerators/ErrorCodes/Rules.cs
+++ b/src/Waystone.Monads.SourceGenerators/ErrorCodes/Rules.cs
@@ -6,15 +6,15 @@ internal static class Rules
 {
     public static readonly DiagnosticDescriptor FlagsEnum = new(
         "WMG0001",
-        "An error code provider enum cannot be a flags enum",
-        "'{0}' is marked with [ErrorCodeProvider] and [Flags], but a combined flags value has no single error code",
+        "An error code catalog enum cannot be a flags enum",
+        "'{0}' is marked with [ErrorCodeCatalog] and [Flags], but a combined flags value has no single error code",
         "Usage",
         DiagnosticSeverity.Error,
         true);
 
     public static readonly DiagnosticDescriptor AliasedValue = new(
         "WMG0002",
-        "An error code provider enum cannot alias a value",
+        "An error code catalog enum cannot alias a value",
         "'{0}' and '{1}' share the value {2}, so neither has a single error code the generated members can return",
         "Usage",
         DiagnosticSeverity.Error,
@@ -22,7 +22,7 @@ internal static class Rules
 
     public static readonly DiagnosticDescriptor ReservedMemberName = new(
         "WMG0003",
-        "An error code provider member name collides with a generated type",
+        "An error code catalog member name collides with a generated type",
         "'{0}' declares a member named '{1}', which is also the name of a type generated into '{2}'",
         "Usage",
         DiagnosticSeverity.Error,
@@ -31,7 +31,7 @@ internal static class Rules
     public static readonly DiagnosticDescriptor MissingErrorTypes = new(
         "WMG0004",
         "The Waystone.Monads error types are not resolvable",
-        "'{0}' is marked with [ErrorCodeProvider] but '{1}' cannot be resolved in this compilation, so no error code members are generated",
+        "'{0}' is marked with [ErrorCodeCatalog] but '{1}' cannot be resolved in this compilation, so no error code members are generated",
         "Usage",
         DiagnosticSeverity.Error,
         true);

--- a/src/Waystone.Monads/Configs/ErrorCodeFactory.cs
+++ b/src/Waystone.Monads/Configs/ErrorCodeFactory.cs
@@ -21,7 +21,7 @@ public class ErrorCodeFactory
     /// <remarks>
     /// Overriding this to shape your codes has been replaced by the declarative
     /// format on
-    /// <see cref="Results.Errors.ErrorCodeProviderAttribute.Format" />, or on
+    /// <see cref="Results.Errors.ErrorCodeCatalogAttribute.Format" />, or on
     /// <see cref="Results.Errors.ErrorCodeFormatAttribute" /> for a whole assembly.
     /// A format is read at compile time, so the generated constants, the analyzers
     /// and the error code registry all agree on what an enum produces; an override
@@ -30,7 +30,7 @@ public class ErrorCodeFactory
     /// <param name="enum">The enum value to convert into an Error Code.</param>
     /// <returns>The created <see cref="ErrorCode" />.</returns>
     [Obsolete(
-        "Shape error codes with [ErrorCodeProvider(Format = \"...\")] on the enum, or [assembly: ErrorCodeFormat(\"...\")] for every enum in the assembly. This member will be removed in 7.0.0.")]
+        "Shape error codes with [ErrorCodeCatalog(Format = \"...\")] on the enum, or [assembly: ErrorCodeFormat(\"...\")] for every enum in the assembly. This member will be removed in 7.0.0.")]
     public virtual ErrorCode FromEnum(Enum @enum)
     {
         Type enumType = @enum.GetType();

--- a/src/Waystone.Monads/PublicAPI.Shipped.txt
+++ b/src/Waystone.Monads/PublicAPI.Shipped.txt
@@ -246,13 +246,13 @@ Waystone.Monads.Results.Errors.ErrorCode
 Waystone.Monads.Results.Errors.ErrorCode.ErrorCode(Waystone.Monads.Results.Errors.ErrorCode! original) -> void
 Waystone.Monads.Results.Errors.ErrorCode.ErrorCode(string! value) -> void
 Waystone.Monads.Results.Errors.ErrorCode.Value.get -> string!
+Waystone.Monads.Results.Errors.ErrorCodeCatalogAttribute
+Waystone.Monads.Results.Errors.ErrorCodeCatalogAttribute.ErrorCodeCatalogAttribute() -> void
+Waystone.Monads.Results.Errors.ErrorCodeCatalogAttribute.Format.get -> string?
+Waystone.Monads.Results.Errors.ErrorCodeCatalogAttribute.Format.set -> void
 Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute
 Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute.ErrorCodeFormatAttribute(string! format) -> void
 Waystone.Monads.Results.Errors.ErrorCodeFormatAttribute.Format.get -> string!
-Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute
-Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute.ErrorCodeProviderAttribute() -> void
-Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute.Format.get -> string?
-Waystone.Monads.Results.Errors.ErrorCodeProviderAttribute.Format.set -> void
 Waystone.Monads.Results.Extensions.AndThenExtensions
 Waystone.Monads.Results.Extensions.AndThenExtensions.extension<TOk, TErr>(System.Threading.Tasks.Task<Waystone.Monads.Results.Result<TOk, TErr>!>!)
 Waystone.Monads.Results.Extensions.AndThenExtensions.extension<TOk, TErr>(System.Threading.Tasks.Task<Waystone.Monads.Results.Result<TOk, TErr>!>!).AndThenAsync<TOut>(System.Func<TOk, System.Threading.Tasks.Task<Waystone.Monads.Results.Result<TOut, TErr>!>!>! factory) -> System.Threading.Tasks.ValueTask<Waystone.Monads.Results.Result<TOut, TErr>!>

--- a/src/Waystone.Monads/Results/Errors/ErrorCode.cs
+++ b/src/Waystone.Monads/Results/Errors/ErrorCode.cs
@@ -32,7 +32,7 @@ public record ErrorCode
     /// <para>
     /// This works the code out by reflection at run time, so it cannot apply the
     /// format declared on the enum and nothing tells you when a rename changes the
-    /// code. Mark the enum with <c>[ErrorCodeProvider]</c> and use the generated
+    /// code. Mark the enum with <c>[ErrorCodeCatalog]</c> and use the generated
     /// <c>ToErrorCode()</c> extension, or the generated <c>ErrorCodes</c> constant
     /// where the member is known at the call site.
     /// </para>
@@ -40,7 +40,7 @@ public record ErrorCode
     /// <param name="value">The enum value to create the error code from.</param>
     /// <returns>The created instance of <see cref="ErrorCode" />.</returns>
     [Obsolete(
-        "Mark the enum with [ErrorCodeProvider] and use the generated ToErrorCode() extension, or the generated ErrorCodes constants, instead of working the code out at run time. This member will be removed in 7.0.0.")]
+        "Mark the enum with [ErrorCodeCatalog] and use the generated ToErrorCode() extension, or the generated ErrorCodes constants, instead of working the code out at run time. This member will be removed in 7.0.0.")]
     public static ErrorCode FromEnum(Enum value) =>
 #pragma warning disable CS0618
         MonadOptions.Current.ErrorCodeFactory.FromEnum(value);

--- a/src/Waystone.Monads/Results/Errors/ErrorCodeCatalogAttribute.cs
+++ b/src/Waystone.Monads/Results/Errors/ErrorCodeCatalogAttribute.cs
@@ -8,10 +8,11 @@ using System;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The generated class is named after the enum with a trailing <c>Error</c> or
-/// <c>ErrorCode</c> deduplicated — <c>OrderError</c> produces
-/// <c>OrderErrorProvider</c> — and is emitted in the enum's namespace at the
-/// enum's declared accessibility.
+/// The generated class is the enum's own name with <c>Catalog</c> appended —
+/// <c>OrderFailure</c> produces <c>OrderFailureCatalog</c> — and is emitted in the
+/// enum's namespace at the enum's declared accessibility. Nothing is trimmed off
+/// the name, so two enums whose names differ generate two classes whose names
+/// differ.
 /// </para>
 /// <para>
 /// The generated codes follow the same <c>{EnumTypeName}.{MemberName}</c>
@@ -28,7 +29,7 @@ using System;
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Enum)]
-public sealed class ErrorCodeProviderAttribute : Attribute
+public sealed class ErrorCodeCatalogAttribute : Attribute
 {
     /// <summary>
     /// The scheme the generated codes of this enum follow, overriding any

--- a/src/Waystone.Monads/Results/Errors/ErrorCodeFormatAttribute.cs
+++ b/src/Waystone.Monads/Results/Errors/ErrorCodeFormatAttribute.cs
@@ -5,7 +5,7 @@ using System;
 /// <summary>
 /// Sets the scheme every generated error code in this project follows, for each
 /// enum that does not set its own through
-/// <see cref="ErrorCodeProviderAttribute.Format" />.
+/// <see cref="ErrorCodeCatalogAttribute.Format" />.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/test/Waystone.Monads.Analyzers.Tests/ErrorCodeRegistryAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/ErrorCodeRegistryAnalyzerTests.cs
@@ -10,7 +10,7 @@ public sealed class ErrorCodeRegistryAnalyzerTests
 
         namespace Ordering;
 
-        [ErrorCodeProvider]
+        [ErrorCodeCatalog]
         public enum OrderErrorCode
         {
             NotFound,
@@ -96,7 +96,7 @@ public sealed class ErrorCodeRegistryAnalyzerTests
 
             namespace Ordering;
 
-            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            [ErrorCodeCatalog(Format = "order.{member:kebab}")]
             public enum OrderErrorCode
             {
                 NotFound,
@@ -156,13 +156,13 @@ public sealed class ErrorCodeRegistryAnalyzerTests
 
             namespace Ordering;
 
-            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            [ErrorCodeCatalog(Format = "order.{member:kebab}")]
             public enum OrderErrorCode
             {
                 NotFound,
             }
 
-            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            [ErrorCodeCatalog(Format = "order.{member:kebab}")]
             public enum ShipmentErrorCode
             {
                 NotFound,

--- a/test/Waystone.Monads.Analyzers.Tests/ErrorCodeReuseAnalyzerTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/ErrorCodeReuseAnalyzerTests.cs
@@ -13,7 +13,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     NotFound,
@@ -22,7 +22,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Shipping
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     {|#0:NotFound|},
@@ -44,7 +44,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     NotFound,
@@ -54,7 +54,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Shipping
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     {|#0:NotFound|},
@@ -83,7 +83,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     NotFound,
@@ -92,7 +92,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Shipping
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     AlreadyShipped,
@@ -108,7 +108,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     NotFound,
@@ -117,7 +117,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Shipping
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum ShipmentError
                 {
                     NotFound,
@@ -133,7 +133,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     NotFound,
@@ -157,7 +157,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     NotFound = 1,
@@ -179,7 +179,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider(Format = "order.{member:kebab}")]
+                [ErrorCodeCatalog(Format = "order.{member:kebab}")]
                 internal enum OrderError
                 {
                     NotFound,
@@ -188,7 +188,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Shipping
             {
-                [ErrorCodeProvider(Format = "order.{member:kebab}")]
+                [ErrorCodeCatalog(Format = "order.{member:kebab}")]
                 internal enum ShipmentError
                 {
                     {|#0:NotFound|},
@@ -214,7 +214,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider(Format = "order.{member}")]
+                [ErrorCodeCatalog(Format = "order.{member}")]
                 internal enum OrderError
                 {
                     NotFound,
@@ -223,7 +223,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Shipping
             {
-                [ErrorCodeProvider(Format = "shipping.{member}")]
+                [ErrorCodeCatalog(Format = "shipping.{member}")]
                 internal enum OrderError
                 {
                     NotFound,
@@ -241,7 +241,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Ordering
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum OrderError
                 {
                     NotFound,
@@ -250,7 +250,7 @@ public class ErrorCodeReuseAnalyzerTests
 
             namespace Shipping
             {
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 internal enum ShipmentError
                 {
                     {|#0:NotFound|},

--- a/test/Waystone.Monads.Analyzers.Tests/UpdateErrorCodeRegistryCodeFixTests.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/UpdateErrorCodeRegistryCodeFixTests.cs
@@ -10,7 +10,7 @@ public sealed class UpdateErrorCodeRegistryCodeFixTests
 
         namespace Ordering;
 
-        [ErrorCodeProvider]
+        [ErrorCodeCatalog]
         public enum OrderErrorCode
         {
             NotFound,

--- a/test/Waystone.Monads.Analyzers.Tests/Verify.cs
+++ b/test/Waystone.Monads.Analyzers.Tests/Verify.cs
@@ -62,7 +62,7 @@ internal static class Verify
         var test = new AnalyzerTest<TAnalyzer> { TestCode = rawSource };
 
         test.TestState.AdditionalFiles.Add(
-            (ErrorCodeRegistry.FileName, registry));
+            (ErrorCodeRegistry.FileName, Lf(registry)));
 
         test.ExpectedDiagnostics.AddRange(expected);
 
@@ -88,10 +88,10 @@ internal static class Verify
         };
 
         test.TestState.AdditionalFiles.Add(
-            (ErrorCodeRegistry.FileName, registry));
+            (ErrorCodeRegistry.FileName, Lf(registry)));
 
         test.FixedState.AdditionalFiles.Add(
-            (ErrorCodeRegistry.FileName, fixedRegistry));
+            (ErrorCodeRegistry.FileName, Lf(fixedRegistry)));
 
         ExpectNothingAfterTheFix(test);
 
@@ -99,6 +99,18 @@ internal static class Verify
 
         return test.RunAsync();
     }
+
+    /// <summary>
+    /// Registry content with LF endings, whatever the test file was checked out with.
+    /// </summary>
+    /// <remarks>
+    /// These strings are raw string literals, so they carry the line ending of the
+    /// test file itself — CRLF on a clone with <c>core.autocrlf=true</c> and LF on one
+    /// without. <c>ErrorCodeRegistry.Render</c> keeps the ending of the file it
+    /// rewrites and defaults to LF for a file with no ending to keep, so an expected
+    /// value that varies by checkout fails on some machines and not others.
+    /// </remarks>
+    private static string Lf(string content) => content.Replace("\r\n", "\n");
 
     /// <summary>
     /// The fixed state expects exactly the diagnostics passed to it and inherits none.

--- a/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeCatalogGeneratorTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeCatalogGeneratorTests.cs
@@ -6,14 +6,14 @@ using Shouldly;
 using Waystone.Monads.Results.Errors;
 using Xunit;
 
-public sealed class ErrorCodeProviderGeneratorTests
+public sealed class ErrorCodeCatalogGeneratorTests
 {
     [Fact]
     public void GeneratesTheWholeProviderForATwoMemberEnum()
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound,
@@ -29,10 +29,10 @@ public sealed class ErrorCodeProviderGeneratorTests
             namespace Sample
             {
                 /// <summary>The error codes declared by <c>global::Sample.OrderError</c>.</summary>
-                public static partial class OrderErrorProvider
+                public static partial class OrderErrorCatalog
                 {
                     /// <summary>The error code string of every <c>global::Sample.OrderError</c> member.</summary>
-                    public static class ErrorCodeStrings
+                    public static class Names
                     {
                         /// <summary>The error code string of <c>global::Sample.OrderError.NotFound</c>.</summary>
                         public const string NotFound = "OrderError.NotFound";
@@ -42,13 +42,13 @@ public sealed class ErrorCodeProviderGeneratorTests
                     }
 
                     /// <summary>The error code of every <c>global::Sample.OrderError</c> member.</summary>
-                    public static class ErrorCodes
+                    public static class Codes
                     {
                         /// <summary>The error code of <c>global::Sample.OrderError.NotFound</c>.</summary>
-                        public static readonly global::Waystone.Monads.Results.Errors.ErrorCode NotFound = new global::Waystone.Monads.Results.Errors.ErrorCode(ErrorCodeStrings.NotFound);
+                        public static readonly global::Waystone.Monads.Results.Errors.ErrorCode NotFound = new global::Waystone.Monads.Results.Errors.ErrorCode(Names.NotFound);
 
                         /// <summary>The error code of <c>global::Sample.OrderError.AlreadyShipped</c>.</summary>
-                        public static readonly global::Waystone.Monads.Results.Errors.ErrorCode AlreadyShipped = new global::Waystone.Monads.Results.Errors.ErrorCode(ErrorCodeStrings.AlreadyShipped);
+                        public static readonly global::Waystone.Monads.Results.Errors.ErrorCode AlreadyShipped = new global::Waystone.Monads.Results.Errors.ErrorCode(Names.AlreadyShipped);
                     }
 
                     /// <summary>Creates an error carrying the error code of a <c>global::Sample.OrderError</c> member.</summary>
@@ -59,7 +59,7 @@ public sealed class ErrorCodeProviderGeneratorTests
                         /// <returns>The created error.</returns>
                         public static global::Waystone.Monads.Results.Errors.Error NotFound(string message)
                         {
-                            return new global::Waystone.Monads.Results.Errors.Error(ErrorCodes.NotFound, message);
+                            return new global::Waystone.Monads.Results.Errors.Error(Codes.NotFound, message);
                         }
 
                         /// <summary>Creates an error carrying the error code of <c>global::Sample.OrderError.AlreadyShipped</c>.</summary>
@@ -67,7 +67,7 @@ public sealed class ErrorCodeProviderGeneratorTests
                         /// <returns>The created error.</returns>
                         public static global::Waystone.Monads.Results.Errors.Error AlreadyShipped(string message)
                         {
-                            return new global::Waystone.Monads.Results.Errors.Error(ErrorCodes.AlreadyShipped, message);
+                            return new global::Waystone.Monads.Results.Errors.Error(Codes.AlreadyShipped, message);
                         }
                     }
 
@@ -79,9 +79,9 @@ public sealed class ErrorCodeProviderGeneratorTests
                         switch (value)
                         {
                             case global::Sample.OrderError.NotFound:
-                                return ErrorCodeStrings.NotFound;
+                                return Names.NotFound;
                             case global::Sample.OrderError.AlreadyShipped:
-                                return ErrorCodeStrings.AlreadyShipped;
+                                return Names.AlreadyShipped;
                             default:
                                 return "OrderError." + value.ToString();
                         }
@@ -95,9 +95,9 @@ public sealed class ErrorCodeProviderGeneratorTests
                         switch (value)
                         {
                             case global::Sample.OrderError.NotFound:
-                                return ErrorCodes.NotFound;
+                                return Codes.NotFound;
                             case global::Sample.OrderError.AlreadyShipped:
-                                return ErrorCodes.AlreadyShipped;
+                                return Codes.AlreadyShipped;
                             default:
                                 return new global::Waystone.Monads.Results.Errors.ErrorCode("OrderError." + value.ToString());
                         }
@@ -118,15 +118,15 @@ public sealed class ErrorCodeProviderGeneratorTests
     }
 
     [Theory]
-    [InlineData("OrderError", "OrderErrorProvider")]
-    [InlineData("OrderErrorCode", "OrderErrorProvider")]
-    [InlineData("PaymentFailure", "PaymentFailureErrorProvider")]
-    [InlineData("Error", "ErrorErrorProvider")]
-    public void DeduplicatesATrailingErrorOrErrorCode(string name, string expected)
+    [InlineData("OrderError", "OrderErrorCatalog")]
+    [InlineData("OrderErrorCode", "OrderErrorCodeCatalog")]
+    [InlineData("PaymentFailure", "PaymentFailureCatalog")]
+    [InlineData("Error", "ErrorCatalog")]
+    public void NamesTheCatalogAfterTheEnum(string name, string expected)
     {
         GeneratorRun run = Verify.Run(
             $$"""
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum {{name}}
             {
                 NotFound,
@@ -142,7 +142,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         Verify.Run(
                 """
-                [ErrorCodeProvider]
+                [ErrorCodeCatalog]
                 public enum OrderError
                 {
                     NotFound,
@@ -175,7 +175,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound,
@@ -197,13 +197,13 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         Verify.Run(
                   """
-                  [ErrorCodeProvider]
+                  [ErrorCodeCatalog]
                   internal enum OrderError
                   {
                       NotFound,
                   }
                   """)
-              .Source.ShouldContain("internal static partial class OrderErrorProvider");
+              .Source.ShouldContain("internal static partial class OrderErrorCatalog");
     }
 
     [Fact]
@@ -211,7 +211,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound,
@@ -226,7 +226,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         (string first, string second) = Verify.RunTwice(
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound,
@@ -234,7 +234,7 @@ public sealed class ErrorCodeProviderGeneratorTests
             """);
 
         second.ShouldBe(first);
-        first.ShouldContain("OrderErrorProvider");
+        first.ShouldContain("OrderErrorCatalog");
     }
 
     [Fact]
@@ -242,14 +242,14 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         (string first, string second) = Verify.RunTwice(
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound,
             }
             """,
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound,
@@ -266,7 +266,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             [Flags]
             public enum OrderError
             {
@@ -287,7 +287,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound = 1,
@@ -304,14 +304,14 @@ public sealed class ErrorCodeProviderGeneratorTests
     }
 
     [Theory]
-    [InlineData("ErrorCodeStrings")]
-    [InlineData("ErrorCodes")]
+    [InlineData("Names")]
+    [InlineData("Codes")]
     [InlineData("Errors")]
     public void ReportsAMemberNamedAfterAGeneratedType(string name)
     {
         GeneratorRun run = Verify.Run(
             $$"""
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 {{name}},
@@ -336,7 +336,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         GeneratorRun run = Verify.Run(
             $$"""
-            [ErrorCodeProvider]
+            [ErrorCodeCatalog]
             public enum OrderError
             {
                 {{name}},
@@ -353,7 +353,7 @@ public sealed class ErrorCodeProviderGeneratorTests
     {
         GeneratorRun run = Verify.RunWithoutMonads(
             """
-            [Waystone.Monads.Results.Errors.ErrorCodeProvider]
+            [Waystone.Monads.Results.Errors.ErrorCodeCatalog]
             public enum OrderError
             {
                 NotFound,

--- a/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeCatalogGeneratorTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeCatalogGeneratorTests.cs
@@ -31,13 +31,13 @@ public sealed class ErrorCodeCatalogGeneratorTests
                 /// <summary>The error codes declared by <c>global::Sample.OrderError</c>.</summary>
                 public static partial class OrderErrorCatalog
                 {
-                    /// <summary>The error code string of every <c>global::Sample.OrderError</c> member.</summary>
+                    /// <summary>The error code name of every <c>global::Sample.OrderError</c> member.</summary>
                     public static class Names
                     {
-                        /// <summary>The error code string of <c>global::Sample.OrderError.NotFound</c>.</summary>
+                        /// <summary>The error code name of <c>global::Sample.OrderError.NotFound</c>.</summary>
                         public const string NotFound = "OrderError.NotFound";
 
-                        /// <summary>The error code string of <c>global::Sample.OrderError.AlreadyShipped</c>.</summary>
+                        /// <summary>The error code name of <c>global::Sample.OrderError.AlreadyShipped</c>.</summary>
                         public const string AlreadyShipped = "OrderError.AlreadyShipped";
                     }
 
@@ -71,10 +71,10 @@ public sealed class ErrorCodeCatalogGeneratorTests
                         }
                     }
 
-                    /// <summary>Gets the error code string of a <c>global::Sample.OrderError</c> value.</summary>
-                    /// <param name="value">The value to read the error code string of.</param>
-                    /// <returns>The error code string. A value that is not a declared member gets the same scheme applied to its numeric value.</returns>
-                    public static string ToErrorCodeString(this global::Sample.OrderError value)
+                    /// <summary>Gets the error code name of a <c>global::Sample.OrderError</c> value.</summary>
+                    /// <param name="value">The value to read the error code name of.</param>
+                    /// <returns>The error code name. A value that is not a declared member gets the same scheme applied to its numeric value.</returns>
+                    public static string ToErrorCodeName(this global::Sample.OrderError value)
                     {
                         switch (value)
                         {
@@ -329,7 +329,7 @@ public sealed class ErrorCodeCatalogGeneratorTests
     /// the three nested class names and not the three extension names.
     /// </summary>
     [Theory]
-    [InlineData("ToErrorCodeString")]
+    [InlineData("ToErrorCodeName")]
     [InlineData("ToErrorCode")]
     [InlineData("ToError")]
     public void AcceptsAMemberNamedAfterAnExtension(string name)

--- a/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeFormatGenerationTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/ErrorCodeFormatGenerationTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 public sealed class ErrorCodeFormatGenerationTests
 {
     private const string Enum = """
-        [ErrorCodeProvider]
+        [ErrorCodeCatalog]
         public enum OrderError
         {
             NotFound,
@@ -28,7 +28,7 @@ public sealed class ErrorCodeFormatGenerationTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            [ErrorCodeCatalog(Format = "order.{member:kebab}")]
             public enum OrderError
             {
                 NotFound,
@@ -58,7 +58,7 @@ public sealed class ErrorCodeFormatGenerationTests
         GeneratorRun run = Verify.RunWithAssemblyAttributes(
             """[assembly: ErrorCodeFormat("{enum:kebab}/{member:snake}")]""",
             """
-            [ErrorCodeProvider(Format = "{member:upper}")]
+            [ErrorCodeCatalog(Format = "{member:upper}")]
             public enum OrderError
             {
                 NotFound,
@@ -74,7 +74,7 @@ public sealed class ErrorCodeFormatGenerationTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            [ErrorCodeCatalog(Format = "order.{member:kebab}")]
             public enum OrderError
             {
                 NotFound,
@@ -93,7 +93,7 @@ public sealed class ErrorCodeFormatGenerationTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider(Format = "{member:pascal}")]
+            [ErrorCodeCatalog(Format = "{member:pascal}")]
             public enum OrderError
             {
                 NotFound,
@@ -113,7 +113,7 @@ public sealed class ErrorCodeFormatGenerationTests
     {
         GeneratorRun run = Verify.Run(
             """
-            [ErrorCodeProvider(Format = "{enum:kebab}")]
+            [ErrorCodeCatalog(Format = "{enum:kebab}")]
             public enum OrderError
             {
                 NotFound,
@@ -135,7 +135,7 @@ public sealed class ErrorCodeFormatGenerationTests
     {
         GeneratorRun first = Verify.Run(
             """
-            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            [ErrorCodeCatalog(Format = "order.{member:kebab}")]
             public enum OrderError
             {
                 NotFound,
@@ -144,7 +144,7 @@ public sealed class ErrorCodeFormatGenerationTests
 
         GeneratorRun second = Verify.Run(
             """
-            [ErrorCodeProvider(Format = "order.{member:kebab}")]
+            [ErrorCodeCatalog(Format = "order.{member:kebab}")]
             public enum ShipmentError
             {
                 NotFound,

--- a/test/Waystone.Monads.SourceGenerators.Tests/GeneratedErrorCodeTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/GeneratedErrorCodeTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 /// <summary>
 /// Exercises the generated members as the consumer sees them: this project loads
-/// the generator as an analyzer, so <see cref="ShipmentErrorProvider" /> below is
+/// the generator as an analyzer, so <see cref="ShipmentErrorCatalog" /> below is
 /// emitted rather than written.
 /// </summary>
 public sealed class GeneratedErrorCodeTests
@@ -15,21 +15,21 @@ public sealed class GeneratedErrorCodeTests
 #pragma warning disable CS0618
     [Fact]
     public void TheConstantMatchesTheRuntimeFactory() =>
-        ShipmentErrorProvider.ErrorCodeStrings.NotFound.ShouldBe(
+        ShipmentErrorCatalog.Names.NotFound.ShouldBe(
             ErrorCode.FromEnum(ShipmentError.NotFound).Value);
 
     [Fact]
     public void TheErrorCodeMatchesTheRuntimeFactory() =>
-        ShipmentErrorProvider.ErrorCodes.AlreadyShipped.ShouldBe(
+        ShipmentErrorCatalog.Codes.AlreadyShipped.ShouldBe(
             ErrorCode.FromEnum(ShipmentError.AlreadyShipped));
 #pragma warning restore CS0618
 
     [Fact]
     public void TheErrorFactoryCarriesTheCodeAndMessage()
     {
-        Error error = ShipmentErrorProvider.Errors.NotFound("no such shipment");
+        Error error = ShipmentErrorCatalog.Errors.NotFound("no such shipment");
 
-        error.Code.ShouldBe(ShipmentErrorProvider.ErrorCodes.NotFound);
+        error.Code.ShouldBe(ShipmentErrorCatalog.Codes.NotFound);
         error.Message.ShouldBe("no such shipment");
     }
 
@@ -38,14 +38,14 @@ public sealed class GeneratedErrorCodeTests
     {
         ShipmentError.AlreadyShipped.ToErrorCodeString()
                      .ShouldBe(
-                          ShipmentErrorProvider.ErrorCodeStrings.AlreadyShipped);
+                          ShipmentErrorCatalog.Names.AlreadyShipped);
 
         ShipmentError.AlreadyShipped.ToErrorCode()
-                     .ShouldBe(ShipmentErrorProvider.ErrorCodes.AlreadyShipped);
+                     .ShouldBe(ShipmentErrorCatalog.Codes.AlreadyShipped);
 
         ShipmentError.AlreadyShipped.ToError("already gone")
                      .ShouldBe(
-                          ShipmentErrorProvider.Errors.AlreadyShipped(
+                          ShipmentErrorCatalog.Errors.AlreadyShipped(
                               "already gone"));
     }
 
@@ -98,7 +98,7 @@ public sealed class GeneratedErrorCodeTests
     }
 }
 
-[ErrorCodeProvider]
+[ErrorCodeCatalog]
 public enum ShipmentError
 {
     NotFound,

--- a/test/Waystone.Monads.SourceGenerators.Tests/GeneratedErrorCodeTests.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/GeneratedErrorCodeTests.cs
@@ -36,7 +36,7 @@ public sealed class GeneratedErrorCodeTests
     [Fact]
     public void TheExtensionsAgreeWithTheNestedClasses()
     {
-        ShipmentError.AlreadyShipped.ToErrorCodeString()
+        ShipmentError.AlreadyShipped.ToErrorCodeName()
                      .ShouldBe(
                           ShipmentErrorCatalog.Names.AlreadyShipped);
 
@@ -61,7 +61,7 @@ public sealed class GeneratedErrorCodeTests
     {
         var undeclared = (ShipmentError)99;
 
-        undeclared.ToErrorCodeString().ShouldBe("ShipmentError.99");
+        undeclared.ToErrorCodeName().ShouldBe("ShipmentError.99");
         undeclared.ToErrorCode().ShouldBe(new ErrorCode("ShipmentError.99"));
     }
 
@@ -76,10 +76,10 @@ public sealed class GeneratedErrorCodeTests
         using (MonadOptions.BeginScope(
                    options => options.UseErrorCodeFactory(new PrefixingFactory())))
         {
-            ShipmentError.NotFound.ToErrorCodeString()
+            ShipmentError.NotFound.ToErrorCodeName()
                          .ShouldBe("ShipmentError.NotFound");
 
-            ((ShipmentError)99).ToErrorCodeString()
+            ((ShipmentError)99).ToErrorCodeName()
                                .ShouldBe("ShipmentError.99");
 
 #pragma warning disable CS0618

--- a/test/Waystone.Monads.SourceGenerators.Tests/Verify.cs
+++ b/test/Waystone.Monads.SourceGenerators.Tests/Verify.cs
@@ -54,7 +54,7 @@ internal static class Verify
             namespace Waystone.Monads.Results.Errors
             {
                 [System.AttributeUsage(System.AttributeTargets.Enum)]
-                public sealed class ErrorCodeProviderAttribute : System.Attribute
+                public sealed class ErrorCodeCatalogAttribute : System.Attribute
                 {
                 }
             }
@@ -116,7 +116,7 @@ internal static class Verify
     }
 
     private static GeneratorDriver Driver() =>
-        CSharpGeneratorDriver.Create(new ErrorCodeProviderGenerator())
+        CSharpGeneratorDriver.Create(new ErrorCodeCatalogGenerator())
                              .WithUpdatedParseOptions(ParseOptions);
 
     private static CSharpParseOptions ParseOptions =>


### PR DESCRIPTION
Provider names a runtime service in .NET — IServiceProvider, TimeProvider,
ILoggerProvider — all injectable and mockable. What this generates is a static
table of compile-time constants, so the name sent readers looking for an
interface to register. It read worse next to the ErrorCodeFactory this release
deprecates, since Provider and Factory are synonyms and the deprecation then
looked like a synonym swap rather than a change of kind.

[ErrorCodeProvider] becomes [ErrorCodeCatalog] so the attribute names the
artifact, the way [EnumExtensions] and [GeneratedRegex] do. {Enum}Provider
becomes {Enum}Catalog, ErrorCodeStrings becomes Names — the standardised word
for a table of string constants, as in HeaderNames and MediaTypeNames — and
ErrorCodes becomes Codes, which no longer stutters under a type that is
entirely about error codes. Errors keeps its name.

The catalog name is now the enum's own name plus Catalog, with nothing trimmed.
The trimming this replaces gave OrderError and OrderErrorCode one class name,
and since the hint name is keyed on the enum the collision surfaced as a CS0101
in the consumer rather than as a generator diagnostic.

Verify.Lf normalises registry content in the analyzer tests. Those expected
values are raw string literals, so they carried the line ending of the test
file itself and disagreed with Render's LF default on a clone with
core.autocrlf=true. The rename surfaced it; it was there before.

None of these names have shipped — v6.1.0 is the latest tag — so this is a
rename rather than a deprecation.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>